### PR TITLE
refactor(commands): commandRegistrar helper + apply to 11 command files

### DIFF
--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -30,6 +30,7 @@ import type { CourseDeploymentList } from '../types/generated';
 import { LecturerRepositoryManager } from '../services/LecturerRepositoryManager';
 import type { MessagesInputPanelProvider } from '../ui/panels/MessagesInputPanel';
 import type { WebSocketService } from '../services/WebSocketService';
+import { commandRegistrar } from './commandHelpers';
 
 interface ReleaseScope {
   label?: string;
@@ -87,6 +88,8 @@ export class LecturerCommands {
   }
 
   registerCommands(): void {
+
+    const register = commandRegistrar(this.context);
     // Tree refresh - register both command names for compatibility
     const refreshHandler = async () => {
       console.log('=== LECTURER TREE REFRESH COMMAND TRIGGERED ===');
@@ -104,72 +107,52 @@ export class LecturerCommands {
     };
     
     // Register refresh commands with proper naming convention
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.refresh', refreshHandler)
-    );
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.refreshCourses', refreshHandler)
-    );
+    register('computor.lecturer.refresh', refreshHandler);
+    register('computor.lecturer.refreshCourses', refreshHandler);
 
     // Sync assignments repositories (manual trigger)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.syncAssignments', async () => {
-        try {
-          const { LecturerRepositoryManager } = await import('../services/LecturerRepositoryManager');
-          const mgr = new LecturerRepositoryManager(this.context, this.apiService);
-          await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: 'Syncing assignments repositories...', cancellable: false }, async (progress) => {
-            await mgr.syncAllAssignments((m) => progress.report({ message: m }));
-          });
-          vscode.window.showInformationMessage('Assignments repositories synced.');
-        } catch (e) {
-          vscode.window.showErrorMessage(`Failed to sync assignments: ${e}`);
-        }
-      })
-    );
+    register('computor.lecturer.syncAssignments', async () => {
+      try {
+        const { LecturerRepositoryManager } = await import('../services/LecturerRepositoryManager');
+        const mgr = new LecturerRepositoryManager(this.context, this.apiService);
+        await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: 'Syncing assignments repositories...', cancellable: false }, async (progress) => {
+          await mgr.syncAllAssignments((m) => progress.report({ message: m }));
+        });
+        vscode.window.showInformationMessage('Assignments repositories synced.');
+      } catch (e) {
+        vscode.window.showErrorMessage(`Failed to sync assignments: ${e}`);
+      }
+    });
 
     // Organization, course family, and course creation
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createOrganization', async () => {
-        await this.createOrganization();
-      })
-    );
+    register('computor.lecturer.createOrganization', async () => {
+      await this.createOrganization();
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createCourseFamily', async (item: OrganizationTreeItem) => {
-        await this.createCourseFamily(item);
-      })
-    );
+    register('computor.lecturer.createCourseFamily', async (item: OrganizationTreeItem) => {
+      await this.createCourseFamily(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createCourse', async (item?: CourseFamilyTreeItem) => {
-        await this.createCourse(item);
-      })
-    );
+    register('computor.lecturer.createCourse', async (item?: CourseFamilyTreeItem) => {
+      await this.createCourse(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.manageCourse', async (item: CourseTreeItem) => {
-        await this.manageCourse(item);
-      })
-    );
+    register('computor.lecturer.manageCourse', async (item: CourseTreeItem) => {
+      await this.manageCourse(item);
+    });
 
     // Course content management
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createCourseContent', async (item: CourseFolderTreeItem | CourseContentTreeItem) => {
-        await this.createCourseContent(item);
-      })
-    );
+    register('computor.lecturer.createCourseContent', async (item: CourseFolderTreeItem | CourseContentTreeItem) => {
+      await this.createCourseContent(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showMessages', async (item: CourseTreeItem | CourseGroupTreeItem | CourseContentTreeItem) => {
-        await this.showMessages(item);
-      })
-    );
+    register('computor.lecturer.showMessages', async (item: CourseTreeItem | CourseGroupTreeItem | CourseContentTreeItem) => {
+      await this.showMessages(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showCourseMemberComments', async (item: CourseMemberTreeItem) => {
-        await this.showCourseMemberComments(item);
-      })
-    );
+    register('computor.lecturer.showCourseMemberComments', async (item: CourseMemberTreeItem) => {
+      await this.showCourseMemberComments(item);
+    });
 
     // Deactivated: Sync GitLab Permissions command
     // this.context.subscriptions.push(
@@ -178,231 +161,169 @@ export class LecturerCommands {
     //   })
     // );
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.changeCourseContentType', async (item: CourseContentTreeItem) => {
-        await this.changeCourseContentType(item);
-      })
-    );
+    register('computor.lecturer.changeCourseContentType', async (item: CourseContentTreeItem) => {
+      await this.changeCourseContentType(item);
+    });
 
     // Course content type management
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createCourseContentType', async (item: CourseFolderTreeItem) => {
-        await this.createCourseContentType(item);
-      })
-    );
+    register('computor.lecturer.createCourseContentType', async (item: CourseFolderTreeItem) => {
+      await this.createCourseContentType(item);
+    });
 
     // Course group management
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createCourseGroup', async (item: CourseFolderTreeItem) => {
-        await this.courseGroupCommands.createCourseGroup(item);
-      })
-    );
+    register('computor.lecturer.createCourseGroup', async (item: CourseFolderTreeItem) => {
+      await this.courseGroupCommands.createCourseGroup(item);
+    });
 
     // Course member import with preview
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.importCourseMembersPreview', async (item: CourseTreeItem | CourseFolderTreeItem) => {
-        await this.importCourseMembersWithPreview(item);
-      })
-    );
+    register('computor.lecturer.importCourseMembersPreview', async (item: CourseTreeItem | CourseFolderTreeItem) => {
+      await this.importCourseMembersWithPreview(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.editCourseContentType', async (item: CourseContentTypeTreeItem) => {
-        await this.editCourseContentType(item);
-      })
-    );
+    register('computor.lecturer.editCourseContentType', async (item: CourseContentTypeTreeItem) => {
+      await this.editCourseContentType(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.deleteCourseContentType', async (item: CourseContentTypeTreeItem) => {
-        await this.deleteCourseContentType(item);
-      })
-    );
+    register('computor.lecturer.deleteCourseContentType', async (item: CourseContentTypeTreeItem) => {
+      await this.deleteCourseContentType(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.renameCourseContent', async (item: CourseContentTreeItem) => {
-        await this.renameCourseContent(item);
-      })
-    );
+    register('computor.lecturer.renameCourseContent', async (item: CourseContentTreeItem) => {
+      await this.renameCourseContent(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.renameCourseContentType', async (item: CourseContentTypeTreeItem) => {
-        await this.renameCourseContentType(item);
-      })
-    );
+    register('computor.lecturer.renameCourseContentType', async (item: CourseContentTypeTreeItem) => {
+      await this.renameCourseContentType(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.deleteCourseContent', async (item: CourseContentTreeItem) => {
-        await this.deleteCourseContent(item);
-      })
-    );
+    register('computor.lecturer.deleteCourseContent', async (item: CourseContentTreeItem) => {
+      await this.deleteCourseContent(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.archiveCourseContent', async (item: CourseContentTreeItem) => {
-        await this.archiveCourseContent(item);
-      })
-    );
+    register('computor.lecturer.archiveCourseContent', async (item: CourseContentTreeItem) => {
+      await this.archiveCourseContent(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.unarchiveCourseContent', async (item: CourseContentTreeItem) => {
-        await this.unarchiveCourseContent(item);
-      })
-    );
+    register('computor.lecturer.unarchiveCourseContent', async (item: CourseContentTreeItem) => {
+      await this.unarchiveCourseContent(item);
+    });
 
     // Example management
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.updateExampleVersion', async (item: CourseContentTreeItem) => {
-        await this.updateExampleVersion(item);
-      })
-    );
+    register('computor.lecturer.updateExampleVersion', async (item: CourseContentTreeItem) => {
+      await this.updateExampleVersion(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.updateExampleVersions', async (item: CourseTreeItem | CourseFolderTreeItem | CourseContentTreeItem) => {
-        await this.batchUpdateExampleVersions(item);
-      })
-    );
+    register('computor.lecturer.updateExampleVersions', async (item: CourseTreeItem | CourseFolderTreeItem | CourseContentTreeItem) => {
+      await this.batchUpdateExampleVersions(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.viewDeploymentInfo', async (item: CourseContentTreeItem) => {
-        await this.viewDeploymentInfo(item);
-      })
-    );
+    register('computor.lecturer.viewDeploymentInfo', async (item: CourseContentTreeItem) => {
+      await this.viewDeploymentInfo(item);
+    });
 
     // GitLab repository opening
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.openGitLabRepo', async (item: CourseTreeItem | CourseMemberTreeItem) => {
-        await this.openGitLabRepository(item);
-      })
-    );
+    register('computor.lecturer.openGitLabRepo', async (item: CourseTreeItem | CourseMemberTreeItem) => {
+      await this.openGitLabRepository(item);
+    });
 
     // Release/deployment commands
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.releaseCourseContent', async (item: CourseTreeItem | CourseFolderTreeItem | CourseContentTreeItem) => {
-        await this.releaseCourseContent(item);
-      })
-    );
+    register('computor.lecturer.releaseCourseContent', async (item: CourseTreeItem | CourseFolderTreeItem | CourseContentTreeItem) => {
+      await this.releaseCourseContent(item);
+    });
 
     // Release from webview (accepts course data directly)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.releaseCourseContentFromWebview', async (courseData: any) => {
