### PR TITLE
refactor(ui): CourseChannelSubscription helper for tree WebSocket wiring

### DIFF
--- a/src/ui/tree/courseChannelSubscription.ts
+++ b/src/ui/tree/courseChannelSubscription.ts
@@ -1,0 +1,56 @@
+import type { WebSocketService, WebSocketEventHandlers } from '../../services/WebSocketService';
+
+/**
+ * Tracks `course:<id>` WebSocket channel subscriptions for a tree provider.
+ * Handles duplicate-subscribe suppression and unsubscription bookkeeping so each
+ * provider only needs to specify its handler callbacks.
+ */
+export class CourseChannelSubscription {
+  private wsService?: WebSocketService;
+  private readonly subscribed = new Set<string>();
+
+  constructor(private readonly handlerId: string) {}
+
+  setService(wsService: WebSocketService | undefined): void {
+    this.wsService = wsService;
+  }
+
+  /**
+   * Subscribe to the `course:<id>` channels that are not already subscribed.
+   * No-op if the service is not set or every channel is already tracked.
+   */
+  subscribeCourses(courseIds: readonly string[], handlers: WebSocketEventHandlers): void {
+    if (!this.wsService) return;
+    const newChannels = courseIds
+      .map(id => `course:${id}`)
+      .filter(ch => !this.subscribed.has(ch));
+    if (newChannels.length === 0) return;
+    newChannels.forEach(ch => this.subscribed.add(ch));
+    this.wsService.subscribe(newChannels, this.handlerId, handlers);
+  }
+
+  /**
+   * Replace the currently-subscribed set with exactly `course:<courseId>`.
+   * Unsubscribes any other channels first, then subscribes to the target channel.
+   * No-op if already subscribed only to the target channel.
+   */
+  switchToCourse(courseId: string, handlers: WebSocketEventHandlers): void {
+    if (!this.wsService) return;
+    const target = `course:${courseId}`;
+    const toDrop = [...this.subscribed].filter(ch => ch !== target);
+    if (toDrop.length > 0) {
+      this.wsService.unsubscribe(toDrop, this.handlerId);
+      toDrop.forEach(ch => this.subscribed.delete(ch));
+    }
+    if (!this.subscribed.has(target)) {
+      this.subscribed.add(target);
+      this.wsService.subscribe([target], this.handlerId, handlers);
+    }
+  }
+
+  unsubscribeAll(): void {
+    if (!this.wsService || this.subscribed.size === 0) return;
+    this.wsService.unsubscribe([...this.subscribed], this.handlerId);
+    this.subscribed.clear();
+  }
+}

--- a/src/ui/tree/lecturer/LecturerTreeDataProvider.ts
+++ b/src/ui/tree/lecturer/LecturerTreeDataProvider.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { GitLabTokenManager } from '../../../services/GitLabTokenManager';
 import { ComputorSettingsManager } from '../../../settings/ComputorSettingsManager';
 import type { WebSocketService } from '../../../services/WebSocketService';
+import { CourseChannelSubscription } from '../courseChannelSubscription';
 import { errorRecoveryService } from '../../../services/ErrorRecoveryService';
 import { performanceMonitor } from '../../../services/PerformanceMonitoringService';
 import { VirtualScrollingService } from '../../../services/VirtualScrollingService';
@@ -105,8 +106,7 @@ export class LecturerTreeDataProvider implements vscode.TreeDataProvider<TreeIte
   private assignmentIdentifierCache: Map<string, string | null> = new Map();
   private fullCourseCache: Map<string, Promise<any>> = new Map();
   private rolesTitleCache: Map<string, string> = new Map();
