### PR TITLE
refactor(git): extract execGitClone helper + apply to 6 call sites

### DIFF
--- a/src/git/gitCloneHelpers.ts
+++ b/src/git/gitCloneHelpers.ts
@@ -1,0 +1,32 @@
+import type { CancellationToken } from 'vscode';
+import { execAsyncWithTimeout } from '../utils/exec';
+
+export interface ExecGitCloneOptions {
+  /** Clone timeout in milliseconds. Defaults to 40s. */
+  timeout?: number;
+  cancellationToken?: CancellationToken;
+  /** Working directory for the clone command (rarely needed). */
+  cwd?: string;
+}
+
+/**
+ * Run `git clone <authenticatedUrl> <targetPath>` through execAsyncWithTimeout
+ * with `GIT_TERMINAL_PROMPT=0` set so the process fails fast instead of
+ * hanging on a stdin credential prompt. Assumes the URL already carries the
+ * token; token refresh / prompting is the caller's responsibility.
+ */
+export async function execGitClone(
+  authenticatedUrl: string,
+  targetPath: string,
+  options: ExecGitCloneOptions = {}
+): Promise<void> {
+  await execAsyncWithTimeout(
+    `git clone "${authenticatedUrl}" "${targetPath}"`,
+    {
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      timeout: options.timeout ?? 40_000,
+      cancellationToken: options.cancellationToken,
+      cwd: options.cwd
+    }
+  );
+}

--- a/src/services/LecturerRepositoryManager.ts
+++ b/src/services/LecturerRepositoryManager.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { execAsyncWithTimeout } from '../utils/exec';
+import { execGitClone } from '../git/gitCloneHelpers';
 import { GitLabTokenManager } from './GitLabTokenManager';
 import { ComputorApiService } from './ComputorApiService';
 import { createRepositoryBackup, isHistoryRewriteError } from '../utils/repositoryBackup';