-        await this.releaseCourseContentFromWebview(courseData);
-      })
-    );
+    register('computor.lecturer.releaseCourseContentFromWebview', async (courseData: any) => {
+      await this.releaseCourseContentFromWebview(courseData);
+    });
 
     // Webview commands
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showCourseDetails', async (item: CourseTreeItem) => {
-        await this.showCourseDetails(item);
-      })
-    );
+    register('computor.lecturer.showCourseDetails', async (item: CourseTreeItem) => {
+      await this.showCourseDetails(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showCourseContentDetails', async (item: CourseContentTreeItem) => {
-        await this.showCourseContentDetails(item);
-      })
-    );
+    register('computor.lecturer.showCourseContentDetails', async (item: CourseContentTreeItem) => {
+      await this.showCourseContentDetails(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showOrganizationDetails', async (item: OrganizationTreeItem) => {
-        await this.showOrganizationDetails(item);
-      })
-    );
+    register('computor.lecturer.showOrganizationDetails', async (item: OrganizationTreeItem) => {
+      await this.showOrganizationDetails(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showCourseFamilyDetails', async (item: CourseFamilyTreeItem) => {
-        await this.showCourseFamilyDetails(item);
-      })
-    );
+    register('computor.lecturer.showCourseFamilyDetails', async (item: CourseFamilyTreeItem) => {
+      await this.showCourseFamilyDetails(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showCourseContentTypeDetails', async (item: CourseContentTypeTreeItem) => {
-        await this.showCourseContentTypeDetails(item);
-      })
-    );
+    register('computor.lecturer.showCourseContentTypeDetails', async (item: CourseContentTypeTreeItem) => {
+      await this.showCourseContentTypeDetails(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showCourseGroupDetails', async (item: CourseGroupTreeItem) => {
-        await this.showCourseGroupDetails(item);
-      })
-    );
+    register('computor.lecturer.showCourseGroupDetails', async (item: CourseGroupTreeItem) => {
+      await this.showCourseGroupDetails(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showCourseMemberDetails', async (item: CourseMemberTreeItem) => {
-        await this.showCourseMemberDetails(item);
-      })
-    );
+    register('computor.lecturer.showCourseMemberDetails', async (item: CourseMemberTreeItem) => {
+      await this.showCourseMemberDetails(item);
+    });
 
     // Course progress overview - shows all students' progress for a course
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showCourseProgressOverview', async (itemOrId: CourseTreeItem | string) => {
-        if (typeof itemOrId === 'string') {
-          // Called with course ID directly (from tutor view)
-          await this.showCourseProgressOverviewById(itemOrId);
-        } else {
-          // Called with tree item
-          await this.showCourseProgressOverview(itemOrId);
-        }
-      })
-    );
+    register('computor.lecturer.showCourseProgressOverview', async (itemOrId: CourseTreeItem | string) => {
+      if (typeof itemOrId === 'string') {
+        // Called with course ID directly (from tutor view)
+        await this.showCourseProgressOverviewById(itemOrId);
+      } else {
+        // Called with tree item
+        await this.showCourseProgressOverview(itemOrId);
+      }
+    });
 
     // Course member progress - shows detailed progress for a single student
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showCourseMemberProgress', async (itemOrId: CourseMemberTreeItem | string, memberName?: string) => {
-        if (typeof itemOrId === 'string') {
-          // Called with course member ID directly (from overview webview)
-          await this.courseMemberProgressWebviewProvider.showMemberProgress(itemOrId, memberName);
-        } else {
-          // Called with tree item
-          await this.showCourseMemberProgress(itemOrId);
-        }
-      })
-    );
+    register('computor.lecturer.showCourseMemberProgress', async (itemOrId: CourseMemberTreeItem | string, memberName?: string) => {
+      if (typeof itemOrId === 'string') {
+        // Called with course member ID directly (from overview webview)
+        await this.courseMemberProgressWebviewProvider.showMemberProgress(itemOrId, memberName);
+      } else {
+        // Called with tree item
+        await this.showCourseMemberProgress(itemOrId);
+      }
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createAssignmentFolder', async (item: CourseContentTreeItem) => {
-        await this.createAssignmentFolder(item);
-      })
-    );
+    register('computor.lecturer.createAssignmentFolder', async (item: CourseContentTreeItem) => {
+      await this.createAssignmentFolder(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createAssignmentFile', async (item: CourseContentTreeItem) => {
-        await this.createAssignmentFile(item);
-      })
-    );
+    register('computor.lecturer.createAssignmentFile', async (item: CourseContentTreeItem) => {
+      await this.createAssignmentFile(item);
+    });
 
     // Open local assignment folder for a content
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.openAssignmentFolder', async (item: CourseContentTreeItem) => {
-        if (!item || !item.courseContent?.id || !item.course?.id) { vscode.window.showWarningMessage('Select an assignment'); return; }
-        try {
-          const course = await this.apiService.getCourse(item.course.id);
-          const content = await this.apiService.getCourseContent(item.courseContent.id, true);
-          const deploymentPath = (content as any)?.deployment?.deployment_path || (content as any)?.deployment?.example_identifier || '';
-          if (!course || !deploymentPath) { vscode.window.showWarningMessage('Assignment not initialized in assignments repo yet.'); return; }
-          const { LecturerRepositoryManager } = await import('../services/LecturerRepositoryManager');
-          const mgr = new LecturerRepositoryManager(this.context, this.apiService);
-          const folder = mgr.getAssignmentFolderPath(course, deploymentPath);
-          if (!folder || !fs.existsSync(folder)) {
-            const choice = await vscode.window.showWarningMessage('Assignment folder missing locally. Sync assignments now?', 'Sync', 'Cancel');
-            if (choice === 'Sync') { await vscode.commands.executeCommand('computor.lecturer.syncAssignments'); }
-            return;
-          }
-          await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(folder));
-        } catch (e) {
-          vscode.window.showErrorMessage(`Failed to open assignment folder: ${e}`);
+    register('computor.lecturer.openAssignmentFolder', async (item: CourseContentTreeItem) => {
+      if (!item || !item.courseContent?.id || !item.course?.id) { vscode.window.showWarningMessage('Select an assignment'); return; }
+      try {
+        const course = await this.apiService.getCourse(item.course.id);
+        const content = await this.apiService.getCourseContent(item.courseContent.id, true);
+        const deploymentPath = (content as any)?.deployment?.deployment_path || (content as any)?.deployment?.example_identifier || '';
+        if (!course || !deploymentPath) { vscode.window.showWarningMessage('Assignment not initialized in assignments repo yet.'); return; }
+        const { LecturerRepositoryManager } = await import('../services/LecturerRepositoryManager');
+        const mgr = new LecturerRepositoryManager(this.context, this.apiService);
+        const folder = mgr.getAssignmentFolderPath(course, deploymentPath);
+        if (!folder || !fs.existsSync(folder)) {
+          const choice = await vscode.window.showWarningMessage('Assignment folder missing locally. Sync assignments now?', 'Sync', 'Cancel');
+          if (choice === 'Sync') { await vscode.commands.executeCommand('computor.lecturer.syncAssignments'); }
+          return;
         }
-      })
-    );
+        await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(folder));
+      } catch (e) {
+        vscode.window.showErrorMessage(`Failed to open assignment folder: ${e}`);
+      }
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.renameCourseGroup', async (item: CourseGroupTreeItem) => {
-        await this.renameCourseGroup(item);
-      })
-    );
+    register('computor.lecturer.renameCourseGroup', async (item: CourseGroupTreeItem) => {
+      await this.renameCourseGroup(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.deleteCourseGroup', async (item: CourseGroupTreeItem) => {
-        await this.deleteCourseGroup(item);
-      })
-    );
+    register('computor.lecturer.deleteCourseGroup', async (item: CourseGroupTreeItem) => {
+      await this.deleteCourseGroup(item);
+    });
   }
 
   private async createOrganization(): Promise<void> {

--- a/src/commands/LecturerExampleCommands.ts
+++ b/src/commands/LecturerExampleCommands.ts
@@ -16,6 +16,7 @@ import type { CheckoutMetadata } from '../utils/checkedOutExampleManager';
 import { ComputorTestingInstaller } from '../services/ComputorTestingInstaller';
 import { shouldExcludeExampleEntry } from '../utils/exampleExcludePatterns';
 import { UploadAllExamplesWebviewProvider } from '../ui/webviews/UploadAllExamplesWebviewProvider';
+import { commandRegistrar } from './commandHelpers';
 
 /**
  * Simplified example commands for the lecturer view
@@ -38,339 +39,260 @@ export class LecturerExampleCommands {
     this.registerCommands();
   }
   private registerCommands(): void {
+    const register = commandRegistrar(this.context);
     // Search examples - already registered in extension.ts but we'll override with better implementation
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.searchExamples', async () => {
-        // Get current search query to prefill the input
-        const currentQuery = this.treeProvider.getSearchQuery();
-        
-        const query = await vscode.window.showInputBox({
-          prompt: 'Search examples by title, identifier, or tags',
-          placeHolder: 'Enter search query',
-          value: currentQuery  // Prefill with current search
-        });
-        
-        if (query !== undefined) {
-          this.treeProvider.setSearchQuery(query);
-          if (query) {
-            vscode.window.showInformationMessage(`Searching for: ${query}`);
-          } else {
-            vscode.window.showInformationMessage('Search cleared');
-          }
+    register('computor.lecturer.searchExamples', async () => {
+      // Get current search query to prefill the input
+      const currentQuery = this.treeProvider.getSearchQuery();
+      
+      const query = await vscode.window.showInputBox({
+        prompt: 'Search examples by title, identifier, or tags',
+        placeHolder: 'Enter search query',
+        value: currentQuery  // Prefill with current search
+      });
+      
+      if (query !== undefined) {
+        this.treeProvider.setSearchQuery(query);
+        if (query) {
+          vscode.window.showInformationMessage(`Searching for: ${query}`);
+        } else {
+          vscode.window.showInformationMessage('Search cleared');
         }
-      })
-    );
+      }
+    });
 
     // Clear search
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.clearExampleSearch', () => {
-        this.treeProvider.clearSearch();
-        vscode.window.showInformationMessage('Search cleared');
-      })
-    );
+    register('computor.lecturer.clearExampleSearch', () => {
+      this.treeProvider.clearSearch();
+      vscode.window.showInformationMessage('Search cleared');
+    });
 
     // Also register clearSearch for the tree item click
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.clearSearch', () => {
-        this.treeProvider.clearSearch();
-        vscode.window.showInformationMessage('Search cleared');
-      })
-    );
+    register('computor.lecturer.clearSearch', () => {
+      this.treeProvider.clearSearch();
+      vscode.window.showInformationMessage('Search cleared');
+    });
 
     // Filter by category
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.filterExamplesByCategory', async () => {
-        const currentCategory = this.treeProvider.getSelectedCategory();
-        const category = await vscode.window.showInputBox({
-          prompt: 'Enter category to filter by (leave empty to clear)',
-          placeHolder: 'e.g., Introduction, Advanced',
-          value: currentCategory || ''
-        });
-        
-        if (category !== undefined) {
-          this.treeProvider.setCategory(category || undefined);
-          if (category) {
-            vscode.window.showInformationMessage(`Filtering by category: ${category}`);
-          } else {
-            vscode.window.showInformationMessage('Category filter cleared');
-          }
+    register('computor.lecturer.filterExamplesByCategory', async () => {
+      const currentCategory = this.treeProvider.getSelectedCategory();
+      const category = await vscode.window.showInputBox({
+        prompt: 'Enter category to filter by (leave empty to clear)',
+        placeHolder: 'e.g., Introduction, Advanced',
+        value: currentCategory || ''
+      });
+      
+      if (category !== undefined) {
+        this.treeProvider.setCategory(category || undefined);
+        if (category) {
+          vscode.window.showInformationMessage(`Filtering by category: ${category}`);
+        } else {
+          vscode.window.showInformationMessage('Category filter cleared');
         }
-      })
-    );
+      }
+    });
 
     // Filter by tags
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.filterExamplesByTags', async () => {
-        const currentTags = this.treeProvider.getSelectedTags();
-        const tagsInput = await vscode.window.showInputBox({
-          prompt: 'Enter tags to filter by (comma-separated, leave empty to clear)',
-          placeHolder: 'e.g., beginner, loops, functions',
-          value: currentTags.join(', ')
-        });
-        
-        if (tagsInput !== undefined) {
-          const tags = tagsInput ? tagsInput.split(',').map(t => t.trim()).filter(t => t) : [];
-          this.treeProvider.setTags(tags);
-          if (tags.length > 0) {
-            vscode.window.showInformationMessage(`Filtering by tags: ${tags.join(', ')}`);
-          } else {
-            vscode.window.showInformationMessage('Tag filter cleared');
-          }
+    register('computor.lecturer.filterExamplesByTags', async () => {
+      const currentTags = this.treeProvider.getSelectedTags();
+      const tagsInput = await vscode.window.showInputBox({
+        prompt: 'Enter tags to filter by (comma-separated, leave empty to clear)',
+        placeHolder: 'e.g., beginner, loops, functions',
+        value: currentTags.join(', ')
+      });
+      
+      if (tagsInput !== undefined) {
+        const tags = tagsInput ? tagsInput.split(',').map(t => t.trim()).filter(t => t) : [];
+        this.treeProvider.setTags(tags);
+        if (tags.length > 0) {
+          vscode.window.showInformationMessage(`Filtering by tags: ${tags.join(', ')}`);
+        } else {
+          vscode.window.showInformationMessage('Tag filter cleared');
         }
-      })
-    );
+      }
+    });
 
     // Clear category filter
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.clearCategoryFilter', () => {
-        this.treeProvider.clearCategoryFilter();
-        vscode.window.showInformationMessage('Category filter cleared');
-      })
-    );
+    register('computor.lecturer.clearCategoryFilter', () => {
+      this.treeProvider.clearCategoryFilter();
+      vscode.window.showInformationMessage('Category filter cleared');
+    });
 
     // Clear tags filter
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.clearTagsFilter', () => {
-        this.treeProvider.clearTagsFilter();
-        vscode.window.showInformationMessage('Tags filter cleared');
-      })
-    );
+    register('computor.lecturer.clearTagsFilter', () => {
+      this.treeProvider.clearTagsFilter();
+      vscode.window.showInformationMessage('Tags filter cleared');
+    });
 
     // Checkout example (latest version)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.checkoutExample', async (item: ExampleTreeItem) => {
-        await this.checkoutExample(item);
-      })
-    );
+    register('computor.lecturer.checkoutExample', async (item: ExampleTreeItem) => {
+      await this.checkoutExample(item);
+    });
 
     // Checkout specific version
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.checkoutExampleVersion', async (item: ExampleTreeItem) => {
-        await this.checkoutExample(item, true);
-      })
-    );
+    register('computor.lecturer.checkoutExampleVersion', async (item: ExampleTreeItem) => {
+      await this.checkoutExample(item, true);
+    });
 
     // Checkout all filtered examples from repository
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.checkoutAllFilteredExamples', async (item: ExampleRepositoryTreeItem) => {
-        await this.checkoutAllFilteredExamples(item);
-      })
-    );
+    register('computor.lecturer.checkoutAllFilteredExamples', async (item: ExampleRepositoryTreeItem) => {
+      await this.checkoutAllFilteredExamples(item);
+    });
 
     // Upload working copy
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.uploadExample', async (item: ExampleTreeItem | CheckedOutVersionTreeItem) => {
-        if (item instanceof CheckedOutVersionTreeItem) {
-          await this.uploadCheckedOutVersion(item);
-        } else {
-          await this.uploadExample(item);
-        }
-      })
-    );
+    register('computor.lecturer.uploadExample', async (item: ExampleTreeItem | CheckedOutVersionTreeItem) => {
+      if (item instanceof CheckedOutVersionTreeItem) {
+        await this.uploadCheckedOutVersion(item);
+      } else {
+        await this.uploadExample(item);
+      }
+    });
 
     // Bump version on working copy
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.bumpExampleVersion', async (item: CheckedOutVersionTreeItem) => {
-        await this.bumpCheckedOutVersion(item);
-      })
-    );
+    register('computor.lecturer.bumpExampleVersion', async (item: CheckedOutVersionTreeItem) => {
+      await this.bumpCheckedOutVersion(item);
+    });
 
     // Reveal checked-out version in explorer
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.revealCheckedOutInExplorer', async (item: CheckedOutVersionTreeItem | CheckedOutGroupTreeItem) => {
-        const p = item instanceof CheckedOutVersionTreeItem ? item.version.fullPath : item.group.fullPath;
-        await vscode.commands.executeCommand('revealInExplorer', vscode.Uri.file(p));
-      })
-    );
+    register('computor.lecturer.revealCheckedOutInExplorer', async (item: CheckedOutVersionTreeItem | CheckedOutGroupTreeItem) => {
+      const p = item instanceof CheckedOutVersionTreeItem ? item.version.fullPath : item.group.fullPath;
+      await vscode.commands.executeCommand('revealInExplorer', vscode.Uri.file(p));
+    });
 
     // Delete entire checked-out example group
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.deleteCheckedOutExample', async (item: CheckedOutGroupTreeItem) => {
-        await this.deleteCheckedOutGroup(item);
-      })
-    );
+    register('computor.lecturer.deleteCheckedOutExample', async (item: CheckedOutGroupTreeItem) => {
+      await this.deleteCheckedOutGroup(item);
+    });
 
     // Delete single checked-out version
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.deleteCheckedOutVersion', async (item: CheckedOutVersionTreeItem) => {
-        await this.deleteCheckedOutVersion(item);
-      })
-    );
+    register('computor.lecturer.deleteCheckedOutVersion', async (item: CheckedOutVersionTreeItem) => {
+      await this.deleteCheckedOutVersion(item);
+    });
 
     // Restore version to working copy
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.restoreVersionToWorking', async (item: CheckedOutVersionTreeItem) => {
-        await this.restoreVersionToWorking(item);
-      })
-    );
+    register('computor.lecturer.restoreVersionToWorking', async (item: CheckedOutVersionTreeItem) => {
+      await this.restoreVersionToWorking(item);
+    });
 
     // Compare version with working copy
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.compareWithWorking', async (item: CheckedOutVersionTreeItem) => {
-        await this.compareWithWorking(item);
-      })
-    );
+    register('computor.lecturer.compareWithWorking', async (item: CheckedOutVersionTreeItem) => {
+      await this.compareWithWorking(item);
+    });
 
     // Compare a single version file with its working counterpart
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.compareFileWithWorking', async (item: FileSystemTreeItem) => {
-        await this.compareFileWithWorking(item);
-      })
-    );
+    register('computor.lecturer.compareFileWithWorking', async (item: FileSystemTreeItem) => {
+      await this.compareFileWithWorking(item);
+    });
 
     // File management commands
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.newFile', async (item: FileSystemTreeItem | CheckedOutVersionTreeItem) => {
-        await this.createFileOrFolder(item, false);
-      })
-    );
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.newFolder', async (item: FileSystemTreeItem | CheckedOutVersionTreeItem) => {
-        await this.createFileOrFolder(item, true);
-      })
-    );
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.renameItem', async (item: FileSystemTreeItem) => {
-        await this.renameFileSystemItem(item);
-      })
-    );
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.deleteItem', async (item: FileSystemTreeItem) => {
-        await this.deleteFileSystemItem(item);
-      })
-    );
+    register('computor.lecturer.newFile', async (item: FileSystemTreeItem | CheckedOutVersionTreeItem) => {
+      await this.createFileOrFolder(item, false);
+    });
+    register('computor.lecturer.newFolder', async (item: FileSystemTreeItem | CheckedOutVersionTreeItem) => {
+      await this.createFileOrFolder(item, true);
+    });
+    register('computor.lecturer.renameItem', async (item: FileSystemTreeItem) => {
+      await this.renameFileSystemItem(item);
+    });
+    register('computor.lecturer.deleteItem', async (item: FileSystemTreeItem) => {
+      await this.deleteFileSystemItem(item);
+    });
 
     // Create new example
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createNewExample', async () => {
-        await this.createNewExample();
-      })
-    );
+    register('computor.lecturer.createNewExample', async () => {
+      await this.createNewExample();
+    });
 
     // Upload new example
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.uploadNewExample', async () => {
-        await this.uploadNewExample();
-      })
-    );
+    register('computor.lecturer.uploadNewExample', async () => {
+      await this.uploadNewExample();
+    });
 
     // Checkout multiple examples
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.checkoutMultipleExamples', async () => {
-        vscode.window.showInformationMessage('Checkout multiple examples - not yet implemented');
-      })
-    );
+    register('computor.lecturer.checkoutMultipleExamples', async () => {
+      vscode.window.showInformationMessage('Checkout multiple examples - not yet implemented');
+    });
 
     // Upload examples from ZIP
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.uploadExamplesFromZip', async (item?: ExampleRepositoryTreeItem) => {
-        await this.uploadExamplesFromZip(item);
-      })
-    );
+    register('computor.lecturer.uploadExamplesFromZip', async (item?: ExampleRepositoryTreeItem) => {
+      await this.uploadExamplesFromZip(item);
+    });
 
     // create content from example
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.createCourseContentFromExample', async (item: ExampleTreeItem) => {
-        await this.createCourseContentFromExample(item);
-      })
-    );
+    register('computor.lecturer.createCourseContentFromExample', async (item: ExampleTreeItem) => {
+      await this.createCourseContentFromExample(item);
+    });
 
     // Refresh examples tree (clear caches first)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.refreshExamples', async () => {
-        try {
-          this.apiService.clearExamplesCache();
-        } catch {}
-        this.treeProvider.refresh();
-      })
-    );
+    register('computor.lecturer.refreshExamples', async () => {
+      try {
+        this.apiService.clearExamplesCache();
+      } catch {}
+      this.treeProvider.refresh();
+    });
 
     // Reveal downloaded example in explorer
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.revealExampleInExplorer', async (item: ExampleTreeItem) => {
-        await this.revealExampleInExplorer(item);
-      })
-    );
+    register('computor.lecturer.revealExampleInExplorer', async (item: ExampleTreeItem) => {
+      await this.revealExampleInExplorer(item);
+    });
 
     // Show example details in webview side panel
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.showExampleDetails', async (item: ExampleTreeItem) => {
-        await this.showExampleDetails(item);
-      })
-    );
+    register('computor.lecturer.showExampleDetails', async (item: ExampleTreeItem) => {
+      await this.showExampleDetails(item);
+    });
 
     // Open test.yaml editor
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.editTestYaml', async (item: FileSystemTreeItem | CheckedOutVersionTreeItem) => {
-        await this.editTestYaml(item);
-      })
-    );
+    register('computor.lecturer.editTestYaml', async (item: FileSystemTreeItem | CheckedOutVersionTreeItem) => {
+      await this.editTestYaml(item);
+    });
 
     // Add test.yaml to working example
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.addTests', async (item: CheckedOutVersionTreeItem) => {
-        await this.addTests(item);
-      })
-    );
+    register('computor.lecturer.addTests', async (item: CheckedOutVersionTreeItem) => {
+      await this.addTests(item);
+    });
 
     // Open meta.yaml editor (from meta.yaml file or working example root)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.editMetaYaml', async (item: FileSystemTreeItem | CheckedOutVersionTreeItem) => {
-        await this.editMetaYaml(item);
-      })
-    );
+    register('computor.lecturer.editMetaYaml', async (item: FileSystemTreeItem | CheckedOutVersionTreeItem) => {
+      await this.editMetaYaml(item);
+    });
 
     // Create new readme in content directory
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.newReadme', async (item: FileSystemTreeItem) => {
-        await this.createNewReadme(item);
-      })
-    );
+    register('computor.lecturer.newReadme', async (item: FileSystemTreeItem) => {
+      await this.createNewReadme(item);
+    });
 
     // Import examples from directory
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.importExamples', async () => {
-        await this.importExamples();
-      })
-    );
+    register('computor.lecturer.importExamples', async () => {
+      await this.importExamples();
+    });
 
     // Upload all examples
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.uploadAllExamples', async () => {
-        await this.uploadAllProvider.show('Upload All Examples');
-      })
-    );
+    register('computor.lecturer.uploadAllExamples', async () => {
+      await this.uploadAllProvider.show('Upload All Examples');
+    });
 
     // Install computor-testing tools
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.installTestingTools', async () => {
-        const installer = ComputorTestingInstaller.getInstance();
-        await installer.install();
-      })
-    );
+    register('computor.lecturer.installTestingTools', async () => {
+      const installer = ComputorTestingInstaller.getInstance();
+      await installer.install();
+    });
 
     // Update computor-testing tools
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.updateTestingTools', async () => {
-        const installer = ComputorTestingInstaller.getInstance();
-        await installer.update();
-      })
-    );
+    register('computor.lecturer.updateTestingTools', async () => {
+      const installer = ComputorTestingInstaller.getInstance();
+      await installer.update();
+    });
 
     // Uninstall computor-testing tools
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.uninstallTestingTools', async () => {
-        const installer = ComputorTestingInstaller.getInstance();
-        await installer.uninstall();
-      })
-    );
+    register('computor.lecturer.uninstallTestingTools', async () => {
+      const installer = ComputorTestingInstaller.getInstance();
+      await installer.uninstall();
+    });
 
     // Run tests on checked-out example
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.runExampleTests', async (item: CheckedOutVersionTreeItem) => {
-        await this.runExampleTests(item);
-      })
-    );
+    register('computor.lecturer.runExampleTests', async (item: CheckedOutVersionTreeItem) => {
+      await this.runExampleTests(item);
+    });
   }
 
   private async checkoutExample(item: ExampleTreeItem, pickVersion: boolean = false): Promise<void> {

--- a/src/commands/LecturerFsCommands.ts
+++ b/src/commands/LecturerFsCommands.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs/promises';
 import { LecturerRepositoryManager } from '../services/LecturerRepositoryManager';
 import { ComputorApiService } from '../services/ComputorApiService';
+import { commandRegistrar } from './commandHelpers';
 
 export class LecturerFsCommands {
   private repositoryManager: LecturerRepositoryManager;
@@ -15,14 +16,14 @@ export class LecturerFsCommands {
   }
 
   register(): void {
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.lecturer.fs.rename', async (item: any) => {
-        await this.renameEntry(item);
-      }),
-      vscode.commands.registerCommand('computor.lecturer.fs.delete', async (item: any) => {
-        await this.deleteEntry(item);
-      })
-    );
+
+    const register = commandRegistrar(this.context);
+    register('computor.lecturer.fs.rename', async (item: any) => {
+      await this.renameEntry(item);
+    });
+    register('computor.lecturer.fs.delete', async (item: any) => {
+      await this.deleteEntry(item);
+    });
   }
 
   private async renameEntry(item: any): Promise<void> {

--- a/src/commands/LogoutCommands.ts
+++ b/src/commands/LogoutCommands.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { ComputorSettingsManager } from '../settings/ComputorSettingsManager';
+import { commandRegistrar } from './commandHelpers';
 
 /**
  * Commands for logging out and clearing credentials
@@ -17,17 +18,15 @@ export class LogoutCommands {
   }
 
   registerCommands(): void {
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.logout', async () => {
-        await this.handleLogout();
-      })
-    );
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.clearAllData', async () => {
-        await this.handleClearAllData();
-      })
-    );
+    const register = commandRegistrar(this.context);
+    register('computor.logout', async () => {
+      await this.handleLogout();
+    });
+
+    register('computor.clearAllData', async () => {
+      await this.handleClearAllData();
+    });
   }
 
   /**

--- a/src/commands/SettingsCommands.ts
+++ b/src/commands/SettingsCommands.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { SettingsWebviewProvider } from '../ui/webviews/SettingsWebviewProvider';
 import { ComputorApiService } from '../services/ComputorApiService';
+import { commandRegistrar } from './commandHelpers';
 
 export class SettingsCommands {
   private settingsWebviewProvider: SettingsWebviewProvider;
@@ -10,9 +11,9 @@ export class SettingsCommands {
   }
 
   register(): void {
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.settingsView', () => this.openSettings())
-    );
+
+    const register = commandRegistrar(this.context);
+    register('computor.settingsView', () => this.openSettings());
   }
 
   setApiService(apiService: ComputorApiService): void {

--- a/src/commands/SignUpCommands.ts
+++ b/src/commands/SignUpCommands.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { SignUpWebviewProvider } from '../ui/webviews/SignUpWebviewProvider';
+import { commandRegistrar } from './commandHelpers';
 
 export class SignUpCommands {
   private signUpWebviewProvider: SignUpWebviewProvider;
@@ -9,9 +10,9 @@ export class SignUpCommands {
   }
 
   register(): void {
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.signUp', () => this.signUp())
-    );
+
+    const register = commandRegistrar(this.context);
+    register('computor.signUp', () => this.signUp());
   }
 
   private async signUp(): Promise<void> {

--- a/src/commands/StudentCommands.ts
+++ b/src/commands/StudentCommands.ts
@@ -15,6 +15,7 @@ import type { MessagesInputPanelProvider } from '../ui/panels/MessagesInputPanel
 import type { WebSocketService } from '../services/WebSocketService';
 import { getExampleVersionId } from '../utils/deploymentHelpers';
 import JSZip from 'jszip';
+import { commandRegistrar } from './commandHelpers';
 
 // (Deprecated legacy types removed)
 
@@ -186,935 +187,912 @@ export class StudentCommands {
 
 
   registerCommands(): void {
+
+
+    const register = commandRegistrar(this.context);
     // Refresh student view
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.refresh', async () => {
-        // Show progress notification while refreshing
-        await vscode.window.withProgress({
-          location: vscode.ProgressLocation.Notification,
-          title: 'Refreshing student view...',
-          cancellable: true
-        }, async (progress, token) => {
-          // Update repositories only for expanded courses
-          if (this.repositoryManager) {
-            const expandedCourseIds = this.treeDataProvider.getExpandedCourseIds();
-            if (expandedCourseIds.size > 0) {
-              try {
-                await this.repositoryManager.autoSetupRepositories(
-                  undefined,
-                  (msg) => progress.report({ message: msg }),
-                  expandedCourseIds,
-                  token
-                );
-              } catch (error) {
-                console.error('[StudentCommands] Failed during repository refresh:', error);
-              }
+    register('computor.student.refresh', async () => {
+      // Show progress notification while refreshing
+      await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: 'Refreshing student view...',
+        cancellable: true
+      }, async (progress, token) => {
+        // Update repositories only for expanded courses
+        if (this.repositoryManager) {
+          const expandedCourseIds = this.treeDataProvider.getExpandedCourseIds();
+          if (expandedCourseIds.size > 0) {
+            try {
+              await this.repositoryManager.autoSetupRepositories(
+                undefined,
+                (msg) => progress.report({ message: msg }),
+                expandedCourseIds,
+                token
+              );
+            } catch (error) {
+              console.error('[StudentCommands] Failed during repository refresh:', error);
             }
           }
+        }
 
-          // Refresh the tree view
-          progress.report({ message: 'Refreshing tree view...' });
-          this.treeDataProvider.refresh();
-        });
-      })
-    );
+        // Refresh the tree view
+        progress.report({ message: 'Refreshing tree view...' });
+        this.treeDataProvider.refresh();
+      });
+    });
 
     // Refresh tree view only (without Git updates) - used after marking messages as read
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.refreshTree', () => {
-        this.treeDataProvider.refresh();
-      })
-    );
+    register('computor.student.refreshTree', () => {
+      this.treeDataProvider.refresh();
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.showMessages', async (item?: any) => {
-        await this.showMessages(item);
-      })
-    );
+    register('computor.student.showMessages', async (item?: any) => {
+      await this.showMessages(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.showTestResults', async (item?: any) => {
-        try {
-          let resultPayload: any | undefined;
-          let resultId: string | undefined;
-          let resultArtifacts: any[] | undefined;
+    register('computor.showTestResults', async (item?: any) => {
+      try {
+        let resultPayload: any | undefined;
+        let resultId: string | undefined;
+        let resultArtifacts: any[] | undefined;
 
-          // Get course content ID from the item (student tree uses courseContent, tutor tree uses content)
-          const courseContentId = item?.courseContent?.id || item?.content?.id;
+        // Get course content ID from the item (student tree uses courseContent, tutor tree uses content)
+        const courseContentId = item?.courseContent?.id || item?.content?.id;
 
-          if (courseContentId) {
-            // Fetch fresh data from API to get latest test results
-            const freshCourseContent = await this.apiService.getStudentCourseContent(courseContentId, { force: true });
-            console.log('[showTestResults] Fresh course content:', JSON.stringify(freshCourseContent, null, 2));
-            const result = freshCourseContent?.result;
-            console.log('[showTestResults] Result object:', JSON.stringify(result, null, 2));
-            console.log('[showTestResults] Result keys:', result ? Object.keys(result) : 'no result');
-            if (result) {
-              resultPayload = result.result_json ?? result;
-              resultId = result.id;
-              resultArtifacts = result.result_artifacts;
-              console.log('[showTestResults] Result payload:', JSON.stringify(resultPayload, null, 2));
-              console.log('[showTestResults] Has result_json?', !!result.result_json);
-              console.log('[showTestResults] Result artifacts count:', resultArtifacts?.length ?? 0);
-            }
-          } else {
-            // Fallback to item data if no ID available
-            const courseContent = (item?.courseContent || item?.content) as any;
-            const result = courseContent?.result;
-            if (result) {
-              resultPayload = result.result_json ?? result;
-              resultId = result.id;
-              resultArtifacts = result.result_artifacts;
-            }
+        if (courseContentId) {
+          // Fetch fresh data from API to get latest test results
+          const freshCourseContent = await this.apiService.getStudentCourseContent(courseContentId, { force: true });
+          console.log('[showTestResults] Fresh course content:', JSON.stringify(freshCourseContent, null, 2));
+          const result = freshCourseContent?.result;
+          console.log('[showTestResults] Result object:', JSON.stringify(result, null, 2));
+          console.log('[showTestResults] Result keys:', result ? Object.keys(result) : 'no result');
+          if (result) {
+            resultPayload = result.result_json ?? result;
+            resultId = result.id;
+            resultArtifacts = result.result_artifacts;
+            console.log('[showTestResults] Result payload:', JSON.stringify(resultPayload, null, 2));
+            console.log('[showTestResults] Has result_json?', !!result.result_json);
+            console.log('[showTestResults] Result artifacts count:', resultArtifacts?.length ?? 0);
           }
-
-          if (resultPayload) {
-            await vscode.commands.executeCommand('computor.results.open', resultPayload, resultId, resultArtifacts);
+        } else {
+          // Fallback to item data if no ID available
+          const courseContent = (item?.courseContent || item?.content) as any;
+          const result = courseContent?.result;
+          if (result) {
+            resultPayload = result.result_json ?? result;
+            resultId = result.id;
+            resultArtifacts = result.result_artifacts;
           }
-
-          try {
-            await vscode.commands.executeCommand('workbench.view.extension.computor-test-results');
-          } catch (focusError) {
-            console.warn('[StudentCommands] Failed to focus test results view container:', focusError);
-          }
-
-          try {
-            await vscode.commands.executeCommand('computor.testResultsPanel.focus');
-          } catch (panelError) {
-            console.warn('[StudentCommands] Failed to focus test results panel:', panelError);
-          }
-
-          if (!resultPayload) {
-            vscode.window.showInformationMessage('No stored test results yet. Run tests to generate new results.');
-          }
-        } catch (error) {
-          console.error('[StudentCommands] Failed to show test results:', error);
-          vscode.window.showErrorMessage('Failed to open test results. Please run tests again.');
         }
-      })
-    );
+
+        if (resultPayload) {
+          await vscode.commands.executeCommand('computor.results.open', resultPayload, resultId, resultArtifacts);
+        }
+
+        try {
+          await vscode.commands.executeCommand('workbench.view.extension.computor-test-results');
+        } catch (focusError) {
+          console.warn('[StudentCommands] Failed to focus test results view container:', focusError);
+        }
+
+        try {
+          await vscode.commands.executeCommand('computor.testResultsPanel.focus');
+        } catch (panelError) {
+          console.warn('[StudentCommands] Failed to focus test results panel:', panelError);
+        }
+
+        if (!resultPayload) {
+          vscode.window.showInformationMessage('No stored test results yet. Run tests to generate new results.');
+        }
+      } catch (error) {
+        console.error('[StudentCommands] Failed to show test results:', error);
+        vscode.window.showErrorMessage('Failed to open test results. Please run tests again.');
+      }
+    });
 
     // Show README preview for assignments
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.showPreview', async (item?: any) => {
-        try {
-          // If item provided, check if it has a directory
-          if (item?.courseContent) {
-            const directoryFromItem: string | undefined = (item.courseContent as any).directory;
-            if (directoryFromItem) {
-              await this.openReadmeIfExists(directoryFromItem);
-              return;
-            } else {
-              // Assignment directory not available (likely not released yet)
-              vscode.window.showWarningMessage('Assignment not available yet. README preview cannot be shown.');
-              return;
-            }
-          }
-
-          // Try to infer from active editor
-          const activePath = vscode.window.activeTextEditor?.document?.uri?.fsPath;
-          if (activePath) {
-            const repoRoot = await this.findRepoRoot(activePath);
-            if (repoRoot) {
-              const rel = path.relative(repoRoot, activePath);
-              const firstSegment = rel.split(path.sep)[0];
-              if (firstSegment && firstSegment !== '' && firstSegment !== '..') {
-                const candidateDir = path.join(repoRoot, firstSegment);
-                const ok = await this.openReadmeIfExists(candidateDir, true);
-                if (ok) return;
-              }
-            }
-          }
-
-          // Fallback: let user pick an assignment directory from current course
-          const courseId = CourseSelectionService.getInstance().getCurrentCourseId();
-          if (!courseId) {
-            vscode.window.showWarningMessage('No course selected. Select a course then try again.');
+    register('computor.student.showPreview', async (item?: any) => {
+      try {
+        // If item provided, check if it has a directory
+        if (item?.courseContent) {
+          const directoryFromItem: string | undefined = (item.courseContent as any).directory;
+          if (directoryFromItem) {
+            await this.openReadmeIfExists(directoryFromItem);
+            return;
+          } else {
+            // Assignment directory not available (likely not released yet)
+            vscode.window.showWarningMessage('Assignment not available yet. README preview cannot be shown.');
             return;
           }
-          const contents = await this.apiService.getStudentCourseContents(courseId);
-          if (this.repositoryManager) {
-            this.repositoryManager.updateExistingRepositoryPaths(courseId, contents);
-          }
-          const assignables = contents
-            .map(c => ({ content: c, directory: (c as any).directory as string | undefined }))
-            .filter(x => !!x.directory && fs.existsSync(x.directory!));
-
-          if (assignables.length === 0) {
-            vscode.window.showInformationMessage('No cloned assignments found for this course. Clone an assignment first.');
-            return;
-          }
-
-          const pick = await vscode.window.showQuickPick(
-            assignables.map(a => ({ label: a.content.title || a.content.path, description: a.directory, a })),
-            { title: 'Select assignment to preview README.md' }
-          );
-          if (!pick) return;
-          await this.openReadmeIfExists(pick.a.directory!);
-        } catch (error: any) {
-          console.error('Failed to show README preview:', error);
-          vscode.window.showErrorMessage(`Failed to show README preview: ${error.message || error}`);
         }
-      })
-    );
+
+        // Try to infer from active editor
+        const activePath = vscode.window.activeTextEditor?.document?.uri?.fsPath;
+        if (activePath) {
+          const repoRoot = await this.findRepoRoot(activePath);
+          if (repoRoot) {
+            const rel = path.relative(repoRoot, activePath);
+            const firstSegment = rel.split(path.sep)[0];
+            if (firstSegment && firstSegment !== '' && firstSegment !== '..') {
+              const candidateDir = path.join(repoRoot, firstSegment);
+              const ok = await this.openReadmeIfExists(candidateDir, true);
+              if (ok) return;
+            }
+          }
+        }
+
+        // Fallback: let user pick an assignment directory from current course
+        const courseId = CourseSelectionService.getInstance().getCurrentCourseId();
+        if (!courseId) {
+          vscode.window.showWarningMessage('No course selected. Select a course then try again.');
+          return;
+        }
+        const contents = await this.apiService.getStudentCourseContents(courseId);
+        if (this.repositoryManager) {
+          this.repositoryManager.updateExistingRepositoryPaths(courseId, contents);
+        }
+        const assignables = contents
+          .map(c => ({ content: c, directory: (c as any).directory as string | undefined }))
+          .filter(x => !!x.directory && fs.existsSync(x.directory!));
+
+        if (assignables.length === 0) {
+          vscode.window.showInformationMessage('No cloned assignments found for this course. Clone an assignment first.');
+          return;
+        }
+
+        const pick = await vscode.window.showQuickPick(
+          assignables.map(a => ({ label: a.content.title || a.content.path, description: a.directory, a })),
+          { title: 'Select assignment to preview README.md' }
+        );
+        if (!pick) return;
+        await this.openReadmeIfExists(pick.a.directory!);
+      } catch (error: any) {
+        console.error('Failed to show README preview:', error);
+        vscode.window.showErrorMessage(`Failed to show README preview: ${error.message || error}`);
+      }
+    });
 
     // Clone repository from course content tree
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.cloneRepository', async (item: any) => {
-        console.log('[CloneRepo] Item received:', item);
-        console.log('[CloneRepo] Item courseContent:', item?.courseContent);
-        console.log('[CloneRepo] Item submissionGroup:', item?.submissionGroup);
+    register('computor.student.cloneRepository', async (item: any) => {
+      console.log('[CloneRepo] Item received:', item);
+      console.log('[CloneRepo] Item courseContent:', item?.courseContent);
+      console.log('[CloneRepo] Item submissionGroup:', item?.submissionGroup);
+      
+      // The item is a CourseContentItem from StudentCourseContentTreeProvider
+      if (!item || !item.submissionGroup || !item.submissionGroup.repository) {
+        vscode.window.showErrorMessage('No repository available for this assignment');
+        return;
+      }
+
+      const submissionGroup = item.submissionGroup;
+      let courseId = submissionGroup.course_id;
+      
+      // If course_id is not in submission group, try to get it from course selection
+      if (!courseId) {
+        const courseSelection = CourseSelectionService.getInstance();
+        courseId = courseSelection.getCurrentCourseId();
         
-        // The item is a CourseContentItem from StudentCourseContentTreeProvider
-        if (!item || !item.submissionGroup || !item.submissionGroup.repository) {
-          vscode.window.showErrorMessage('No repository available for this assignment');
+        if (!courseId) {
+          console.error('[CloneRepo] Course ID is missing from submission group and no course selected:', submissionGroup);
+          vscode.window.showErrorMessage('No course selected. Please select a course first.');
           return;
         }
-
-        const submissionGroup = item.submissionGroup;
-        let courseId = submissionGroup.course_id;
         
-        // If course_id is not in submission group, try to get it from course selection
-        if (!courseId) {
-          const courseSelection = CourseSelectionService.getInstance();
-          courseId = courseSelection.getCurrentCourseId();
-          
-          if (!courseId) {
-            console.error('[CloneRepo] Course ID is missing from submission group and no course selected:', submissionGroup);
-            vscode.window.showErrorMessage('No course selected. Please select a course first.');
-            return;
-          }
-          
-          console.log('[CloneRepo] Using course ID from course selection:', courseId);
+        console.log('[CloneRepo] Using course ID from course selection:', courseId);
+      }
+      
+      try {
+        if (!this.repositoryManager) {
+          vscode.window.showErrorMessage('Repository manager not available');
+          return;
         }
-        
-        try {
-          if (!this.repositoryManager) {
-            vscode.window.showErrorMessage('Repository manager not available');
-            return;
-          }
-          await vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: `Cloning repository for ${submissionGroup.course_content_title}...`,
-            cancellable: false
-          }, async () => {
-            await this.repositoryManager!.autoSetupRepositories(courseId!);
-          });
+        await vscode.window.withProgress({
+          location: vscode.ProgressLocation.Notification,
+          title: `Cloning repository for ${submissionGroup.course_content_title}...`,
+          cancellable: false
+        }, async () => {
+          await this.repositoryManager!.autoSetupRepositories(courseId!);
+        });
 
-          this.treeDataProvider.refresh();
-          vscode.window.showInformationMessage('Repository cloned/updated. Expand the assignment to see files.');
-        } catch (error: any) {
-          vscode.window.showErrorMessage(`Failed to clone repository: ${error?.message || error}`);
-        }
-      })
-    );
+        this.treeDataProvider.refresh();
+        vscode.window.showInformationMessage('Repository cloned/updated. Expand the assignment to see files.');
+      } catch (error: any) {
+        vscode.window.showErrorMessage(`Failed to clone repository: ${error?.message || error}`);
+      }
+    });
 
     // Open course in browser (if GitLab URL exists)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.openInBrowser', async (item: any) => {
-        if (!item || !item.course.repository) {
-          vscode.window.showErrorMessage('No repository URL available');
-          return;
-        }
+    register('computor.student.openInBrowser', async (item: any) => {
+      if (!item || !item.course.repository) {
+        vscode.window.showErrorMessage('No repository URL available');
+        return;
+      }
 
-        const url = `${item.course.repository.provider_url}/${item.course.repository.full_path}`;
-        vscode.env.openExternal(vscode.Uri.parse(url));
-      })
-    );
+      const url = `${item.course.repository.provider_url}/${item.course.repository.full_path}`;
+      vscode.env.openExternal(vscode.Uri.parse(url));
+    });
 
     // Clone submission group repository
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.cloneSubmissionGroupRepository', async (submissionGroup: SubmissionGroupStudentList, courseId: string) => {
-        if (!submissionGroup || !submissionGroup.repository) {
-          vscode.window.showErrorMessage('No repository available for this submission group');
+    register('computor.student.cloneSubmissionGroupRepository', async (submissionGroup: SubmissionGroupStudentList, courseId: string) => {
+      if (!submissionGroup || !submissionGroup.repository) {
+        vscode.window.showErrorMessage('No repository available for this submission group');
+        return;
+      }
+
+      try {
+        if (!this.repositoryManager) {
+          vscode.window.showErrorMessage('Repository manager not available');
           return;
         }
-
-        try {
-          if (!this.repositoryManager) {
-            vscode.window.showErrorMessage('Repository manager not available');
-            return;
-          }
-          await vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: `Cloning repository for ${submissionGroup.course_content_title}...`,
-            cancellable: false
-          }, async () => {
-            await this.repositoryManager!.autoSetupRepositories(courseId);
-          });
-          this.treeDataProvider.refresh();
-          vscode.window.showInformationMessage('Repository cloned/updated for the submission group.');
-        } catch (error: any) {
-          vscode.window.showErrorMessage(`Failed to clone repository: ${error?.message || error}`);
-        }
-      })
-    );
+        await vscode.window.withProgress({
+          location: vscode.ProgressLocation.Notification,
+          title: `Cloning repository for ${submissionGroup.course_content_title}...`,
+          cancellable: false
+        }, async () => {
+          await this.repositoryManager!.autoSetupRepositories(courseId);
+        });
+        this.treeDataProvider.refresh();
+        vscode.window.showInformationMessage('Repository cloned/updated for the submission group.');
+      } catch (error: any) {
+        vscode.window.showErrorMessage(`Failed to clone repository: ${error?.message || error}`);
+      }
+    });
 
     // Submit assignment
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.submitAssignment', async (itemOrSubmissionGroup: any) => {
-        try {
-          // Support invocation from tree item (preferred)
-          let directory: string | undefined;
-          let assignmentPath: string | undefined;
-          let assignmentTitle: string | undefined;
-          let submissionGroup: SubmissionGroupStudentList | undefined;
-          let courseContentId: string | undefined;
-          let testingServiceId: string | null | undefined;
-          let courseContent: CourseContentStudentList | CourseContentStudentGet | undefined;
+    register('computor.student.submitAssignment', async (itemOrSubmissionGroup: any) => {
+      try {
+        // Support invocation from tree item (preferred)
+        let directory: string | undefined;
+        let assignmentPath: string | undefined;
+        let assignmentTitle: string | undefined;
+        let submissionGroup: SubmissionGroupStudentList | undefined;
+        let courseContentId: string | undefined;
+        let testingServiceId: string | null | undefined;
+        let courseContent: CourseContentStudentList | CourseContentStudentGet | undefined;
 
-          if (itemOrSubmissionGroup?.courseContent) {
-            const item = itemOrSubmissionGroup;
-            courseContent = item.courseContent as CourseContentStudentList | CourseContentStudentGet;
-            directory = (item.courseContent as any)?.directory as string | undefined;
-            {
-              const pv: any = (item.courseContent as any)?.path;
-              assignmentPath = pv == null ? undefined : String(pv);
-            }
-            {
-              const tv: any = (item.courseContent as any)?.title;
-              assignmentTitle = tv == null ? assignmentPath : String(tv);
-            }
-            submissionGroup = item.submissionGroup as SubmissionGroupStudentList | undefined;
-            courseContentId = typeof item.courseContent?.id === 'string' ? item.courseContent.id : undefined;
-            testingServiceId = courseContent?.testing_service_id;
-          } else {
-            // Backward compatibility with old signature
-            submissionGroup = itemOrSubmissionGroup as SubmissionGroupStudentList | undefined;
-            {
-              const sv: any = submissionGroup?.course_content_path as any;
-              assignmentPath = sv == null ? undefined : String(sv);
-            }
-            {
-              const stv: any = submissionGroup?.course_content_title as any;
-              assignmentTitle = stv == null ? assignmentPath : String(stv);
-            }
-
-
-            // Try to resolve directory via current course contents
-            const courseId = CourseSelectionService.getInstance().getCurrentCourseId();
-            if (courseId) {
-              const contents = await this.apiService.getStudentCourseContents(courseId);
-              if (this.repositoryManager) {
-                this.repositoryManager.updateExistingRepositoryPaths(courseId, contents);
-              }
-              const match = contents.find(c => c.submission_group?.id === submissionGroup?.id);
-              directory = (match as any)?.directory as string | undefined;
-              if (!courseContentId && match?.id) {
-                courseContentId = String(match.id);
-              }
-              if (match) {
-                courseContent = match;
-                testingServiceId = match.testing_service_id;
-              }
-            }
+        if (itemOrSubmissionGroup?.courseContent) {
+          const item = itemOrSubmissionGroup;
+          courseContent = item.courseContent as CourseContentStudentList | CourseContentStudentGet;
+          directory = (item.courseContent as any)?.directory as string | undefined;
+          {
+            const pv: any = (item.courseContent as any)?.path;
+            assignmentPath = pv == null ? undefined : String(pv);
+          }
+          {
+            const tv: any = (item.courseContent as any)?.title;
+            assignmentTitle = tv == null ? assignmentPath : String(tv);
+          }
+          submissionGroup = item.submissionGroup as SubmissionGroupStudentList | undefined;
+          courseContentId = typeof item.courseContent?.id === 'string' ? item.courseContent.id : undefined;
+          testingServiceId = courseContent?.testing_service_id;
+        } else {
+          // Backward compatibility with old signature
+          submissionGroup = itemOrSubmissionGroup as SubmissionGroupStudentList | undefined;
+          {
+            const sv: any = submissionGroup?.course_content_path as any;
+            assignmentPath = sv == null ? undefined : String(sv);
+          }
+          {
+            const stv: any = submissionGroup?.course_content_title as any;
+            assignmentTitle = stv == null ? assignmentPath : String(stv);
           }
 
-          if (!directory || !fs.existsSync(directory)) {
-            vscode.window.showErrorMessage('Assignment directory not found. Please clone the repository first.');
-            return;
-          }
-          if (!assignmentPath) {
-            vscode.window.showErrorMessage('Assignment path is missing.');
-            return;
-          }
 
-          if (!submissionGroup?.id) {
-            vscode.window.showErrorMessage('Submission group information missing; cannot create submission.');
-            return;
-          }
-
-          const submissionDirectory = directory as string;
-          const submissionGroupId = String(submissionGroup.id);
-
-          const repoPath = await this.findRepoRoot(submissionDirectory);
-          if (!repoPath) {
-            vscode.window.showErrorMessage('Could not determine repository root.');
-            return;
-          }
-
-          // Save all open files in the assignment directory
-          await this.saveAllFilesInDirectory(submissionDirectory);
-
-          // Perform submission by ensuring latest work is committed and pushed
-          let submissionOk = false;
-          let submissionVersion: string | undefined;
-          let submissionResponse: SubmissionUploadResponseModel | undefined;
-          let reusedExistingSubmission = false;
-
-          // First, check current commit and whether it has been tested
-          const currentCommitBeforeStaging = await this.gitService.getLatestCommitHash(repoPath);
-          const hasUncommittedChanges = await this.gitService.hasChanges(repoPath);
-
-          if (hasUncommittedChanges || !currentCommitBeforeStaging) {
-            // If there are uncommitted changes, we need to commit them first
-            const commitLabel = assignmentTitle || assignmentPath || courseContentId || 'Assignment';
-
-            await vscode.window.withProgress({
-              location: vscode.ProgressLocation.Notification,
-              title: 'Preparing submission...',
-              cancellable: false
-            }, async (progress) => {
-              progress.report({ message: 'Staging changes...' });
-              await this.gitService.stageAll(repoPath);
-
-              const hasStagedFiles = await this.gitService.hasStagedFiles(repoPath);
-              if (hasStagedFiles) {
-                const now = new Date();
-                const timestamp = now.toISOString().replace('T', ' ').split('.')[0];
-                const commitMessage = `Update ${commitLabel} - ${timestamp}`;
-                progress.report({ message: 'Committing changes...' });
-                await this.gitService.commitChanges(repoPath, commitMessage);
-              }
-
-              const currentBranch = await this.gitService.getCurrentBranch(repoPath);
-              if (!currentBranch) {
-                throw new Error('Could not determine current branch.');
-              }
-
-              progress.report({ message: `Pushing ${currentBranch}...` });
-              await this.pushWithAuthRetry(repoPath);
-            });
-          }
-
-          const currentCommitHash = await this.gitService.getLatestCommitHash(repoPath);
-          if (!currentCommitHash) {
-            throw new Error('Failed to get current commit hash');
-          }
-
-          // Get the most recent tested artifact (submit=false)
-          let latestTestedArtifact: any = null;
-          try {
-            const latestTestedArtifacts = await this.apiService.listStudentSubmissionArtifacts({
-              submission_group_id: submissionGroupId,
-              submit: false
-            });
-
-            if (latestTestedArtifacts.length > 0) {
-              latestTestedArtifact = latestTestedArtifacts[0];
-            }
-          } catch (listError) {
-            console.warn('[submitAssignment] Failed to check tested artifacts:', listError);
-          }
-
-          // Check if current commit has been tested
-          const currentCommitTested = latestTestedArtifact?.version_identifier === currentCommitHash;
-
-          // If testing is required and current commit hasn't been tested, run test first
-          if (testingServiceId && !currentCommitTested) {
-            console.log(`[submitAssignment] Testing required (testing_service_id: ${testingServiceId}), running test first...`);
-
-            let testArtifactId: string | undefined;
-
-            // Check if artifact already exists for current commit (untested)
-            try {
-              const existingArtifacts = await this.apiService.listStudentSubmissionArtifacts({
-                submission_group_id: submissionGroupId,
-                version_identifier: currentCommitHash
-              });
-
-              if (existingArtifacts.length > 0) {
-                const artifact = existingArtifacts[0];
-                if (artifact) {
-                  const hasResult = artifact.result !== undefined && artifact.result !== null;
-                  if (hasResult) {
-                    // Already tested, update latestTestedArtifact
-                    console.log(`[submitAssignment] Commit ${currentCommitHash} already tested`);
-                    latestTestedArtifact = artifact;
-                  } else {
-                    // Artifact exists but not tested - reuse it for testing
-                    console.log(`[submitAssignment] Reusing existing untested artifact ID: ${artifact.id}`);
-                    testArtifactId = artifact.id;
-                  }
-                }
-              }
-            } catch (checkError) {
-              console.warn('[submitAssignment] Failed to check existing artifacts:', checkError);
-            }
-
-            // If no existing artifact, create one
-            if (!testArtifactId && !latestTestedArtifact?.version_identifier) {
-              await vscode.window.withProgress({
-                location: vscode.ProgressLocation.Notification,
-                title: `Testing ${assignmentTitle}...`,
-                cancellable: false
-              }, async (progress) => {
-                progress.report({ message: 'Packaging submission archive...' });
-                const archive = await this.createSubmissionArchive(submissionDirectory);
-                console.log(`[submitAssignment] Archive created for testing`);
-
-                progress.report({ message: 'Uploading for testing...' });
-                const testSubmissionResponse = await this.apiService.createStudentSubmission({
-                  submission_group_id: submissionGroupId,
-                  version_identifier: currentCommitHash,
-                  submit: false
-                }, archive);
-                console.log(`[submitAssignment] Created test artifact:`, testSubmissionResponse);
-
-                if (testSubmissionResponse?.artifacts && testSubmissionResponse.artifacts.length > 0) {
-                  testArtifactId = testSubmissionResponse.artifacts[0];
-                }
-              });
-            }
-
-            // Run the test and wait for results
-            if (testArtifactId && courseContentId) {
-              console.log(`[submitAssignment] Submitting test with artifact ID: ${testArtifactId}`);
-              const testResult = await this.testResultService.submitTestByArtifactAndAwaitResults(
-                testArtifactId,
-                assignmentTitle || 'Assignment',
-                undefined,
-                { courseContentId }
-              );
-
-              // Check if test was successful
-              // Test is considered successful if status is SUCCESS (regardless of score)
-              // We allow submission even with partial test scores
-              if (!testResult || testResult.status === 'ERROR' || testResult.status === 'TIMEOUT') {
-                vscode.window.showErrorMessage('Test execution failed. Please try again.');
-                // Clear cache and refresh tree
-                if (courseContentId) {
-                  this.apiService.clearStudentCourseContentCache(courseContentId);
-                  this.treeDataProvider.refresh();
-                }
-                return;
-              }
-
-              if (testResult.status === 'CANCELLED') {
-                vscode.window.showWarningMessage('Test was cancelled. Submission aborted.');
-                if (courseContentId) {
-                  this.apiService.clearStudentCourseContentCache(courseContentId);
-                  this.treeDataProvider.refresh();
-                }
-                return;
-              }
-
-              // FAILED status means test execution failed (not that tests didn't pass)
-              // We still proceed with submission as the student may want to submit anyway
-              console.log(`[submitAssignment] Test completed with status: ${testResult.status}, proceeding with submission`);
-
-              // Update latestTestedArtifact with the newly tested artifact
-              try {
-                const testedArtifacts = await this.apiService.listStudentSubmissionArtifacts({
-                  submission_group_id: submissionGroupId,
-                  version_identifier: currentCommitHash
-                });
-                if (testedArtifacts.length > 0) {
-                  latestTestedArtifact = testedArtifacts[0];
-                }
-              } catch (refreshError) {
-                console.warn('[submitAssignment] Failed to refresh tested artifact:', refreshError);
-              }
-            }
-          }
-
-          // Determine which version to submit
-          // If we have a tested artifact, submit that version (not HEAD)
-          // This ensures we submit the commit that was actually tested
-          if (latestTestedArtifact?.version_identifier) {
-            submissionVersion = latestTestedArtifact.version_identifier;
-            console.log(`[submitAssignment] Using tested artifact version: ${submissionVersion}`);
-          } else {
-            // No tested artifact exists, submit current HEAD
-            submissionVersion = currentCommitHash;
-            console.log(`[submitAssignment] No tested artifact found, using current HEAD: ${submissionVersion}`);
-          }
-
-          await vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: `Submitting ${assignmentTitle}...`,
-            cancellable: false
-          }, async (progress) => {
-            try {
-
-              let existingArtifactId: string | undefined;
-              let alreadySubmitted = false;
-              try {
-                // Get artifact for this version
-                const existingSubmissions = await this.apiService.listStudentSubmissionArtifacts({
-                  submission_group_id: submissionGroupId,
-                  version_identifier: submissionVersion
-                });
-                console.log(`[submitAssignment] GET response: Found ${existingSubmissions.length} artifacts for version ${submissionVersion}`);
-                console.log(`[submitAssignment] Full response:`, JSON.stringify(existingSubmissions, null, 2));
-
-                if (existingSubmissions.length > 0) {
-                  const matchingArtifact = existingSubmissions[0];
-                  existingArtifactId = matchingArtifact!.id;
-                  alreadySubmitted = matchingArtifact!.submit === true;
-                  console.log(`[submitAssignment] Found latest artifact ${existingArtifactId}:`);
-                  console.log(`  - submit field value: ${matchingArtifact!.submit}`);
-                  console.log(`  - submit field type: ${typeof matchingArtifact!.submit}`);
-                  console.log(`  - alreadySubmitted: ${alreadySubmitted}`);
-                  console.log(`  - Full artifact:`, JSON.stringify(matchingArtifact, null, 2));
-                } else {
-                  console.log(`[submitAssignment] GET returned empty array - no existing artifacts`);
-                }
-              } catch (listError) {
-                console.warn('[submitAssignment] Failed to check existing submissions:', listError);
-              }
-
-              if (existingArtifactId && alreadySubmitted) {
-                // Case 1: Artifact exists AND submit=true → Do nothing
-                reusedExistingSubmission = true;
-                submissionOk = true;
-                progress.report({ message: 'Submission already exists for this version.' });
-                console.log('[submitAssignment] Case 1: Artifact already submitted (submit=true), doing nothing');
-                return;
-              } else if (existingArtifactId && !alreadySubmitted) {
-                // Case 2: Artifact exists AND submit=false → PATCH to mark as submitted
-                console.log('[submitAssignment] Case 2: Artifact exists but submit=false, calling PATCH');
-                progress.report({ message: 'Marking existing artifact as submitted...' });
-                submissionResponse = await this.apiService.updateStudentSubmission(
-                  existingArtifactId,
-                  { submit: true }
-                );
-              } else {
-                // Case 3: No existing artifact → POST to create new submission
-                console.log('[submitAssignment] Case 3: No existing artifact found, calling POST to create new submission');
-                progress.report({ message: 'Packaging submission archive...' });
-                const archive = await this.createSubmissionArchive(submissionDirectory);
-
-                progress.report({ message: 'Creating submission...' });
-                submissionResponse = await this.apiService.createStudentSubmission({
-                  submission_group_id: submissionGroupId,
-                  version_identifier: submissionVersion || undefined,
-                  submit: true
-                }, archive);
-              }
-
-              submissionOk = true;
-            } catch (e) {
-              throw e;
-            }
-          });
-          if (submissionOk) {
-            try {
-              if (courseContentId) {
-                // After PATCH, fetch fresh data from the API and update the tree
-                const courseId = CourseSelectionService.getInstance().getCurrentCourseId();
-                console.log('[submitAssignment] Fetching fresh course contents after PATCH:', {
-                  courseId,
-                  courseContentId
-                });
-
-                if (courseId) {
-                  // Clear cache and fetch fresh data with course_id filter
-                  this.apiService.clearStudentCourseContentsCache(courseId);
-                  this.apiService.clearStudentCourseContentCache(courseContentId);
-
-                  // This will make: GET /students/course-contents?course_id=...
-                  await this.apiService.getStudentCourseContents(courseId, { force: true });
-
-                  // Now refresh the tree item with the fresh data
-                  await this.treeDataProvider.refreshContentItem(courseContentId);
-                  console.log('[submitAssignment] Tree refresh complete');
-                } else {
-                  console.warn('[submitAssignment] No courseId available, doing full refresh');
-                  this.treeDataProvider.refresh();
-                }
-              } else {
-                console.log('[submitAssignment] No courseContentId, doing full refresh');
-                this.treeDataProvider.refresh();
-              }
-            } catch (refreshError) {
-              console.error('[submitAssignment] Failed to refresh course content after submission:', refreshError);
-            }
-
-            if (reusedExistingSubmission) {
-              vscode.window.showWarningMessage('This artifact has already been submitted. No action taken.');
-            } else if (submissionResponse) {
-              const successMessage = 'Assignment submitted successfully.';
-
-              vscode.window.showInformationMessage(successMessage);
-            } else {
-              vscode.window.showWarningMessage('Submission completed without a response from the server.');
-            }
-          }
-        } catch (error: any) {
-          console.error('Failed to submit assignment:', error?.response?.data || error);
-          const message = typeof error?.message === 'string'
-            ? error.message
-            : typeof error === 'string'
-              ? error
-              : 'Failed to submit assignment.';
-          vscode.window.showErrorMessage(message);
-        }
-      })
-    );
-
-    // View submission group details (accepts tree item || raw submission group)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.viewSubmissionGroup', async (arg: any) => {
-        await this.showContentDetails(arg);
-      })
-    );
-
-    // Commit and push assignment changes
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.commitAssignment', async (item: any) => {
-        console.log('[CommitAssignment] Item received:', item);
-        
-        // The item is a CourseContentItem from StudentCourseContentTreeProvider
-        if (!item || !item.courseContent) {
-          vscode.window.showErrorMessage('No assignment selected');
-          return;
-        }
-
-        // Get the assignment directory
-        const directory = (item.courseContent as any).directory;
-        if (!directory || !fs.existsSync(directory)) {
-          vscode.window.showErrorMessage('Assignment directory not found. Please clone the repository first.');
-          return;
-        }
-
-        const assignmentPath = item.courseContent.path;
-        const assignmentTitle = item.courseContent.title || assignmentPath;
-
-        try {
-          // Save all open files in the assignment directory
-          await this.saveAllFilesInDirectory(directory);
-
-          // Check if there are any changes to commit
-          const hasChanges = await this.gitService.hasChanges(directory);
-          if (!hasChanges) {
-            vscode.window.showInformationMessage('No changes to commit in this assignment.');
-            return;
-          }
-
-          // Generate automatic commit message
-          const now = new Date();
-          const timestamp = now.toISOString().replace('T', ' ').split('.')[0];
-          const commitMessage = `Update ${assignmentTitle} - ${timestamp}`;
-
-          // Show progress while committing and pushing
-          await vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: `Committing and pushing ${assignmentTitle}...`,
-            cancellable: false
-          }, async (progress) => {
-            progress.report({ increment: 0, message: 'Preparing to commit...' });
-
-            // Find repository root
-            const repoPath = await this.findRepoRoot(directory);
-            if (!repoPath) {
-              throw new Error('Could not determine repository root');
-            }
-
-            progress.report({ increment: 40, message: 'Committing changes...' });
-            // Stage only the assignment directory
-            await this.gitService.stagePath(repoPath, directory);
-
-            // Commit only if something is staged
-            const hasStagedFiles = await this.gitService.hasStagedFiles(repoPath);
-            if (!hasStagedFiles) {
-              throw new Error('No changes to commit in the assignment folder');
-            }
-
-            await this.gitService.commitChanges(repoPath, commitMessage);
-
-            progress.report({ increment: 60, message: 'Pushing to remote...' });
-            // Push to main branch, prompting for new token if required
-            await this.pushWithAuthRetry(repoPath);
-
-            progress.report({ increment: 100, message: 'Successfully committed and pushed!' });
-          });
-
-          vscode.window.showInformationMessage(`Successfully committed and pushed ${assignmentTitle}`);
-
-          // Optionally refresh the tree to update any status indicators
-          this.treeDataProvider.refreshNode(item);
-        } catch (error: any) {
-          console.error('Failed to commit assignment:', error);
-          vscode.window.showErrorMessage(`Failed to commit assignment: ${error.message}`);
-        }
-      })
-    );
-
-    // Test assignment (includes commit, push, and test submission)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.testAssignment', async (item: any) => {
-        console.log('[TestAssignment] Item received:', item);
-        
-        // The item is a CourseContentItem from StudentCourseContentTreeProvider
-        if (!item || !item.courseContent) {
-          vscode.window.showErrorMessage('No assignment selected');
-          return;
-        }
-
-        // Get the assignment directory and submission metadata
-        let directory = (item.courseContent as any).directory as string | undefined;
-        const assignmentPath = item.courseContent.path;
-        const assignmentTitle = item.courseContent.title || assignmentPath;
-        let submissionGroup = item.submissionGroup as SubmissionGroupStudentList | undefined;
-
-        if ((!directory || !fs.existsSync(directory)) || !submissionGroup?.id) {
+          // Try to resolve directory via current course contents
           const courseId = CourseSelectionService.getInstance().getCurrentCourseId();
           if (courseId) {
-            const contents = await this.apiService.getStudentCourseContents(courseId) || [];
+            const contents = await this.apiService.getStudentCourseContents(courseId);
             if (this.repositoryManager) {
               this.repositoryManager.updateExistingRepositoryPaths(courseId, contents);
             }
-            const match = contents.find(c => c.id === item.courseContent.id);
-            if (!directory && match) {
-              directory = (match as any)?.directory as string | undefined;
+            const match = contents.find(c => c.submission_group?.id === submissionGroup?.id);
+            directory = (match as any)?.directory as string | undefined;
+            if (!courseContentId && match?.id) {
+              courseContentId = String(match.id);
             }
-            if (!submissionGroup?.id) {
-              submissionGroup = match?.submission_group as SubmissionGroupStudentList | undefined;
+            if (match) {
+              courseContent = match;
+              testingServiceId = match.testing_service_id;
             }
           }
         }
 
         if (!directory || !fs.existsSync(directory)) {
           vscode.window.showErrorMessage('Assignment directory not found. Please clone the repository first.');
+          return;
+        }
+        if (!assignmentPath) {
+          vscode.window.showErrorMessage('Assignment path is missing.');
           return;
         }
 
         if (!submissionGroup?.id) {
-          vscode.window.showErrorMessage('Submission group information missing; cannot upload for testing.');
+          vscode.window.showErrorMessage('Submission group information missing; cannot create submission.');
           return;
         }
 
         const submissionDirectory = directory as string;
         const submissionGroupId = String(submissionGroup.id);
-        const courseContentId = typeof item.courseContent.id === 'string'
-          ? item.courseContent.id
-          : String(item.courseContent.id);
 
-        let testSucceeded = false;
-        try {
-          // Save all open files in the assignment directory
-          await this.saveAllFilesInDirectory(submissionDirectory);
+        const repoPath = await this.findRepoRoot(submissionDirectory);
+        if (!repoPath) {
+          vscode.window.showErrorMessage('Could not determine repository root.');
+          return;
+        }
 
-          const hasChanges = await this.gitService.hasChanges(submissionDirectory);
-          let currentCommitHash = await this.gitService.getLatestCommitHash(submissionDirectory);
+        // Save all open files in the assignment directory
+        await this.saveAllFilesInDirectory(submissionDirectory);
 
-          // Commit changes first if there are any
-          if (hasChanges) {
-            await vscode.window.withProgress({
-              location: vscode.ProgressLocation.Notification,
-              title: `Preparing ${assignmentTitle}...`,
-              cancellable: true
-            }, async (progress, token) => {
-              progress.report({ message: 'Committing changes...' });
-              await this.gitService.stageAll(submissionDirectory);
+        // Perform submission by ensuring latest work is committed and pushed
+        let submissionOk = false;
+        let submissionVersion: string | undefined;
+        let submissionResponse: SubmissionUploadResponseModel | undefined;
+        let reusedExistingSubmission = false;
+
+        // First, check current commit and whether it has been tested
+        const currentCommitBeforeStaging = await this.gitService.getLatestCommitHash(repoPath);
+        const hasUncommittedChanges = await this.gitService.hasChanges(repoPath);
+
+        if (hasUncommittedChanges || !currentCommitBeforeStaging) {
+          // If there are uncommitted changes, we need to commit them first
+          const commitLabel = assignmentTitle || assignmentPath || courseContentId || 'Assignment';
+
+          await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Preparing submission...',
+            cancellable: false
+          }, async (progress) => {
+            progress.report({ message: 'Staging changes...' });
+            await this.gitService.stageAll(repoPath);
+
+            const hasStagedFiles = await this.gitService.hasStagedFiles(repoPath);
+            if (hasStagedFiles) {
               const now = new Date();
               const timestamp = now.toISOString().replace('T', ' ').split('.')[0];
-              const commitMessage = `Update ${assignmentTitle} - ${timestamp}`;
-              await this.gitService.commitChanges(submissionDirectory, commitMessage);
+              const commitMessage = `Update ${commitLabel} - ${timestamp}`;
+              progress.report({ message: 'Committing changes...' });
+              await this.gitService.commitChanges(repoPath, commitMessage);
+            }
 
-              progress.report({ message: 'Pushing to remote...' });
-              try {
-                await this.pushWithAuthRetry(submissionDirectory);
-                progress.report({ message: 'Successfully pushed to remote.' });
-              } catch (pushError) {
-                console.error('[TestAssignment] Git push failed:', pushError);
-                throw new Error(`Failed to push changes to remote: ${pushError instanceof Error ? pushError.message : String(pushError)}`);
+            const currentBranch = await this.gitService.getCurrentBranch(repoPath);
+            if (!currentBranch) {
+              throw new Error('Could not determine current branch.');
+            }
+
+            progress.report({ message: `Pushing ${currentBranch}...` });
+            await this.pushWithAuthRetry(repoPath);
+          });
+        }
+
+        const currentCommitHash = await this.gitService.getLatestCommitHash(repoPath);
+        if (!currentCommitHash) {
+          throw new Error('Failed to get current commit hash');
+        }
+
+        // Get the most recent tested artifact (submit=false)
+        let latestTestedArtifact: any = null;
+        try {
+          const latestTestedArtifacts = await this.apiService.listStudentSubmissionArtifacts({
+            submission_group_id: submissionGroupId,
+            submit: false
+          });
+
+          if (latestTestedArtifacts.length > 0) {
+            latestTestedArtifact = latestTestedArtifacts[0];
+          }
+        } catch (listError) {
+          console.warn('[submitAssignment] Failed to check tested artifacts:', listError);
+        }
+
+        // Check if current commit has been tested
+        const currentCommitTested = latestTestedArtifact?.version_identifier === currentCommitHash;
+
+        // If testing is required and current commit hasn't been tested, run test first
+        if (testingServiceId && !currentCommitTested) {
+          console.log(`[submitAssignment] Testing required (testing_service_id: ${testingServiceId}), running test first...`);
+
+          let testArtifactId: string | undefined;
+
+          // Check if artifact already exists for current commit (untested)
+          try {
+            const existingArtifacts = await this.apiService.listStudentSubmissionArtifacts({
+              submission_group_id: submissionGroupId,
+              version_identifier: currentCommitHash
+            });
+
+            if (existingArtifacts.length > 0) {
+              const artifact = existingArtifacts[0];
+              if (artifact) {
+                const hasResult = artifact.result !== undefined && artifact.result !== null;
+                if (hasResult) {
+                  // Already tested, update latestTestedArtifact
+                  console.log(`[submitAssignment] Commit ${currentCommitHash} already tested`);
+                  latestTestedArtifact = artifact;
+                } else {
+                  // Artifact exists but not tested - reuse it for testing
+                  console.log(`[submitAssignment] Reusing existing untested artifact ID: ${artifact.id}`);
+                  testArtifactId = artifact.id;
+                }
               }
+            }
+          } catch (checkError) {
+            console.warn('[submitAssignment] Failed to check existing artifacts:', checkError);
+          }
 
-              progress.report({ message: 'Getting commit hash...' });
-              currentCommitHash = await this.gitService.getLatestCommitHash(submissionDirectory);
+          // If no existing artifact, create one
+          if (!testArtifactId && !latestTestedArtifact?.version_identifier) {
+            await vscode.window.withProgress({
+              location: vscode.ProgressLocation.Notification,
+              title: `Testing ${assignmentTitle}...`,
+              cancellable: false
+            }, async (progress) => {
+              progress.report({ message: 'Packaging submission archive...' });
+              const archive = await this.createSubmissionArchive(submissionDirectory);
+              console.log(`[submitAssignment] Archive created for testing`);
+
+              progress.report({ message: 'Uploading for testing...' });
+              const testSubmissionResponse = await this.apiService.createStudentSubmission({
+                submission_group_id: submissionGroupId,
+                version_identifier: currentCommitHash,
+                submit: false
+              }, archive);
+              console.log(`[submitAssignment] Created test artifact:`, testSubmissionResponse);
+
+              if (testSubmissionResponse?.artifacts && testSubmissionResponse.artifacts.length > 0) {
+                testArtifactId = testSubmissionResponse.artifacts[0];
+              }
             });
           }
 
-          // Now check for existing artifact for current HEAD commit
-          let submissionResponse: any = null;
-          if (currentCommitHash && courseContentId) {
-            // Check if artifact already exists for this commit
-            try {
-              const existingArtifacts = await this.apiService.listStudentSubmissionArtifacts({
-                submission_group_id: submissionGroupId,
-                version_identifier: currentCommitHash
-              });
-
-              if (existingArtifacts.length > 0) {
-                const artifact = existingArtifacts[0];
-                if (!artifact) {
-                  throw new Error('Unexpected: artifact is undefined');
-                }
-
-                console.log(`[TestAssignment] Found existing artifact for commit ${currentCommitHash}:`, artifact);
-
-                // Check if artifact has been tested (has result field)
-                const hasResult = artifact.result !== undefined && artifact.result !== null;
-
-                if (hasResult) {
-                  throw new Error('This commit has already been tested. Make new changes to test again.');
-                }
-
-                // Artifact exists but not tested yet - reuse it
-                console.log(`[TestAssignment] Reusing existing untested artifact ID: ${artifact.id}`);
-                submissionResponse = { artifacts: [artifact.id] };
-              } else {
-                // No artifact exists, create new one
-                console.log(`[TestAssignment] No artifact found for commit ${currentCommitHash}, creating new one`);
-                await vscode.window.withProgress({
-                  location: vscode.ProgressLocation.Notification,
-                  title: `Preparing ${assignmentTitle}...`,
-                  cancellable: false
-                }, async (progress) => {
-                  progress.report({ message: 'Packaging submission archive...' });
-                  const archive = await this.createSubmissionArchive(submissionDirectory);
-                  console.log(`[TestAssignment] Archive created successfully`);
-
-                  progress.report({ message: 'Uploading submission package...' });
-                  submissionResponse = await this.apiService.createStudentSubmission({
-                    submission_group_id: submissionGroupId,
-                    version_identifier: currentCommitHash,
-                    submit: false
-                  }, archive);
-                  console.log(`[TestAssignment] Created new artifact:`, submissionResponse);
-                });
-              }
-            } catch (error: any) {
-              console.error('[TestAssignment] Error handling artifact:', error);
-              throw error;
-            }
-          }
-
-          // Submit test - TestResultService will handle its own progress if polling is needed
-          if (submissionResponse?.artifacts?.length > 0) {
-            const artifactId = submissionResponse.artifacts[0];
-            console.log(`[TestAssignment] Submitting test with artifact ID: ${artifactId}`);
-            await this.testResultService.submitTestByArtifactAndAwaitResults(
-              artifactId,
-              assignmentTitle,
+          // Run the test and wait for results
+          if (testArtifactId && courseContentId) {
+            console.log(`[submitAssignment] Submitting test with artifact ID: ${testArtifactId}`);
+            const testResult = await this.testResultService.submitTestByArtifactAndAwaitResults(
+              testArtifactId,
+              assignmentTitle || 'Assignment',
               undefined,
               { courseContentId }
             );
-            testSucceeded = true;
-          } else if (currentCommitHash && courseContentId) {
-            console.error('[TestAssignment] No artifact ID available, cannot submit test');
-            throw new Error('Failed to create or retrieve submission artifact');
-          } else {
-            vscode.window.showWarningMessage('Could not determine commit hash or content ID for testing');
+
+            // Check if test was successful
+            // Test is considered successful if status is SUCCESS (regardless of score)
+            // We allow submission even with partial test scores
+            if (!testResult || testResult.status === 'ERROR' || testResult.status === 'TIMEOUT') {
+              vscode.window.showErrorMessage('Test execution failed. Please try again.');
+              // Clear cache and refresh tree
+              if (courseContentId) {
+                this.apiService.clearStudentCourseContentCache(courseContentId);
+                this.treeDataProvider.refresh();
+              }
+              return;
+            }
+
+            if (testResult.status === 'CANCELLED') {
+              vscode.window.showWarningMessage('Test was cancelled. Submission aborted.');
+              if (courseContentId) {
+                this.apiService.clearStudentCourseContentCache(courseContentId);
+                this.treeDataProvider.refresh();
+              }
+              return;
+            }
+
+            // FAILED status means test execution failed (not that tests didn't pass)
+            // We still proceed with submission as the student may want to submit anyway
+            console.log(`[submitAssignment] Test completed with status: ${testResult.status}, proceeding with submission`);
+
+            // Update latestTestedArtifact with the newly tested artifact
+            try {
+              const testedArtifacts = await this.apiService.listStudentSubmissionArtifacts({
+                submission_group_id: submissionGroupId,
+                version_identifier: currentCommitHash
+              });
+              if (testedArtifacts.length > 0) {
+                latestTestedArtifact = testedArtifacts[0];
+              }
+            } catch (refreshError) {
+              console.warn('[submitAssignment] Failed to refresh tested artifact:', refreshError);
+            }
+          }
+        }
+
+        // Determine which version to submit
+        // If we have a tested artifact, submit that version (not HEAD)
+        // This ensures we submit the commit that was actually tested
+        if (latestTestedArtifact?.version_identifier) {
+          submissionVersion = latestTestedArtifact.version_identifier;
+          console.log(`[submitAssignment] Using tested artifact version: ${submissionVersion}`);
+        } else {
+          // No tested artifact exists, submit current HEAD
+          submissionVersion = currentCommitHash;
+          console.log(`[submitAssignment] No tested artifact found, using current HEAD: ${submissionVersion}`);
+        }
+
+        await vscode.window.withProgress({
+          location: vscode.ProgressLocation.Notification,
+          title: `Submitting ${assignmentTitle}...`,
+          cancellable: false
+        }, async (progress) => {
+          try {
+
+            let existingArtifactId: string | undefined;
+            let alreadySubmitted = false;
+            try {
+              // Get artifact for this version
+              const existingSubmissions = await this.apiService.listStudentSubmissionArtifacts({
+                submission_group_id: submissionGroupId,
+                version_identifier: submissionVersion
+              });
+              console.log(`[submitAssignment] GET response: Found ${existingSubmissions.length} artifacts for version ${submissionVersion}`);
+              console.log(`[submitAssignment] Full response:`, JSON.stringify(existingSubmissions, null, 2));
+
+              if (existingSubmissions.length > 0) {
+                const matchingArtifact = existingSubmissions[0];
+                existingArtifactId = matchingArtifact!.id;
+                alreadySubmitted = matchingArtifact!.submit === true;
+                console.log(`[submitAssignment] Found latest artifact ${existingArtifactId}:`);
+                console.log(`  - submit field value: ${matchingArtifact!.submit}`);
+                console.log(`  - submit field type: ${typeof matchingArtifact!.submit}`);
+                console.log(`  - alreadySubmitted: ${alreadySubmitted}`);
+                console.log(`  - Full artifact:`, JSON.stringify(matchingArtifact, null, 2));
+              } else {
+                console.log(`[submitAssignment] GET returned empty array - no existing artifacts`);
+              }
+            } catch (listError) {
+              console.warn('[submitAssignment] Failed to check existing submissions:', listError);
+            }
+
+            if (existingArtifactId && alreadySubmitted) {
+              // Case 1: Artifact exists AND submit=true → Do nothing
+              reusedExistingSubmission = true;
+              submissionOk = true;
+              progress.report({ message: 'Submission already exists for this version.' });
+              console.log('[submitAssignment] Case 1: Artifact already submitted (submit=true), doing nothing');
+              return;
+            } else if (existingArtifactId && !alreadySubmitted) {
+              // Case 2: Artifact exists AND submit=false → PATCH to mark as submitted
+              console.log('[submitAssignment] Case 2: Artifact exists but submit=false, calling PATCH');
+              progress.report({ message: 'Marking existing artifact as submitted...' });
+              submissionResponse = await this.apiService.updateStudentSubmission(
+                existingArtifactId,
+                { submit: true }
+              );
+            } else {
+              // Case 3: No existing artifact → POST to create new submission
+              console.log('[submitAssignment] Case 3: No existing artifact found, calling POST to create new submission');
+              progress.report({ message: 'Packaging submission archive...' });
+              const archive = await this.createSubmissionArchive(submissionDirectory);
+
+              progress.report({ message: 'Creating submission...' });
+              submissionResponse = await this.apiService.createStudentSubmission({
+                submission_group_id: submissionGroupId,
+                version_identifier: submissionVersion || undefined,
+                submit: true
+              }, archive);
+            }
+
+            submissionOk = true;
+          } catch (e) {
+            throw e;
+          }
+        });
+        if (submissionOk) {
+          try {
+            if (courseContentId) {
+              // After PATCH, fetch fresh data from the API and update the tree
+              const courseId = CourseSelectionService.getInstance().getCurrentCourseId();
+              console.log('[submitAssignment] Fetching fresh course contents after PATCH:', {
+                courseId,
+                courseContentId
+              });
+
+              if (courseId) {
+                // Clear cache and fetch fresh data with course_id filter
+                this.apiService.clearStudentCourseContentsCache(courseId);
+                this.apiService.clearStudentCourseContentCache(courseContentId);
+
+                // This will make: GET /students/course-contents?course_id=...
+                await this.apiService.getStudentCourseContents(courseId, { force: true });
+
+                // Now refresh the tree item with the fresh data
+                await this.treeDataProvider.refreshContentItem(courseContentId);
+                console.log('[submitAssignment] Tree refresh complete');
+              } else {
+                console.warn('[submitAssignment] No courseId available, doing full refresh');
+                this.treeDataProvider.refresh();
+              }
+            } else {
+              console.log('[submitAssignment] No courseContentId, doing full refresh');
+              this.treeDataProvider.refresh();
+            }
+          } catch (refreshError) {
+            console.error('[submitAssignment] Failed to refresh course content after submission:', refreshError);
           }
 
-          // Only refresh if test completed successfully
-          if (testSucceeded) {
-            // Clear the cache for this specific content to ensure fresh data
-            this.apiService.clearStudentCourseContentCache(courseContentId);
-            // Use full refresh to ensure tree updates properly
-            this.treeDataProvider.refresh();
+          if (reusedExistingSubmission) {
+            vscode.window.showWarningMessage('This artifact has already been submitted. No action taken.');
+          } else if (submissionResponse) {
+            const successMessage = 'Assignment submitted successfully.';
+
+            vscode.window.showInformationMessage(successMessage);
+          } else {
+            vscode.window.showWarningMessage('Submission completed without a response from the server.');
           }
-        } catch (error: any) {
-          console.error('Failed to test assignment:', error);
-          // Only show error message for git push failures
-          // Other errors (like test submission errors) are already handled by TestResultService
-          if (error?.message && error.message.includes('Failed to push changes to remote')) {
-            vscode.window.showErrorMessage(`Assignment test aborted: ${error.message}`);
-          }
-          // For other errors, TestResultService has already shown the error message
         }
-      })
-    );
+      } catch (error: any) {
+        console.error('Failed to submit assignment:', error?.response?.data || error);
+        const message = typeof error?.message === 'string'
+          ? error.message
+          : typeof error === 'string'
+            ? error
+            : 'Failed to submit assignment.';
+        vscode.window.showErrorMessage(message);
+      }
+    });
+
+    // View submission group details (accepts tree item || raw submission group)
+    register('computor.student.viewSubmissionGroup', async (arg: any) => {
+      await this.showContentDetails(arg);
+    });
+
+    // Commit and push assignment changes
+    register('computor.student.commitAssignment', async (item: any) => {
+      console.log('[CommitAssignment] Item received:', item);
+      
+      // The item is a CourseContentItem from StudentCourseContentTreeProvider
+      if (!item || !item.courseContent) {
+        vscode.window.showErrorMessage('No assignment selected');
+        return;
+      }
+
+      // Get the assignment directory
+      const directory = (item.courseContent as any).directory;
+      if (!directory || !fs.existsSync(directory)) {
+        vscode.window.showErrorMessage('Assignment directory not found. Please clone the repository first.');
+        return;
+      }
+
+      const assignmentPath = item.courseContent.path;
+      const assignmentTitle = item.courseContent.title || assignmentPath;
+
+      try {
+        // Save all open files in the assignment directory
+        await this.saveAllFilesInDirectory(directory);
+
+        // Check if there are any changes to commit
+        const hasChanges = await this.gitService.hasChanges(directory);
+        if (!hasChanges) {
+          vscode.window.showInformationMessage('No changes to commit in this assignment.');
+          return;
+        }
+
+        // Generate automatic commit message
+        const now = new Date();
+        const timestamp = now.toISOString().replace('T', ' ').split('.')[0];
+        const commitMessage = `Update ${assignmentTitle} - ${timestamp}`;
+
+        // Show progress while committing and pushing
+        await vscode.window.withProgress({
+          location: vscode.ProgressLocation.Notification,
+          title: `Committing and pushing ${assignmentTitle}...`,
+          cancellable: false
+        }, async (progress) => {
+          progress.report({ increment: 0, message: 'Preparing to commit...' });
+
+          // Find repository root
+          const repoPath = await this.findRepoRoot(directory);
+          if (!repoPath) {
+            throw new Error('Could not determine repository root');
+          }
+
+          progress.report({ increment: 40, message: 'Committing changes...' });
+          // Stage only the assignment directory
+          await this.gitService.stagePath(repoPath, directory);
+
+          // Commit only if something is staged
+          const hasStagedFiles = await this.gitService.hasStagedFiles(repoPath);
+          if (!hasStagedFiles) {
+            throw new Error('No changes to commit in the assignment folder');
+          }
+
+          await this.gitService.commitChanges(repoPath, commitMessage);
+
+          progress.report({ increment: 60, message: 'Pushing to remote...' });
+          // Push to main branch, prompting for new token if required
+          await this.pushWithAuthRetry(repoPath);
+
+          progress.report({ increment: 100, message: 'Successfully committed and pushed!' });
+        });
+
+        vscode.window.showInformationMessage(`Successfully committed and pushed ${assignmentTitle}`);
+
+        // Optionally refresh the tree to update any status indicators
+        this.treeDataProvider.refreshNode(item);
+      } catch (error: any) {
+        console.error('Failed to commit assignment:', error);
+        vscode.window.showErrorMessage(`Failed to commit assignment: ${error.message}`);
+      }
+    });
+
+    // Test assignment (includes commit, push, and test submission)
+    register('computor.student.testAssignment', async (item: any) => {
+      console.log('[TestAssignment] Item received:', item);
+      
+      // The item is a CourseContentItem from StudentCourseContentTreeProvider
+      if (!item || !item.courseContent) {
+        vscode.window.showErrorMessage('No assignment selected');
+        return;
+      }
+
+      // Get the assignment directory and submission metadata
+      let directory = (item.courseContent as any).directory as string | undefined;
+      const assignmentPath = item.courseContent.path;
+      const assignmentTitle = item.courseContent.title || assignmentPath;
+      let submissionGroup = item.submissionGroup as SubmissionGroupStudentList | undefined;
+
+      if ((!directory || !fs.existsSync(directory)) || !submissionGroup?.id) {
+        const courseId = CourseSelectionService.getInstance().getCurrentCourseId();
+        if (courseId) {
+          const contents = await this.apiService.getStudentCourseContents(courseId) || [];
+          if (this.repositoryManager) {
+            this.repositoryManager.updateExistingRepositoryPaths(courseId, contents);
+          }
+          const match = contents.find(c => c.id === item.courseContent.id);
+          if (!directory && match) {
+            directory = (match as any)?.directory as string | undefined;
+          }
+          if (!submissionGroup?.id) {
+            submissionGroup = match?.submission_group as SubmissionGroupStudentList | undefined;
+          }
+        }
+      }
+
+      if (!directory || !fs.existsSync(directory)) {
+        vscode.window.showErrorMessage('Assignment directory not found. Please clone the repository first.');
+        return;
+      }
+
+      if (!submissionGroup?.id) {
+        vscode.window.showErrorMessage('Submission group information missing; cannot upload for testing.');
+        return;
+      }
+
+      const submissionDirectory = directory as string;
+      const submissionGroupId = String(submissionGroup.id);
+      const courseContentId = typeof item.courseContent.id === 'string'
+        ? item.courseContent.id
+        : String(item.courseContent.id);
+
+      let testSucceeded = false;
+      try {
+        // Save all open files in the assignment directory
+        await this.saveAllFilesInDirectory(submissionDirectory);
+
+        const hasChanges = await this.gitService.hasChanges(submissionDirectory);
+        let currentCommitHash = await this.gitService.getLatestCommitHash(submissionDirectory);
+
+        // Commit changes first if there are any
+        if (hasChanges) {
+          await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: `Preparing ${assignmentTitle}...`,
+            cancellable: true
+          }, async (progress, token) => {
+            progress.report({ message: 'Committing changes...' });
+            await this.gitService.stageAll(submissionDirectory);
+            const now = new Date();
+            const timestamp = now.toISOString().replace('T', ' ').split('.')[0];
+            const commitMessage = `Update ${assignmentTitle} - ${timestamp}`;
+            await this.gitService.commitChanges(submissionDirectory, commitMessage);
+
+            progress.report({ message: 'Pushing to remote...' });
+            try {
+              await this.pushWithAuthRetry(submissionDirectory);
+              progress.report({ message: 'Successfully pushed to remote.' });
+            } catch (pushError) {
+              console.error('[TestAssignment] Git push failed:', pushError);
+              throw new Error(`Failed to push changes to remote: ${pushError instanceof Error ? pushError.message : String(pushError)}`);
+            }
+
+            progress.report({ message: 'Getting commit hash...' });
+            currentCommitHash = await this.gitService.getLatestCommitHash(submissionDirectory);
+          });
+        }
+
+        // Now check for existing artifact for current HEAD commit
+        let submissionResponse: any = null;
+        if (currentCommitHash && courseContentId) {
+          // Check if artifact already exists for this commit
+          try {
+            const existingArtifacts = await this.apiService.listStudentSubmissionArtifacts({
+              submission_group_id: submissionGroupId,
+              version_identifier: currentCommitHash
+            });
+
+            if (existingArtifacts.length > 0) {
+              const artifact = existingArtifacts[0];
+              if (!artifact) {
+                throw new Error('Unexpected: artifact is undefined');
+              }
+
+              console.log(`[TestAssignment] Found existing artifact for commit ${currentCommitHash}:`, artifact);
+
+              // Check if artifact has been tested (has result field)
+              const hasResult = artifact.result !== undefined && artifact.result !== null;
+
+              if (hasResult) {
+                throw new Error('This commit has already been tested. Make new changes to test again.');
+              }
+
+              // Artifact exists but not tested yet - reuse it
+              console.log(`[TestAssignment] Reusing existing untested artifact ID: ${artifact.id}`);
+              submissionResponse = { artifacts: [artifact.id] };
+            } else {
+              // No artifact exists, create new one
+              console.log(`[TestAssignment] No artifact found for commit ${currentCommitHash}, creating new one`);
+              await vscode.window.withProgress({
+                location: vscode.ProgressLocation.Notification,
+                title: `Preparing ${assignmentTitle}...`,
+                cancellable: false
+              }, async (progress) => {
+                progress.report({ message: 'Packaging submission archive...' });
+                const archive = await this.createSubmissionArchive(submissionDirectory);
+                console.log(`[TestAssignment] Archive created successfully`);
+
+                progress.report({ message: 'Uploading submission package...' });
+                submissionResponse = await this.apiService.createStudentSubmission({
+                  submission_group_id: submissionGroupId,
+                  version_identifier: currentCommitHash,
+                  submit: false
+                }, archive);
+                console.log(`[TestAssignment] Created new artifact:`, submissionResponse);
+              });
+            }
+          } catch (error: any) {
+            console.error('[TestAssignment] Error handling artifact:', error);
+            throw error;
+          }
+        }
+
+        // Submit test - TestResultService will handle its own progress if polling is needed
+        if (submissionResponse?.artifacts?.length > 0) {
+          const artifactId = submissionResponse.artifacts[0];
+          console.log(`[TestAssignment] Submitting test with artifact ID: ${artifactId}`);
+          await this.testResultService.submitTestByArtifactAndAwaitResults(
+            artifactId,
+            assignmentTitle,
+            undefined,
+            { courseContentId }
+          );
+          testSucceeded = true;
+        } else if (currentCommitHash && courseContentId) {
+          console.error('[TestAssignment] No artifact ID available, cannot submit test');
+          throw new Error('Failed to create or retrieve submission artifact');
+        } else {
+          vscode.window.showWarningMessage('Could not determine commit hash or content ID for testing');
+        }
+
+        // Only refresh if test completed successfully
+        if (testSucceeded) {
+          // Clear the cache for this specific content to ensure fresh data
+          this.apiService.clearStudentCourseContentCache(courseContentId);
+          // Use full refresh to ensure tree updates properly
+          this.treeDataProvider.refresh();
+        }
+      } catch (error: any) {
+        console.error('Failed to test assignment:', error);
+        // Only show error message for git push failures
+        // Other errors (like test submission errors) are already handled by TestResultService
+        if (error?.message && error.message.includes('Failed to push changes to remote')) {
+          vscode.window.showErrorMessage(`Assignment test aborted: ${error.message}`);
+        }
+        // For other errors, TestResultService has already shown the error message
+      }
+    });
 
     // Help command
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.student.help', async (item?: any) => {
-        await this.showHelp(item);
-      })
-    );
+    register('computor.student.help', async (item?: any) => {
+      await this.showHelp(item);
+    });
   }
 
   private async showHelp(item?: any): Promise<void> {

--- a/src/commands/StudentOfflineCommands.ts
+++ b/src/commands/StudentOfflineCommands.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { StudentOfflineTreeProvider } from '../ui/tree/student/StudentOfflineTreeProvider';
 import { GitService } from '../services/GitService';
 import { OfflineRepositoryManager } from '../services/OfflineRepositoryManager';
+import { commandRegistrar } from './commandHelpers';
 
 /**
  * Commands for the student offline mode
@@ -26,54 +27,42 @@ export class StudentOfflineCommands {
     }
 
     registerCommands(): void {
+
+      const register = commandRegistrar(this.context);
         // Add new course
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand('computor.student.offline.addCourse', async () => {
-                await this.addCourse();
-            })
-        );
+        register('computor.student.offline.addCourse', async () => {
+            await this.addCourse();
+        });
 
         // Refresh offline view
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand('computor.student.offline.refresh', () => {
-                this.treeProvider.refresh();
-            })
-        );
+        register('computor.student.offline.refresh', () => {
+            this.treeProvider.refresh();
+        });
 
         // Save (add + commit + push) assignment
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand('computor.student.offline.saveAssignment', async (item: any) => {
-                await this.saveAssignment(item);
-            })
-        );
+        register('computor.student.offline.saveAssignment', async (item: any) => {
+            await this.saveAssignment(item);
+        });
 
         // Open assignment in terminal
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand('computor.student.offline.openInTerminal', async (item: any) => {
-                await this.openInTerminal(item);
-            })
-        );
+        register('computor.student.offline.openInTerminal', async (item: any) => {
+            await this.openInTerminal(item);
+        });
 
         // Open repository in terminal (course level)
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand('computor.student.offline.openRepoInTerminal', async (item: any) => {
-                await this.openRepoInTerminal(item);
-            })
-        );
+        register('computor.student.offline.openRepoInTerminal', async (item: any) => {
+            await this.openRepoInTerminal(item);
+        });
 
         // Pull latest changes from remote
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand('computor.student.offline.pullChanges', async (item: any) => {
-                await this.pullChanges(item);
-            })
-        );
+        register('computor.student.offline.pullChanges', async (item: any) => {
+            await this.pullChanges(item);
+        });
 
         // Show preview for README
-        this.context.subscriptions.push(
-            vscode.commands.registerCommand('computor.student.offline.showPreview', async (item: any) => {
-                await this.showReadmePreview(item);
-            })
-        );
+        register('computor.student.offline.showPreview', async (item: any) => {
+            await this.showReadmePreview(item);
+        });
     }
 
     /**

--- a/src/commands/TutorCommands.ts
+++ b/src/commands/TutorCommands.ts
@@ -19,6 +19,7 @@ interface TutorFilterRefreshable {
 import type { MessagesInputPanelProvider } from '../ui/panels/MessagesInputPanel';
 import type { WebSocketService } from '../services/WebSocketService';
 import { TutorTestService } from '../services/TutorTestService';
+import { commandRegistrar } from './commandHelpers';
 
 export class TutorCommands {
   private context: vscode.ExtensionContext;
@@ -59,404 +60,374 @@ export class TutorCommands {
   }
 
   registerCommands(): void {
+
+    const register = commandRegistrar(this.context);
     // Refresh tutor view: clear caches for current member to force API reload
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.refresh', async () => {
-        try {
-          const sel = TutorSelectionService.getInstance();
-          const memberId = sel.getCurrentMemberId();
-          const courseId = sel.getCurrentCourseId();
-          const groupId = sel.getCurrentGroupId();
-
-          // Clear all tutor-related caches to ensure fresh data
-          this.apiService.clearTutorCoursesCache();
-          if (courseId) {
-            this.apiService.clearTutorCourseGroupsCache(courseId);
-            this.apiService.clearTutorCourseMembersCache(courseId, groupId || undefined);
-          }
-          if (memberId) {
-            this.apiService.clearTutorMemberCourseContentsCache(memberId);
-          }
-          // Also clear content kinds to be safe
-          this.apiService.clearCourseContentKindsCache();
-
-          // Proactively fetch fresh data to trigger API calls
-          if (courseId) {
-            await this.apiService.getTutorCourseMembers(courseId, groupId || undefined);
-          }
-          if (courseId && memberId) {
-            await this.apiService.getTutorCourseContents(courseId, memberId);
-          }
-        } catch (error) {
-          console.error('[TutorCommands] Error refreshing tutor data:', error);
-        }
-        this.treeDataProvider.refresh();
-        this.filterProvider?.refreshFilters();
-      })
-    );
-
-    // Refresh tree view only (without cache clearing/API re-fetch) - used after marking messages as read
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.refreshTree', () => {
-        this.treeDataProvider.refresh();
-      })
-    );
-
-    // Show Course Progress (uses current selected course from filters)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.showCourseProgress', async () => {
-        const sel = TutorSelectionService.getInstance();
-        const courseId = sel.getCurrentCourseId();
-        if (!courseId) {
-          vscode.window.showWarningMessage('Please select a course first.');
-          return;
-        }
-        await vscode.commands.executeCommand('computor.lecturer.showCourseProgressOverview', courseId);
-      })
-    );
-
-    // Show Member Progress (uses current selected member from filters)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.showMemberProgress', async () => {
+    register('computor.tutor.refresh', async () => {
+      try {
         const sel = TutorSelectionService.getInstance();
         const memberId = sel.getCurrentMemberId();
-        const memberName = sel.getCurrentMemberLabel();
-        if (!memberId) {
-          vscode.window.showWarningMessage('Please select a member first.');
-          return;
+        const courseId = sel.getCurrentCourseId();
+        const groupId = sel.getCurrentGroupId();
+
+        // Clear all tutor-related caches to ensure fresh data
+        this.apiService.clearTutorCoursesCache();
+        if (courseId) {
+          this.apiService.clearTutorCourseGroupsCache(courseId);
+          this.apiService.clearTutorCourseMembersCache(courseId, groupId || undefined);
         }
-        await vscode.commands.executeCommand('computor.lecturer.showCourseMemberProgress', memberId, memberName);
-      })
-    );
+        if (memberId) {
+          this.apiService.clearTutorMemberCourseContentsCache(memberId);
+        }
+        // Also clear content kinds to be safe
+        this.apiService.clearCourseContentKindsCache();
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.showCourseMemberComments', async () => {
-        await this.showCourseMemberComments();
-      })
-    );
+        // Proactively fetch fresh data to trigger API calls
+        if (courseId) {
+          await this.apiService.getTutorCourseMembers(courseId, groupId || undefined);
+        }
+        if (courseId && memberId) {
+          await this.apiService.getTutorCourseContents(courseId, memberId);
+        }
+      } catch (error) {
+        console.error('[TutorCommands] Error refreshing tutor data:', error);
+      }
+      this.treeDataProvider.refresh();
+      this.filterProvider?.refreshFilters();
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.showMessages', async (item?: any) => {
-        await this.showMessages(item);
-      })
-    );
+    // Refresh tree view only (without cache clearing/API re-fetch) - used after marking messages as read
+    register('computor.tutor.refreshTree', () => {
+      this.treeDataProvider.refresh();
+    });
+
+    // Show Course Progress (uses current selected course from filters)
+    register('computor.tutor.showCourseProgress', async () => {
+      const sel = TutorSelectionService.getInstance();
+      const courseId = sel.getCurrentCourseId();
+      if (!courseId) {
+        vscode.window.showWarningMessage('Please select a course first.');
+        return;
+      }
+      await vscode.commands.executeCommand('computor.lecturer.showCourseProgressOverview', courseId);
+    });
+
+    // Show Member Progress (uses current selected member from filters)
+    register('computor.tutor.showMemberProgress', async () => {
+      const sel = TutorSelectionService.getInstance();
+      const memberId = sel.getCurrentMemberId();
+      const memberName = sel.getCurrentMemberLabel();
+      if (!memberId) {
+        vscode.window.showWarningMessage('Please select a member first.');
+        return;
+      }
+      await vscode.commands.executeCommand('computor.lecturer.showCourseMemberProgress', memberId, memberName);
+    });
+
+    register('computor.tutor.showCourseMemberComments', async () => {
+      await this.showCourseMemberComments();
+    });
+
+    register('computor.tutor.showMessages', async (item?: any) => {
+      await this.showMessages(item);
+    });
 
     // Old tutor example/course commands removed in favor of TutorStudentTreeProvider actions
 
     // Tutor: Clone student repository (scaffold)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.cloneStudentRepository', async (item: any) => {
-        try {
-          // Prefer repository information from the clicked assignment's submission_group
-          const content: any = item?.content || item?.course_content;
-          const contentCourseId: string | undefined = content?.course_id;
-          const submission = content?.submission_group || content?.submission;
-          const submissionRepo = submission?.repository;
+    register('computor.tutor.cloneStudentRepository', async (item: any) => {
+      try {
+        // Prefer repository information from the clicked assignment's submission_group
+        const content: any = item?.content || item?.course_content;
+        const contentCourseId: string | undefined = content?.course_id;
+        const submission = content?.submission_group || content?.submission;
+        const submissionRepo = submission?.repository;
 
-          const sel = TutorSelectionService.getInstance();
-          let courseId = contentCourseId || sel.getCurrentCourseId() || '';
-          let memberId = sel.getCurrentMemberId() || '';
-          if (!courseId || !memberId) {
-            // Fallback prompts only if selection is missing
-            if (!courseId) courseId = (await vscode.window.showInputBox({ title: 'Course ID', prompt: 'Enter course ID', ignoreFocusOut: true })) || '';
-            if (!memberId) memberId = (await vscode.window.showInputBox({ title: 'Course Member ID', prompt: 'Enter course member ID', ignoreFocusOut: true })) || '';
+        const sel = TutorSelectionService.getInstance();
+        let courseId = contentCourseId || sel.getCurrentCourseId() || '';
+        let memberId = sel.getCurrentMemberId() || '';
+        if (!courseId || !memberId) {
+          // Fallback prompts only if selection is missing
+          if (!courseId) courseId = (await vscode.window.showInputBox({ title: 'Course ID', prompt: 'Enter course ID', ignoreFocusOut: true })) || '';
+          if (!memberId) memberId = (await vscode.window.showInputBox({ title: 'Course Member ID', prompt: 'Enter course member ID', ignoreFocusOut: true })) || '';
+        }
+        if (!courseId || !memberId) { return; }
+
+        // Build remote URL: prefer clone_url; then url/web_url; try to construct from provider_url + full_path; fallback to backend member repo; if still missing, throw
+        let remoteUrl: string | undefined = submissionRepo?.clone_url || submissionRepo?.url || submissionRepo?.web_url;
+        if (!remoteUrl && submissionRepo) {
+          const base = (submissionRepo as any).provider_url || (submissionRepo as any).provider || submissionRepo.url || '';
+          const full = submissionRepo.full_path || '';
+          if (base && full) {
+            remoteUrl = `${base.replace(/\/$/, '')}/${full.replace(/^\//, '')}`;
+            if (!remoteUrl.endsWith('.git')) remoteUrl += '.git';
           }
-          if (!courseId || !memberId) { return; }
+        }
+        if (!remoteUrl) {
+          // Try backend member repository endpoint
+          const repoMeta = await this.apiService.getTutorStudentRepository(courseId, memberId);
+          remoteUrl = repoMeta?.remote_url;
+        }
+        if (!remoteUrl) {
+          vscode.window.showErrorMessage('No repository URL found for this student assignment.');
+          return;
+        }
 
-          // Build remote URL: prefer clone_url; then url/web_url; try to construct from provider_url + full_path; fallback to backend member repo; if still missing, throw
-          let remoteUrl: string | undefined = submissionRepo?.clone_url || submissionRepo?.url || submissionRepo?.web_url;
-          if (!remoteUrl && submissionRepo) {
-            const base = (submissionRepo as any).provider_url || (submissionRepo as any).provider || submissionRepo.url || '';
-            const full = submissionRepo.full_path || '';
-            if (base && full) {
-              remoteUrl = `${base.replace(/\/$/, '')}/${full.replace(/^\//, '')}`;
-              if (!remoteUrl.endsWith('.git')) remoteUrl += '.git';
+        // Extract submission group ID if available
+        const submissionGroupId = submission?.id || content?.submission_group?.id;
+        // Include full repository data for full_path
+        const fullSubmissionRepo = submissionRepo || content?.submission_group?.repository;
+        const repoName = deriveRepositoryDirectoryName({
+          submissionRepo: fullSubmissionRepo,
+          remoteUrl,
+          submissionGroupId,
+          courseId,
+          memberId
+        });
+
+        // Ensure workspace directories exist
+        await this.workspaceStructure.ensureDirectories();
+
+        // Use review directory for tutor repositories
+        const dir = this.workspaceStructure.getReviewRepositoryPath(repoName);
+        await fs.promises.mkdir(dir, { recursive: true });
+        // Git clone into the destination if empty
+        const exists = await fs.promises.readdir(dir).then(list => list.length > 0).catch(() => false);
+        if (exists) {
+          vscode.window.showWarningMessage(`Directory not empty: ${dir}. Skipping clone.`);
+        } else {
+          const origin = (() => { try { const u = new URL(remoteUrl!); return u.origin; } catch { return undefined; } })();
+          const tokenManager = GitLabTokenManager.getInstance(this.context);
+          let authUrl = remoteUrl!;
+          if (origin) {
+            const savedToken = await tokenManager.getToken(origin);
+            if (savedToken) {
+              authUrl = tokenManager.buildAuthenticatedCloneUrl(remoteUrl!, savedToken);
             }
           }
-          if (!remoteUrl) {
-            // Try backend member repository endpoint
-            const repoMeta = await this.apiService.getTutorStudentRepository(courseId, memberId);
-            remoteUrl = repoMeta?.remote_url;
-          }
-          if (!remoteUrl) {
-            vscode.window.showErrorMessage('No repository URL found for this student assignment.');
-            return;
-          }
-
-          // Extract submission group ID if available
-          const submissionGroupId = submission?.id || content?.submission_group?.id;
-          // Include full repository data for full_path
-          const fullSubmissionRepo = submissionRepo || content?.submission_group?.repository;
-          const repoName = deriveRepositoryDirectoryName({
-            submissionRepo: fullSubmissionRepo,
-            remoteUrl,
-            submissionGroupId,
-            courseId,
-            memberId
-          });
-
-          // Ensure workspace directories exist
-          await this.workspaceStructure.ensureDirectories();
-
-          // Use review directory for tutor repositories
-          const dir = this.workspaceStructure.getReviewRepositoryPath(repoName);
-          await fs.promises.mkdir(dir, { recursive: true });
-          // Git clone into the destination if empty
-          const exists = await fs.promises.readdir(dir).then(list => list.length > 0).catch(() => false);
-          if (exists) {
-            vscode.window.showWarningMessage(`Directory not empty: ${dir}. Skipping clone.`);
-          } else {
-            const origin = (() => { try { const u = new URL(remoteUrl!); return u.origin; } catch { return undefined; } })();
-            const tokenManager = GitLabTokenManager.getInstance(this.context);
-            let authUrl = remoteUrl!;
-            if (origin) {
-              const savedToken = await tokenManager.getToken(origin);
-              if (savedToken) {
-                authUrl = tokenManager.buildAuthenticatedCloneUrl(remoteUrl!, savedToken);
-              }
-            }
-            try {
+          try {
+            await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: 'Cloning student repository...', cancellable: false }, async () => {
+              await createSimpleGit().clone(authUrl, dir);
+            });
+            vscode.window.showInformationMessage(`Student repository cloned to ${dir}`);
+            this.treeDataProvider.refresh();
+          } catch (e: any) {
+            const msg = String(e?.message || e || '');
+            if (origin && (msg.includes('Authentication failed') || msg.includes('could not read Username') || msg.includes('401'))) {
+              const newToken = await (async () => {
+                // Reuse token manager's prompt behavior
+                const t = await vscode.window.showInputBox({
+                  title: `GitLab Authentication for ${origin}`,
+                  prompt: `Enter your GitLab Personal Access Token for ${origin}`,
+                  placeHolder: 'glpat-xxxxxxxxxxxxxxxxxxxx',
+                  password: true,
+                  ignoreFocusOut: true
+                });
+                if (t) await tokenManager.storeToken(origin, t);
+                return t || undefined;
+              })();
+              if (!newToken) throw e;
+              authUrl = tokenManager.buildAuthenticatedCloneUrl(remoteUrl!, newToken);
               await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: 'Cloning student repository...', cancellable: false }, async () => {
                 await createSimpleGit().clone(authUrl, dir);
               });
               vscode.window.showInformationMessage(`Student repository cloned to ${dir}`);
               this.treeDataProvider.refresh();
-            } catch (e: any) {
-              const msg = String(e?.message || e || '');
-              if (origin && (msg.includes('Authentication failed') || msg.includes('could not read Username') || msg.includes('401'))) {
-                const newToken = await (async () => {
-                  // Reuse token manager's prompt behavior
-                  const t = await vscode.window.showInputBox({
-                    title: `GitLab Authentication for ${origin}`,
-                    prompt: `Enter your GitLab Personal Access Token for ${origin}`,
-                    placeHolder: 'glpat-xxxxxxxxxxxxxxxxxxxx',
-                    password: true,
-                    ignoreFocusOut: true
-                  });
-                  if (t) await tokenManager.storeToken(origin, t);
-                  return t || undefined;
-                })();
-                if (!newToken) throw e;
-                authUrl = tokenManager.buildAuthenticatedCloneUrl(remoteUrl!, newToken);
-                await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: 'Cloning student repository...', cancellable: false }, async () => {
-                  await createSimpleGit().clone(authUrl, dir);
-                });
-                vscode.window.showInformationMessage(`Student repository cloned to ${dir}`);
-                this.treeDataProvider.refresh();
-              } else {
-                throw e;
-              }
+            } else {
+              throw e;
             }
           }
-          // Directory is already inside the current workspace; no need to add a new folder
-        } catch (e: any) {
-          vscode.window.showErrorMessage(`Failed to clone student repository: ${e?.message || e}`);
         }
-      })
-    );
+        // Directory is already inside the current workspace; no need to add a new folder
+      } catch (e: any) {
+        vscode.window.showErrorMessage(`Failed to clone student repository: ${e?.message || e}`);
+      }
+    });
 
     // Tutor: Update student repository (pull latest changes)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.updateStudentRepository', async (item: any) => {
-        try {
-          const content: any = item?.content || item?.courseContent || item?.course_content || item;
-          const submission = content?.submission_group || content?.submission || content;
-          const submissionRepo = submission?.repository || content?.submission_group?.repository;
+    register('computor.tutor.updateStudentRepository', async (item: any) => {
+      try {
+        const content: any = item?.content || item?.courseContent || item?.course_content || item;
+        const submission = content?.submission_group || content?.submission || content;
+        const submissionRepo = submission?.repository || content?.submission_group?.repository;
 
-          // Get course and member context
-          const sel = TutorSelectionService.getInstance();
-          let courseId = sel.getCurrentCourseId();
-          let memberId = sel.getCurrentMemberId();
+        // Get course and member context
+        const sel = TutorSelectionService.getInstance();
+        let courseId = sel.getCurrentCourseId();
+        let memberId = sel.getCurrentMemberId();
 
-          if (!courseId || !memberId) {
-            if (!courseId) courseId = (await vscode.window.showInputBox({ title: 'Course ID', prompt: 'Enter course ID', ignoreFocusOut: true })) || '';
-            if (!memberId) memberId = (await vscode.window.showInputBox({ title: 'Course Member ID', prompt: 'Enter course member ID', ignoreFocusOut: true })) || '';
-          }
-          if (!courseId || !memberId) { return; }
-
-          // Build remote URL
-          let remoteUrl: string | undefined = submissionRepo?.clone_url || submissionRepo?.url || submissionRepo?.web_url;
-          if (!remoteUrl && submissionRepo) {
-            const base = (submissionRepo as any).provider_url || (submissionRepo as any).provider || submissionRepo.url || '';
-            const full = submissionRepo.full_path || '';
-            if (base && full) {
-              remoteUrl = `${base.replace(/\/$/, '')}/${full.replace(/^\//, '')}`;
-              if (!remoteUrl.endsWith('.git')) remoteUrl += '.git';
-            }
-          }
-
-          // Get repository directory name
-          const submissionGroupId = submission?.id || content?.submission_group?.id;
-          const fullSubmissionRepo = submissionRepo || content?.submission_group?.repository;
-          const repoName = deriveRepositoryDirectoryName({
-            submissionRepo: fullSubmissionRepo,
-            remoteUrl,
-            submissionGroupId,
-            courseId,
-            memberId
-          });
-
-          const dir = this.workspaceStructure.getReviewRepositoryPath(repoName);
-          const gitDir = path.join(dir, '.git');
-
-          // Check if repository exists
-          if (!fs.existsSync(gitDir)) {
-            vscode.window.showErrorMessage('Repository not found. Please clone it first.');
-            return;
-          }
-
-          // Update the repository
-          await vscode.window.withProgress(
-            { location: vscode.ProgressLocation.Notification, title: 'Updating student repository...', cancellable: false },
-            async () => {
-              const git = createSimpleGit({ baseDir: dir });
-              await git.fetch(['--all']);
-              await git.pull(['--ff-only']);
-            }
-          );
-
-          vscode.window.showInformationMessage('Repository updated successfully.');
-          this.treeDataProvider.refresh();
-        } catch (e: any) {
-          vscode.window.showErrorMessage(`Failed to update repository: ${e?.message || e}`);
+        if (!courseId || !memberId) {
+          if (!courseId) courseId = (await vscode.window.showInputBox({ title: 'Course ID', prompt: 'Enter course ID', ignoreFocusOut: true })) || '';
+          if (!memberId) memberId = (await vscode.window.showInputBox({ title: 'Course Member ID', prompt: 'Enter course member ID', ignoreFocusOut: true })) || '';
         }
-      })
-    );
+        if (!courseId || !memberId) { return; }
+
+        // Build remote URL
+        let remoteUrl: string | undefined = submissionRepo?.clone_url || submissionRepo?.url || submissionRepo?.web_url;
+        if (!remoteUrl && submissionRepo) {
+          const base = (submissionRepo as any).provider_url || (submissionRepo as any).provider || submissionRepo.url || '';
+          const full = submissionRepo.full_path || '';
+          if (base && full) {
+            remoteUrl = `${base.replace(/\/$/, '')}/${full.replace(/^\//, '')}`;
+            if (!remoteUrl.endsWith('.git')) remoteUrl += '.git';
+          }
+        }
+
+        // Get repository directory name
+        const submissionGroupId = submission?.id || content?.submission_group?.id;
+        const fullSubmissionRepo = submissionRepo || content?.submission_group?.repository;
+        const repoName = deriveRepositoryDirectoryName({
+          submissionRepo: fullSubmissionRepo,
+          remoteUrl,
+          submissionGroupId,
+          courseId,
+          memberId
+        });
+
+        const dir = this.workspaceStructure.getReviewRepositoryPath(repoName);
+        const gitDir = path.join(dir, '.git');
+
+        // Check if repository exists
+        if (!fs.existsSync(gitDir)) {
+          vscode.window.showErrorMessage('Repository not found. Please clone it first.');
+          return;
+        }
+
+        // Update the repository
+        await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Notification, title: 'Updating student repository...', cancellable: false },
+          async () => {
+            const git = createSimpleGit({ baseDir: dir });
+            await git.fetch(['--all']);
+            await git.pull(['--ff-only']);
+          }
+        );
+
+        vscode.window.showInformationMessage('Repository updated successfully.');
+        this.treeDataProvider.refresh();
+      } catch (e: any) {
+        vscode.window.showErrorMessage(`Failed to update repository: ${e?.message || e}`);
+      }
+    });
 
     // Tutor: Set grading and status together
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.assignment.grading', async (item: { content?: CourseContentStudentList; courseContent?: CourseContentStudentList }) => {
-        const content: CourseContentStudentList | undefined = item?.content || item?.courseContent;
-        const contentId = content?.id;
-        if (!content || !contentId) { vscode.window.showErrorMessage('No course content selected.'); return; }
+    register('computor.tutor.assignment.grading', async (item: { content?: CourseContentStudentList; courseContent?: CourseContentStudentList }) => {
+      const content: CourseContentStudentList | undefined = item?.content || item?.courseContent;
+      const contentId = content?.id;
+      if (!content || !contentId) { vscode.window.showErrorMessage('No course content selected.'); return; }
 
-        const sel = TutorSelectionService.getInstance();
-        const memberId = sel.getCurrentMemberId();
-        if (!memberId) { vscode.window.showErrorMessage('No course member selected.'); return; }
+      const sel = TutorSelectionService.getInstance();
+      const memberId = sel.getCurrentMemberId();
+      if (!memberId) { vscode.window.showErrorMessage('No course member selected.'); return; }
 
-        // Get the latest submitted artifact to ensure grade is applied correctly
-        const submissionGroup: SubmissionGroupStudentList | undefined | null = content.submission_group;
-        let latestSubmittedArtifactId: string | undefined;
-        if (submissionGroup?.id) {
-          const artifacts = await this.apiService.listSubmissionArtifacts(submissionGroup.id, { latest: true });
-          if (artifacts && artifacts.length > 0 && artifacts[0]) {
-            latestSubmittedArtifactId = artifacts[0].id;
-          }
+      // Get the latest submitted artifact to ensure grade is applied correctly
+      const submissionGroup: SubmissionGroupStudentList | undefined | null = content.submission_group;
+      let latestSubmittedArtifactId: string | undefined;
+      if (submissionGroup?.id) {
+        const artifacts = await this.apiService.listSubmissionArtifacts(submissionGroup.id, { latest: true });
+        if (artifacts && artifacts.length > 0 && artifacts[0]) {
+          latestSubmittedArtifactId = artifacts[0].id;
+        }
+      }
+
+      // Previous grade (0.0–1.0) from submission_group, previous status from content
+      const prevGrade: number | undefined = typeof submissionGroup?.grading === 'number' ? submissionGroup.grading : undefined;
+      const prevStatus: string | undefined = content.status ?? undefined;
+
+      const gradingInput = await vscode.window.showInputBox({
+        title: 'Grading',
+        prompt: 'Enter grade as percentage (0–100%)',
+        placeHolder: 'e.g., 85',
+        value: prevGrade != null ? String(Math.round(prevGrade * 100)) : undefined,
+        ignoreFocusOut: true,
+        validateInput: (v) => {
+          if (!v || !v.trim()) return 'Enter a percentage between 0 and 100';
+          const n = Number(v.replace('%', '').trim());
+          if (!isFinite(n)) return 'Not a number';
+          if (n < 0 || n > 100) return 'Value must be between 0 and 100';
+          return undefined;
+        }
+      });
+      if (gradingInput == null) return; // cancelled
+      const grade = Math.max(0, Math.min(1, Number(gradingInput.replace('%', '').trim()) / 100));
+
+      const statusOptions: Array<vscode.QuickPickItem & { value: GradingStatus }> = [
+        { label: 'corrected', description: 'Mark as corrected', value: 1 as GradingStatus },
+        { label: 'correction_necessary', description: 'Correction necessary', value: 2 as GradingStatus },
+        { label: 'improvement_possible', description: 'Improvement possible', value: 3 as GradingStatus },
+        { label: 'not_reviewed', description: 'Not reviewed', value: 0 as GradingStatus },
+      ];
+      const statusPick = await vscode.window.showQuickPick(statusOptions, {
+        title: 'Status',
+        placeHolder: prevStatus ? `Current: ${prevStatus}` : 'Choose status',
+        canPickMany: false,
+        ignoreFocusOut: true
+      });
+      if (!statusPick) return; // cancelled
+
+      try {
+        const tutorGrade: TutorGradeCreate = {
+          artifact_id: latestSubmittedArtifactId,
+          grade,
+          status: statusPick.value,
+        };
+        await this.apiService.submitTutorGrade(memberId, contentId, tutorGrade);
+
+        // Clear caches and refresh to get updated data
+        const courseId = sel.getCurrentCourseId();
+        const groupId = sel.getCurrentGroupId();
+
+        this.apiService.clearTutorMemberCourseContentsCache(memberId);
+        if (courseId) {
+          this.apiService.clearTutorCourseMembersCache(courseId, groupId || undefined);
         }
 
-        // Previous grade (0.0–1.0) from submission_group, previous status from content
-        const prevGrade: number | undefined = typeof submissionGroup?.grading === 'number' ? submissionGroup.grading : undefined;
-        const prevStatus: string | undefined = content.status ?? undefined;
+        // Full tree refresh: status changes affect parent unit items (aggregated from API)
+        this.treeDataProvider.refresh();
+        this.filterProvider?.refreshFilters();
 
-        const gradingInput = await vscode.window.showInputBox({
-          title: 'Grading',
-          prompt: 'Enter grade as percentage (0–100%)',
-          placeHolder: 'e.g., 85',
-          value: prevGrade != null ? String(Math.round(prevGrade * 100)) : undefined,
-          ignoreFocusOut: true,
-          validateInput: (v) => {
-            if (!v || !v.trim()) return 'Enter a percentage between 0 and 100';
-            const n = Number(v.replace('%', '').trim());
-            if (!isFinite(n)) return 'Not a number';
-            if (n < 0 || n > 100) return 'Value must be between 0 and 100';
-            return undefined;
-          }
-        });
-        if (gradingInput == null) return; // cancelled
-        const grade = Math.max(0, Math.min(1, Number(gradingInput.replace('%', '').trim()) / 100));
-
-        const statusOptions: Array<vscode.QuickPickItem & { value: GradingStatus }> = [
-          { label: 'corrected', description: 'Mark as corrected', value: 1 as GradingStatus },
-          { label: 'correction_necessary', description: 'Correction necessary', value: 2 as GradingStatus },
-          { label: 'improvement_possible', description: 'Improvement possible', value: 3 as GradingStatus },
-          { label: 'not_reviewed', description: 'Not reviewed', value: 0 as GradingStatus },
-        ];
-        const statusPick = await vscode.window.showQuickPick(statusOptions, {
-          title: 'Status',
-          placeHolder: prevStatus ? `Current: ${prevStatus}` : 'Choose status',
-          canPickMany: false,
-          ignoreFocusOut: true
-        });
-        if (!statusPick) return; // cancelled
-
-        try {
-          const tutorGrade: TutorGradeCreate = {
-            artifact_id: latestSubmittedArtifactId,
-            grade,
-            status: statusPick.value,
-          };
-          await this.apiService.submitTutorGrade(memberId, contentId, tutorGrade);
-
-          // Clear caches and refresh to get updated data
-          const courseId = sel.getCurrentCourseId();
-          const groupId = sel.getCurrentGroupId();
-
-          this.apiService.clearTutorMemberCourseContentsCache(memberId);
-          if (courseId) {
-            this.apiService.clearTutorCourseMembersCache(courseId, groupId || undefined);
-          }
-
-          // Full tree refresh: status changes affect parent unit items (aggregated from API)
-          this.treeDataProvider.refresh();
-          this.filterProvider?.refreshFilters();
-
-          vscode.window.showInformationMessage(`Updated: ${Math.round(grade * 100)}% • ${statusPick.label}`);
-        } catch (e: any) {
-          vscode.window.showErrorMessage(`Failed to update grading: ${e?.message || e}`);
-        }
-      })
-    );
+        vscode.window.showInformationMessage(`Updated: ${Math.round(grade * 100)}% • ${statusPick.label}`);
+      } catch (e: any) {
+        vscode.window.showErrorMessage(`Failed to update grading: ${e?.message || e}`);
+      }
+    });
 
     // Tutor: Download reference (example version)
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.downloadReference', async (item: any) => {
-        await this.downloadReference(item);
-      })
-    );
+    register('computor.tutor.downloadReference', async (item: any) => {
+      await this.downloadReference(item);
+    });
 
     // Tutor: Download submission artifact
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.downloadSubmissionArtifact', async (item: any) => {
-        await this.downloadSubmissionArtifact(item);
-      })
-    );
+    register('computor.tutor.downloadSubmissionArtifact', async (item: any) => {
+      await this.downloadSubmissionArtifact(item);
+    });
 
     // Tutor: Compare with reference
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.compareWithReference', async (item: any) => {
-        await this.compareWithReference(item);
-      })
-    );
+    register('computor.tutor.compareWithReference', async (item: any) => {
+      await this.compareWithReference(item);
+    });
 
     // Tutor: Show submission test results
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.showSubmissionTestResults', async (item: any) => {
-        await this.showSubmissionTestResults(item);
-      })
-    );
+    register('computor.tutor.showSubmissionTestResults', async (item: any) => {
+      await this.showSubmissionTestResults(item);
+    });
 
     // Tutor: Checkout - download reference and latest submission (or just reference if no submission)
     // When called from context menu (confirmRedownload=true), asks before re-downloading existing files
     // When called from selection (confirmRedownload=false), always downloads without asking
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.checkout', async (item: unknown, confirmRedownload?: boolean) => {
-        await this.queueCheckout(item, confirmRedownload ?? true);
-      })
-    );
+    register('computor.tutor.checkout', async (item: unknown, confirmRedownload?: boolean) => {
+      await this.queueCheckout(item, confirmRedownload ?? true);
+    });
 
     // Tutor: Show README preview for assignment
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.showReadme', async (item: any) => {
-        await this.showReadme(item);
-      })
-    );
+    register('computor.tutor.showReadme', async (item: any) => {
+      await this.showReadme(item);
+    });
 
     // Tutor: Run test on submission
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.tutor.runTest', async (item: any) => {
-        await this.runTestOnSubmission(item);
-      })
-    );
+    register('computor.tutor.runTest', async (item: any) => {
+      await this.runTestOnSubmission(item);
+    });
   }
 
   private async queueCheckout(item: unknown, confirmRedownload: boolean): Promise<void> {

--- a/src/commands/UserManagerCommands.ts
+++ b/src/commands/UserManagerCommands.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ComputorApiService } from '../services/ComputorApiService';
 import { UserManagerTreeProvider } from '../ui/tree/user-manager/UserManagerTreeProvider';
 import { UserManagementWebviewProvider } from '../ui/webviews/UserManagementWebviewProvider';
+import { commandRegistrar } from './commandHelpers';
 
 export class UserManagerCommands {
   private userManagementWebviewProvider: UserManagementWebviewProvider;
@@ -19,37 +20,31 @@ export class UserManagerCommands {
   }
 
   registerCommands(): void {
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.userManager.refresh', async () => {
-        await this.handleRefresh();
-      })
-    );
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.userManager.openUserDetails', async (item?: any) => {
-        await this.handleOpenUserDetails(item);
-      })
-    );
+    const register = commandRegistrar(this.context);
+    register('computor.userManager.refresh', async () => {
+      await this.handleRefresh();
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.userManager.searchUsers', async () => {
-        const currentQuery = this.treeProvider.getSearchQuery();
-        const query = await vscode.window.showInputBox({
-          prompt: 'Search users by name, email, or username',
-          placeHolder: 'Enter search query',
-          value: currentQuery
-        });
-        if (query !== undefined) {
-          this.treeProvider.setSearchQuery(query);
-        }
-      })
-    );
+    register('computor.userManager.openUserDetails', async (item?: any) => {
+      await this.handleOpenUserDetails(item);
+    });
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.userManager.clearSearch', () => {
-        this.treeProvider.clearSearch();
-      })
-    );
+    register('computor.userManager.searchUsers', async () => {
+      const currentQuery = this.treeProvider.getSearchQuery();
+      const query = await vscode.window.showInputBox({
+        prompt: 'Search users by name, email, or username',
+        placeHolder: 'Enter search query',
+        value: currentQuery
+      });
+      if (query !== undefined) {
+        this.treeProvider.setSearchQuery(query);
+      }
+    });
+
+    register('computor.userManager.clearSearch', () => {
+      this.treeProvider.clearSearch();
+    });
   }
 
   private async handleRefresh(): Promise<void> {

--- a/src/commands/UserPasswordCommands.ts
+++ b/src/commands/UserPasswordCommands.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ComputorApiService } from '../services/ComputorApiService';
 import { UserPassword } from '../types/generated/users';
+import { commandRegistrar } from './commandHelpers';
 
 export class UserPasswordCommands {
   constructor(
@@ -9,9 +10,9 @@ export class UserPasswordCommands {
   ) {}
 
   register(): void {
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand('computor.user.changePassword', () => this.changePassword())
-    );
+
+    const register = commandRegistrar(this.context);
+    register('computor.user.changePassword', () => this.changePassword());
   }
 
   private async changePassword(): Promise<void> {

--- a/src/commands/commandHelpers.ts
+++ b/src/commands/commandHelpers.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+
+export type CommandHandler = (...args: any[]) => any;
+
+/**
+ * Returns a function that registers a VS Code command and pushes the
+ * resulting disposable onto `context.subscriptions`. Intended for
+ * `*Commands` classes so each call site is `register(id, handler)`
+ * instead of `this.context.subscriptions.push(vscode.commands.registerCommand(id, handler))`.
+ */
+export function commandRegistrar(context: vscode.ExtensionContext): (id: string, handler: CommandHandler) => void {
+  return (id, handler) => {
+    context.subscriptions.push(vscode.commands.registerCommand(id, handler));
+  };
+}


### PR DESCRIPTION
Closes #58.

Part 4 of the \`refactor/april-2026\` course. Targets the intermediate branch; maintainer merges \`refactor/april-2026\` → \`main\` at the end.

## Change

Adds \`src/commands/commandHelpers.ts\` (15 LOC) with:

\`\`\`ts
export function commandRegistrar(context: vscode.ExtensionContext) {
  return (id: string, handler: CommandHandler) => {
    context.subscriptions.push(vscode.commands.registerCommand(id, handler));
  };
}
\`\`\`

Each \`*Commands\` class now opens its registration method with:

\`\`\`ts
const register = commandRegistrar(this.context);
register('computor.x.y', handler);
register('computor.x.z', handler);
\`\`\`

Instead of 3-line wrappers per registration.

## Application

| File | Registrations |
|---|---|
| LecturerCommands | 41 |
| LecturerExampleCommands | 40 |
| TutorCommands | 16 |
| StudentCommands | 13 |
| StudentOfflineCommands | 7 |
| UserManagerCommands | 4 |
| LogoutCommands | 2 |
| LecturerFsCommands | 2 |
| SettingsCommands | 1 |
| SignUpCommands | 1 |
| UserPasswordCommands | 1 |
| **Total** | **128** |

The bulk was applied by a one-off Python script (not committed) that matched the exact \`this.context.subscriptions.push(\\n  vscode.commands.registerCommand(...)\\n);\` pattern and dedented bodies by the detected inner-indent width. Short-form and \`private registerCommands()\` edge cases were cleaned up by hand.

## Result

- Net ~−205 LOC (after helper)
- \`tsc --noEmit\`: clean
- \`npm run compile\` (webpack): clean
- \`npm run lint\`: no new warnings (eqeqeq / semi warnings present are all pre-existing in their respective lines)
- Zero behavior changes

## Deliberately out of scope

- No error-handling wrapper. Different commands have intentionally-different user-facing error messages; a one-size-fits-all wrapper would change UX. That's a separate discussion / branch.
- \`extension.ts\`'s standalone \`context.subscriptions.push(vscode.commands.registerCommand(...))\` calls are left alone on this branch — they live outside a class method and would benefit from a slightly different helper shape. Candidate for a follow-up once auth-session + view-init branches are merged.
- \`src/types/generated/*\` untouched.