-  private wsService?: WebSocketService;
-  private subscribedCourseChannels: Set<string> = new Set();
+  private wsSubscription = new CourseChannelSubscription('lecturer-tree');
 
   constructor(context: vscode.ExtensionContext, apiService?: ComputorApiService) {
     // Use provided apiService or create a new one
@@ -120,18 +120,11 @@ export class LecturerTreeDataProvider implements vscode.TreeDataProvider<TreeIte
   }
 
   setWebSocketService(wsService: WebSocketService): void {
-    this.wsService = wsService;
+    this.wsSubscription.setService(wsService);
   }
 
   private subscribeToCourseChannels(courseIds: string[]): void {
-    if (!this.wsService) return;
-    const newChannels = courseIds
-      .map(id => `course:${id}`)
-      .filter(ch => !this.subscribedCourseChannels.has(ch));
-    if (newChannels.length === 0) return;
-
-    newChannels.forEach(ch => this.subscribedCourseChannels.add(ch));
-    this.wsService.subscribe(newChannels, 'lecturer-tree', {
+    this.wsSubscription.subscribeCourses(courseIds, {
       onDeploymentStatusChanged: (event) => {
         console.log(`[LecturerTree/WS] Deployment status changed: ${event.course_content_id} -> ${event.new_status}`);
         void this.forceRefreshCourse(event.course_id);

--- a/src/ui/tree/student/StudentCourseContentTreeProvider.ts
+++ b/src/ui/tree/student/StudentCourseContentTreeProvider.ts
@@ -7,6 +7,7 @@ import { CourseSelectionService } from '../../../services/CourseSelectionService
 import { StudentRepositoryManager } from '../../../services/StudentRepositoryManager';
 import { ComputorSettingsManager } from '../../../settings/ComputorSettingsManager';
 import type { WebSocketService } from '../../../services/WebSocketService';
+import { CourseChannelSubscription } from '../courseChannelSubscription';
 import { SubmissionGroupStudentList, CourseContentStudentList, CourseContentTypeList, CourseContentKindList } from '../../../types/generated';
 import { IconGenerator } from '../../../utils/IconGenerator';
 import { hasExampleAssigned } from '../../../utils/deploymentHelpers';
@@ -48,8 +49,7 @@ export class StudentCourseContentTreeProvider implements vscode.TreeDataProvider
     private coursesSetupThisSession: Set<string> = new Set();
     // Track individual assignments where setup has already been attempted (to avoid repeated popups)
     private assignmentsSetupAttempted: Set<string> = new Set();
-    private wsService?: WebSocketService;
-    private subscribedCourseChannels: Set<string> = new Set();
+    private wsSubscription = new CourseChannelSubscription('student-tree');
     
     constructor(
         apiService: ComputorApiService, 
@@ -67,18 +67,11 @@ export class StudentCourseContentTreeProvider implements vscode.TreeDataProvider
     }
     
     setWebSocketService(wsService: WebSocketService): void {
-        this.wsService = wsService;
+        this.wsSubscription.setService(wsService);
     }
 
     private subscribeToCourseChannels(courseIds: string[]): void {
-        if (!this.wsService) return;
-        const newChannels = courseIds
-            .map(id => `course:${id}`)
-            .filter(ch => !this.subscribedCourseChannels.has(ch));
-        if (newChannels.length === 0) return;
-
-        newChannels.forEach(ch => this.subscribedCourseChannels.add(ch));
-        this.wsService.subscribe(newChannels, 'student-tree', {
+        this.wsSubscription.subscribeCourses(courseIds, {
             onDeploymentStatusChanged: (event) => {
                 console.log(`[StudentTree/WS] Deployment status changed: ${event.course_content_id} -> ${event.new_status}`);
                 if (event.new_status === 'deployed' || event.new_status === 'failed') {

--- a/src/ui/tree/tutor/TutorStudentTreeProvider.ts
+++ b/src/ui/tree/tutor/TutorStudentTreeProvider.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import { ComputorApiService } from '../../../services/ComputorApiService';
 import { TutorSelectionService } from '../../../services/TutorSelectionService';
 import type { WebSocketService } from '../../../services/WebSocketService';
+import { CourseChannelSubscription } from '../courseChannelSubscription';
 import { IconGenerator } from '../../../utils/IconGenerator';
 import { CourseContentStudentList, CourseContentKindList, SubmissionGroupStudentList } from '../../../types/generated';
 import { deriveRepositoryDirectoryName, buildReviewRepoRoot } from '../../../utils/repositoryNaming';
@@ -38,29 +39,18 @@ export class TutorStudentTreeProvider implements vscode.TreeDataProvider<vscode.
   private expandedContentIds = new Set<string>();
   private expandedVirtualFolderIds = new Set<string>();
   private expandedSubmissionIds = new Set<string>();
-  private wsService?: WebSocketService;
-  private subscribedCourseChannel?: string;
+  private wsSubscription = new CourseChannelSubscription('tutor-tree');
 
   constructor(private api: ComputorApiService, private selection: TutorSelectionService) {
     selection.onDidChangeSelection(() => this.refresh());
   }
 
   setWebSocketService(wsService: WebSocketService): void {
-    this.wsService = wsService;
+    this.wsSubscription.setService(wsService);
   }
 
   private subscribeToCourseChannel(courseId: string): void {
-    if (!this.wsService) return;
-    const channel = `course:${courseId}`;
-    if (this.subscribedCourseChannel === channel) return;
-
-    // Unsubscribe from previous course channel
-    if (this.subscribedCourseChannel) {
-      this.wsService.unsubscribe([this.subscribedCourseChannel], 'tutor-tree');
-    }
-
-    this.subscribedCourseChannel = channel;
-    this.wsService.subscribe([channel], 'tutor-tree', {
+    this.wsSubscription.switchToCourse(courseId, {
       onDeploymentStatusChanged: (event) => {
         console.log(`[TutorTree/WS] Deployment status changed: ${event.course_content_id} -> ${event.new_status}`);
         if (event.new_status === 'deployed' || event.new_status === 'failed') {


### PR DESCRIPTION
Closes #64.

Part 7 of the \`refactor/april-2026\` course.

## Change

Adds \`src/ui/tree/courseChannelSubscription.ts\` — a small class that owns \`course:<id>\` WebSocket subscription state for a tree provider:

\`\`\`ts
new CourseChannelSubscription('lecturer-tree');

// Subscribe to multiple courses (Set-based, idempotent):
this.wsSubscription.subscribeCourses(courseIds, handlers);

// Switch to a single course (unsubscribes the others):
this.wsSubscription.switchToCourse(courseId, handlers);

// Service swap / teardown:
this.wsSubscription.setService(wsService);
this.wsSubscription.unsubscribeAll();
\`\`\`

## Application

| Provider | Before | After |
|---|---|---|
| \`LecturerTreeDataProvider\` | \`wsService\` + \`subscribedCourseChannels: Set<string>\` fields and 12 LOC of bookkeeping | \`wsSubscription.subscribeCourses\` call |
| \`StudentCourseContentTreeProvider\` | same | same |
| \`TutorStudentTreeProvider\` | \`wsService\` + \`subscribedCourseChannel?: string\` with unsubscribe-previous logic | \`wsSubscription.switchToCourse\` call |

Handler callback bodies stay at each provider (refresh strategies differ: Lecturer does \`forceRefreshCourse\`, Student does \`refreshContentById\`/\`refreshCourseById\`, Tutor does \`refresh\`). Subscribe labels \`'lecturer-tree'\` / \`'student-tree'\` / \`'tutor-tree'\` preserved verbatim.

## Result

- +56 LOC helper, −36 LOC across three providers (net +20 with the helper header, but 3 Set-tracking copies collapse into one canonical implementation)
- \`tsc --noEmit\`: clean
- \`npm run compile\` (webpack): clean
- Zero behavior changes — same subscribe IDs, same channel strings, same idempotence guarantees

## Notes

- \`src/types/generated/*\` untouched.
- Follow-up candidate: wire \`unsubscribeAll()\` into each provider's dispose path. The existing code doesn't dispose subscriptions on tear-down either, so I left that alone to keep this PR behavior-preserving. Happy to do it as a micro-follow-up.