@@ -69,7 +70,7 @@ export class LecturerRepositoryManager {
 
     if (!exists) {
       report(`Cloning course ${courseId} assignments...`);
-      await execAsyncWithTimeout(`git clone "${authUrl}" "${target}"`, { env: { ...process.env, GIT_TERMINAL_PROMPT: '0' }, timeout: 40_000 });
+      await execGitClone(authUrl, target);
     } else {
       report(`Pulling course ${courseId} assignments...`);
       try {
@@ -102,7 +103,7 @@ export class LecturerRepositoryManager {
 
         report(`Recreating course ${courseId} from origin...`);
         try {
-          await execAsyncWithTimeout(`git clone "${authUrl}" "${target}"`, { env: { ...process.env, GIT_TERMINAL_PROMPT: '0' }, timeout: 40_000 });
+          await execGitClone(authUrl, target);
         } catch (cloneError) {
           console.error(`[LecturerRepo] Re-clone failed for course ${courseId}:`, cloneError);
           vscode.window.showErrorMessage(`Computor could not recreate the assignments repository. Your files${backupPath ? ` were backed up at ${backupPath}` : ''}.`);

--- a/src/services/OfflineRepositoryManager.ts
+++ b/src/services/OfflineRepositoryManager.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { execAsync, execAsyncWithTimeout } from '../utils/exec';
+import { execAsync } from '../utils/exec';
+import { execGitClone } from '../git/gitCloneHelpers';
 import { addTokenToGitUrl, extractOriginFromGitUrl } from '../utils/gitUrlHelpers';
 
 /**
@@ -266,10 +267,7 @@ export class OfflineRepositoryManager {
 
       try {
         // Clone the repository
-        await execAsyncWithTimeout(`git clone "${authenticatedUrl}" "${repoName}"`, {
-          cwd: studentDir,
-          timeout: 40_000
-        });
+        await execGitClone(authenticatedUrl, repoName, { cwd: studentDir });
 
         progress.report({ increment: 60, message: 'Setting up remote...' });
 

--- a/src/services/StudentRepositoryManager.ts
+++ b/src/services/StudentRepositoryManager.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import { ComputorApiService } from './ComputorApiService';
 import { GitLabTokenManager } from './GitLabTokenManager';
 import { execAsync, execAsyncWithTimeout, GitTimeoutError, GitCancelledError } from '../utils/exec';
+import { execGitClone } from '../git/gitCloneHelpers';
 import { CTGit } from '../git/CTGit';
 import { GitErrorHandler } from '../git/GitErrorHandler';
 import { createRepositoryBackup, isHistoryRewriteError } from '../utils/repositoryBackup';
@@ -678,14 +679,7 @@ export class StudentRepositoryManager {
     const attemptClone = async (activeToken: string): Promise<void> => {
       const authenticatedUrl = addTokenToGitUrl(cloneUrl, activeToken);
       try {
-        await execAsyncWithTimeout(`git clone "${authenticatedUrl}" "${repoPath}"`, {
-          env: {
-            ...process.env,
-            GIT_TERMINAL_PROMPT: '0'
-          },
-          timeout: 40_000,
-          cancellationToken
-        });
+        await execGitClone(authenticatedUrl, repoPath, { cancellationToken });
         console.log(`[StudentRepositoryManager] Successfully cloned to ${repoPath}`);
       } catch (error) {
         // Clean up partial clone directory on any failure

--- a/src/services/StudentWorkspaceManager.ts
+++ b/src/services/StudentWorkspaceManager.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { ComputorApiService } from './ComputorApiService';
-import { execAsync, execAsyncWithTimeout } from '../utils/exec';
+import { execAsync } from '../utils/exec';
+import { execGitClone } from '../git/gitCloneHelpers';
 import { GitLabTokenManager } from './GitLabTokenManager';
 
 interface CourseInfo {
@@ -280,23 +281,10 @@ export class StudentWorkspaceManager {
         
         if (isEmpty && fs.existsSync(targetPath)) {
           // Clone directly
-          await execAsyncWithTimeout(`git clone "${authenticatedUrl}" .`, {
-            cwd: targetPath,
-            env: {
-              ...process.env,
-              GIT_TERMINAL_PROMPT: '0'
-            },
-            timeout: 40_000
-          });
+          await execGitClone(authenticatedUrl, '.', { cwd: targetPath });
         } else {
           // Clone normally
-          await execAsyncWithTimeout(`git clone "${authenticatedUrl}" "${targetPath}"`, {
-            env: {
-              ...process.env,
-              GIT_TERMINAL_PROMPT: '0'
-            },
-            timeout: 40_000
-          });
+          await execGitClone(authenticatedUrl, targetPath);
         }
 
         vscode.window.showInformationMessage(`Successfully cloned ${course.title || course.path}`);


### PR DESCRIPTION
Closes #62.

Part 6 of the \`refactor/april-2026\` course.

## Change

Adds \`src/git/gitCloneHelpers.ts\` (32 LOC) with:

\`\`\`ts
export async function execGitClone(
  authenticatedUrl: string,
  targetPath: string,
  options: { timeout?: number; cancellationToken?: CancellationToken; cwd?: string } = {}
): Promise<void> {
  await execAsyncWithTimeout(\`git clone \"\${authenticatedUrl}\" \"\${targetPath}\"\`, {
    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
    timeout: options.timeout ?? 40_000,
    cancellationToken: options.cancellationToken,
    cwd: options.cwd
  });
}
\`\`\`

Applied to 6 call sites:

| File | Count |
|---|---|
| \`StudentRepositoryManager.cloneRepository\` (attemptClone) | 1 |
| \`LecturerRepositoryManager\` (initial + re-clone after history reset) | 2 |
| \`StudentWorkspaceManager\` (empty-target + non-empty-target) | 2 |
| \`OfflineRepositoryManager\` (course clone) | 1 |

## Minor behavior change flagged

\`OfflineRepositoryManager\`'s clone previously did **not** set \`GIT_TERMINAL_PROMPT=0\`. It now does, matching every other clone site in the codebase. This is strictly safer — prevents the process from hanging on an interactive stdin credential prompt if the stored token is invalid. Worth calling out even though it's the obviously-correct behavior.

## Deliberately left alone

- Tutor's \`createSimpleGit().clone(...)\` path (\`TutorCommands.cloneStudentRepository\`) — different library (\`simple-git\`) and a different token UX (interactive input box prompt on auth-fail vs. \`GitLabTokenManager\` auto-refresh). Not worth unifying in this branch.

## Result

- +32 LOC helper, −31 LOC across 4 files (net ~flat, win is centralization / safety)
- \`tsc --noEmit\`: clean
- \`npm run compile\` (webpack): clean
- \`src/types/generated/*\` untouched