### PR TITLE
feat: sign up with glpat and gl url

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
         "category": "Computor"
       },
       {
+        "command": "computor.signUp",
+        "title": "Sign Up (Set Initial Password)",
+        "category": "Computor"
+      },
+      {
         "command": "computor.loginOffline",
         "title": "Login (Offline Mode)",
         "category": "Computor"

--- a/src/commands/SignUpCommands.ts
+++ b/src/commands/SignUpCommands.ts
@@ -1,0 +1,287 @@
+import * as vscode from 'vscode';
+import { GitLabTokenManager } from '../services/GitLabTokenManager';
+import { ComputorSettingsManager } from '../settings/ComputorSettingsManager';
+import { SetPasswordRequest, PasswordOperationResponse } from '../types/generated/common';
+
+/**
+ * Commands for user sign-up (initial password setup)
+ *
+ * This handles the case where a user doesn't have a password yet and needs to:
+ * 1. Authenticate with GitLab PAT + GitLab URL
+ * 2. Set their initial password via /password/set endpoint
+ * 3. Store the GitLab token for future use
+ * 4. Trigger the login flow
+ */
+export class SignUpCommands {
+  private gitLabTokenManager: GitLabTokenManager;
+  private settingsManager: ComputorSettingsManager;
+
+  constructor(private context: vscode.ExtensionContext) {
+    this.gitLabTokenManager = GitLabTokenManager.getInstance(context);
+    this.settingsManager = new ComputorSettingsManager(context);
+  }
+
+  register(): void {
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand('computor.signUp', () => this.signUp())
+    );
+  }
+
+  private async signUp(): Promise<void> {
+    try {
+      // Step 1: Ensure we have a backend URL
+      const baseUrl = await this.ensureBaseUrl();
+      if (!baseUrl) {
+        return;
+      }
+
+      // Step 2: Prompt for GitLab URL
+      const gitlabUrl = await this.promptForGitLabUrl();
+      if (!gitlabUrl) {
+        return;
+      }
+
+      // Step 3: Prompt for GitLab Personal Access Token
+      const gitlabToken = await this.promptForGitLabToken(gitlabUrl);
+      if (!gitlabToken) {
+        return;
+      }
+
+      // Step 4: Validate the GitLab token
+      const isValid = await this.validateGitLabToken(gitlabUrl, gitlabToken);
+      if (!isValid) {
+        return;
+      }
+
+      // Step 5: Prompt for new password
+      const password = await this.promptForPassword();
+      if (!password) {
+        return;
+      }
+
+      // Step 6: Call /password/set endpoint with provider_auth
+      await this.setInitialPassword(baseUrl, gitlabUrl, gitlabToken, password);
+
+      // Step 7: Store the GitLab token
+      await this.gitLabTokenManager.storeToken(gitlabUrl, gitlabToken);
+
+      // Step 8: Trigger login flow
+      vscode.window.showInformationMessage(
+        'Password set successfully! Please log in with your new credentials.'
+      );
+      await vscode.commands.executeCommand('computor.login');
+    } catch (error: any) {
+      vscode.window.showErrorMessage(`Sign-up failed: ${error?.message || error}`);
+      console.error('[SignUpCommands] Sign-up error:', error);
+    }
+  }
+
+  private async ensureBaseUrl(): Promise<string | undefined> {
+    const existingBaseUrl = await this.settingsManager.getBaseUrl();
+
+    if (existingBaseUrl) {
+      return existingBaseUrl;
+    }
+
+    const baseUrl = await vscode.window.showInputBox({
+      title: 'Computor Sign Up - Backend URL',
+      prompt: 'Enter the Computor backend URL',
+      placeHolder: 'http://localhost:8000',
+      ignoreFocusOut: true,
+      validateInput: (value) => {
+        try {
+          new URL(value);
+          return undefined;
+        } catch {
+          return 'Enter a valid URL';
+        }
+      }
+    });
+
+    if (!baseUrl) {
+      return undefined;
+    }
+
+    await this.settingsManager.setBaseUrl(baseUrl);
+    return baseUrl;
+  }
+
+  private async promptForGitLabUrl(): Promise<string | undefined> {
+    const gitlabUrl = await vscode.window.showInputBox({
+      title: 'Computor Sign Up - GitLab URL',
+      prompt: 'Enter your GitLab instance URL (for authentication)',
+      placeHolder: 'https://gitlab.com',
+      ignoreFocusOut: true,
+      validateInput: (value) => {
+        if (!value) {
+          return 'GitLab URL is required';
+        }
+        try {
+          const url = new URL(value);
+          if (!url.protocol.startsWith('http')) {
+            return 'URL must start with http:// or https://';
+          }
+          return undefined;
+        } catch {
+          return 'Enter a valid URL';
+        }
+      }
+    });
+
+    if (!gitlabUrl) {
+      return undefined;
+    }
+
+    // Normalize to origin (remove trailing slash and path)
+    try {
+      const url = new URL(gitlabUrl);
+      return url.origin;
+    } catch {
+      return gitlabUrl;
+    }
+  }
+
+  private async promptForGitLabToken(gitlabUrl: string): Promise<string | undefined> {
+    const token = await vscode.window.showInputBox({
+      title: 'Computor Sign Up - GitLab Token',
+      prompt: `Enter your GitLab Personal Access Token for ${gitlabUrl}`,
+      placeHolder: 'glpat-xxxxxxxxxxxxxxxxxxxx',
+      password: true,
+      ignoreFocusOut: true,
+      validateInput: (value) => {
+        if (!value) {
+          return 'GitLab token is required';
+        }
+        if (value.length < 10) {
+          return 'Token seems too short';
+        }
+        return undefined;
+      }
+    });
+
+    return token;
+  }
+
+  private async validateGitLabToken(gitlabUrl: string, token: string): Promise<boolean> {
+    return await vscode.window.withProgress({
+      location: vscode.ProgressLocation.Notification,
+      title: 'Validating GitLab token...',
+      cancellable: false
+    }, async () => {
+      const validation = await this.gitLabTokenManager.validateToken(gitlabUrl, token);
+
+      if (validation.valid) {
+        vscode.window.showInformationMessage(
+          `✓ GitLab token validated successfully\nAuthenticated as: ${validation.name} (${validation.username})`
+        );
+        return true;
+      } else {
+        vscode.window.showErrorMessage(
+          `GitLab token validation failed: ${validation.error}`
+        );
+        return false;
+      }
+    });
+  }
+
+  private async promptForPassword(): Promise<string | undefined> {
+    const newPassword = await vscode.window.showInputBox({
+      title: 'Computor Sign Up - New Password',
+      prompt: 'Enter your new password (minimum 12 characters)',
+      password: true,
+      ignoreFocusOut: true,
+      validateInput: (value) => {
+        if (!value) {
+          return 'Password is required';
+        }
+        if (value.length < 12) {
+          return 'Password must be at least 12 characters';
+        }
+        return undefined;
+      }
+    });
+
+    if (!newPassword) {
+      return undefined;
+    }
+
+    const confirmPassword = await vscode.window.showInputBox({
+      title: 'Computor Sign Up - Confirm Password',
+      prompt: 'Confirm your new password',
+      password: true,
+      ignoreFocusOut: true,
+      validateInput: (value) => {
+        if (!value) {
+          return 'Password confirmation is required';
+        }
+        if (value !== newPassword) {
+          return 'Passwords do not match';
+        }
+        return undefined;
+      }
+    });
+
+    if (!confirmPassword) {
+      return undefined;
+    }
+
+    return newPassword;
+  }
+
+  private async setInitialPassword(
+    baseUrl: string,
+    gitlabUrl: string,
+    gitlabToken: string,
+    password: string
+  ): Promise<void> {
+    await vscode.window.withProgress({
+      location: vscode.ProgressLocation.Notification,
+      title: 'Setting initial password...',
+      cancellable: false
+    }, async () => {
+      const payload: SetPasswordRequest = {
+        new_password: password,
+        confirm_password: password,
+        provider_auth: {
+          method: 'gitlab_pat',
+          credentials: {
+            access_token: gitlabToken,
+            gitlab_url: gitlabUrl
+          }
+        }
+      };
+
+      const url = `${baseUrl}/password/set`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+
+        try {
+          const errorJson = JSON.parse(errorText);
+          if (errorJson.detail) {
+            errorMessage = errorJson.detail;
+          } else if (errorJson.message) {
+            errorMessage = errorJson.message;
+          }
+        } catch {
+          if (errorText) {
+            errorMessage = errorText;
+          }
+        }
+
+        throw new Error(errorMessage);
+      }
+
+      const result: PasswordOperationResponse = await response.json();
+      console.log('[SignUpCommands] Password set successfully:', result);
+    });
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { LecturerCommands } from './commands/LecturerCommands';
 import { LecturerExampleCommands } from './commands/LecturerExampleCommands';
 import { LecturerFsCommands } from './commands/LecturerFsCommands';
 import { UserPasswordCommands } from './commands/UserPasswordCommands';
+import { SignUpCommands } from './commands/SignUpCommands';
 import { LogoutCommands } from './commands/LogoutCommands';
 import { UserProfileWebviewProvider } from './ui/webviews/UserProfileWebviewProvider';
 
@@ -902,6 +903,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // Unified login command
   context.subscriptions.push(vscode.commands.registerCommand('computor.login', async () => unifiedLoginFlow(context)));
+
+  // Sign-up command (for users without passwords)
+  new SignUpCommands(context).register();
 
   // Offline mode login command
   context.subscriptions.push(vscode.commands.registerCommand('computor.loginOffline', async () => {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add new sign-up command for users without passwords

- Implement GitLab PAT and URL authentication flow

- Integrate password setup via `/password/set` endpoint

- Register command in extension activation and package.json


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User initiates sign-up"] --> B["Prompt GitLab URL"]
  B --> C["Prompt GitLab PAT"]
  C --> D["Validate GitLab token"]
  D --> E["Prompt new password"]
  E --> F["Call /password/set endpoint"]
  F --> G["Store GitLab token"]
  G --> H["Trigger login flow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SignUpCommands.ts</strong><dd><code>New sign-up command with GitLab authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/commands/SignUpCommands.ts

<ul><li>New file implementing complete sign-up workflow for users without <br>passwords<br> <li> Handles GitLab URL and PAT input with validation<br> <li> Validates GitLab token and prompts for initial password setup<br> <li> Calls <code>/password/set</code> endpoint with provider authentication credentials<br> <li> Stores GitLab token and triggers login flow upon successful setup</ul>


</details>


  </td>
  <td><a href="https://github.com/computor-org/computor-vscode/pull/29/files#diff-f7e1ebcd5861ab63ae157b823833e8d41acd7c1e352e39ac743227022f17e8f8">+287/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>extension.ts</strong><dd><code>Register sign-up command in extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/extension.ts

<ul><li>Import new <code>SignUpCommands</code> class<br> <li> Register sign-up command during extension activation<br> <li> Instantiate <code>SignUpCommands</code> and call register method</ul>


</details>


  </td>
  <td><a href="https://github.com/computor-org/computor-vscode/pull/29/files#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add sign-up command to package manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Add new <code>computor.signUp</code> command definition<br> <li> Set command title to "Sign Up (Set Initial Password)"<br> <li> Categorize command under "Computor" category</ul>


</details>


  </td>
  <td><a href="https://github.com/computor-org/computor-vscode/pull/29/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

