### PR TITLE
refactor(comments): split into display webview + bottom-panel input

### DIFF
--- a/package.json
+++ b/package.json
@@ -869,6 +869,11 @@
           "id": "computor-messages-input",
           "title": "Message Input",
           "icon": "$(comment)"
+        },
+        {
+          "id": "computor-comments-input",
+          "title": "Comment Input",
+          "icon": "$(note)"
         }
       ]
     },
@@ -954,6 +959,15 @@
           "name": "Compose",
           "icon": "$(comment)",
           "contextualTitle": "Message Input"
+        }
+      ],
+      "computor-comments-input": [
+        {
+          "id": "computor.courseMemberCommentsInputPanel",
+          "type": "webview",
+          "name": "Compose",
+          "icon": "$(note)",
+          "contextualTitle": "Comment Input"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -1402,8 +1402,8 @@
         },
         {
           "command": "computor.tutor.showCourseMemberComments",
-          "when": "view == computor.tutor.courses && viewItem =~ /^tutorStudentContent/",
-          "group": "2_discussion@2"
+          "when": "view == computor.tutor.filters && viewItem =~ /^tutorMember/",
+          "group": "2_discussion@1"
         },
         {
           "command": "computor.lecturer.checkoutExample",

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -15,6 +15,7 @@ import { CourseMemberWebviewProvider } from '../ui/webviews/CourseMemberWebviewP
 import { CourseMemberImportWebviewProvider } from '../ui/webviews/CourseMemberImportWebviewProvider';
 import { MessagesWebviewProvider, MessageTargetContext } from '../ui/webviews/MessagesWebviewProvider';
 import { CourseMemberCommentsWebviewProvider } from '../ui/webviews/CourseMemberCommentsWebviewProvider';
+import { CourseMemberCommentsInputPanelProvider } from '../ui/panels/CourseMemberCommentsInputPanel';
 import { DeploymentInfoWebviewProvider } from '../ui/webviews/DeploymentInfoWebviewProvider';
 import { ReleaseValidationWebviewProvider } from '../ui/webviews/ReleaseValidationWebviewProvider';
 import { CourseProgressOverviewWebviewProvider } from '../ui/webviews/CourseProgressOverviewWebviewProvider';
@@ -61,7 +62,8 @@ export class LecturerCommands {
     private treeDataProvider: LecturerTreeDataProvider,
     apiService?: ComputorApiService,
     messagesInputPanel?: MessagesInputPanelProvider,
-    wsService?: WebSocketService
+    wsService?: WebSocketService,
+    commentsInputPanel?: CourseMemberCommentsInputPanelProvider
   ) {
     // Use provided apiService or create a new one
     this.apiService = apiService || new ComputorApiService(context);
@@ -80,6 +82,9 @@ export class LecturerCommands {
       this.messagesWebviewProvider.setWebSocketService(wsService);
     }
     this.commentsWebviewProvider = new CourseMemberCommentsWebviewProvider(context, this.apiService);
+    if (commentsInputPanel) {
+      this.commentsWebviewProvider.setInputPanel(commentsInputPanel);
+    }
     this.deploymentInfoWebviewProvider = new DeploymentInfoWebviewProvider(context, this.apiService);
     this.releaseValidationWebviewProvider = new ReleaseValidationWebviewProvider(context, this.apiService);
     this.courseProgressOverviewWebviewProvider = new CourseProgressOverviewWebviewProvider(context, this.apiService);

--- a/src/commands/TutorCommands.ts
+++ b/src/commands/TutorCommands.ts
@@ -61,7 +61,17 @@ export class TutorCommands {
     this.workspaceStructure = WorkspaceStructureManager.getInstance();
     this.filterProvider = filterProvider;
     this.tutorTestService = TutorTestService.getInstance(this.apiService);
-    // No workspace manager needed for current tutor actions
+
+    // When the tutor selects a different course member in the filter tree, and the
+    // comments webview is currently open, switch it to the new member automatically.
+    const selectionService = TutorSelectionService.getInstance();
+    this.context.subscriptions.push(selectionService.onDidChangeSelection(() => {
+      if (!this.commentsWebviewProvider.isOpen()) { return; }
+      const memberId = selectionService.getCurrentMemberId();
+      if (!memberId) { return; }
+      if (this.commentsWebviewProvider.getCurrentCourseMemberId() === memberId) { return; }
+      void this.showCourseMemberComments();
+    }));
   }
 
   registerCommands(): void {

--- a/src/commands/TutorCommands.ts
+++ b/src/commands/TutorCommands.ts
@@ -10,6 +10,7 @@ import { deriveRepositoryDirectoryName } from '../utils/repositoryNaming';
 import { WorkspaceStructureManager } from '../utils/workspaceStructure';
 // Import interfaces from generated types (interfaces removed to avoid duplication)
 import { CourseMemberCommentsWebviewProvider } from '../ui/webviews/CourseMemberCommentsWebviewProvider';
+import { CourseMemberCommentsInputPanelProvider } from '../ui/panels/CourseMemberCommentsInputPanel';
 import { MessagesWebviewProvider, MessageTargetContext } from '../ui/webviews/MessagesWebviewProvider';
 import { MessageCreate, CourseContentStudentList, SubmissionGroupStudentList } from '../types/generated';
 import { TutorGradeCreate, GradingStatus } from '../types/generated/common';
@@ -39,13 +40,17 @@ export class TutorCommands {
     apiService?: ComputorApiService,
     filterProvider?: TutorFilterRefreshable,
     messagesInputPanel?: MessagesInputPanelProvider,
-    wsService?: WebSocketService
+    wsService?: WebSocketService,
+    commentsInputPanel?: CourseMemberCommentsInputPanelProvider
   ) {
     this.context = context;
     this.treeDataProvider = treeDataProvider;
     // Use provided apiService or create a new one
     this.apiService = apiService || new ComputorApiService(context);
     this.commentsWebviewProvider = new CourseMemberCommentsWebviewProvider(context, this.apiService);
+    if (commentsInputPanel) {
+      this.commentsWebviewProvider.setInputPanel(commentsInputPanel);
+    }
     this.messagesWebviewProvider = new MessagesWebviewProvider(context, this.apiService);
     if (messagesInputPanel) {
       this.messagesWebviewProvider.setInputPanel(messagesInputPanel);

--- a/src/commands/TutorCommands.ts
+++ b/src/commands/TutorCommands.ts
@@ -64,13 +64,14 @@ export class TutorCommands {
 
     // When the tutor selects a different course member in the filter tree, and the
     // comments webview is currently open, switch it to the new member automatically.
+    // preserveFocus keeps the keyboard caret in the filter tree so up/down keep working.
     const selectionService = TutorSelectionService.getInstance();
     this.context.subscriptions.push(selectionService.onDidChangeSelection(() => {
       if (!this.commentsWebviewProvider.isOpen()) { return; }
       const memberId = selectionService.getCurrentMemberId();
       if (!memberId) { return; }
       if (this.commentsWebviewProvider.getCurrentCourseMemberId() === memberId) { return; }
-      void this.showCourseMemberComments();
+      void this.showCourseMemberComments({ preserveFocus: true });
     }));
   }
 
@@ -472,7 +473,7 @@ export class TutorCommands {
     }
   }
 
-  private async showCourseMemberComments(): Promise<void> {
+  private async showCourseMemberComments(opts?: { preserveFocus?: boolean }): Promise<void> {
     try {
       const selection = TutorSelectionService.getInstance();
       const memberId = selection.getCurrentMemberId();
@@ -491,7 +492,7 @@ export class TutorCommands {
         segments.push(courseLabel);
       }
       const title = segments.length > 0 ? segments.join(' — ') : memberId;
-      await this.commentsWebviewProvider.showComments(memberId, title);
+      await this.commentsWebviewProvider.showComments(memberId, title, opts);
     } catch (error: any) {
       vscode.window.showErrorMessage(`Failed to open comments: ${error?.message || error}`);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,7 @@ import { TutorCommands } from './commands/TutorCommands';
 import { TestResultsPanelProvider, TestResultsTreeDataProvider } from './ui/panels/TestResultsPanel';
 import { TestResultService } from './services/TestResultService';
 import { MessagesInputPanelProvider } from './ui/panels/MessagesInputPanel';
+import { CourseMemberCommentsInputPanelProvider } from './ui/panels/CourseMemberCommentsInputPanel';
 import { manageGitLabTokens } from './commands/manageGitLabTokens';
 import { configureGit } from './commands/configureGit';
 import { showGettingStarted } from './commands/showGettingStarted';
@@ -537,6 +538,7 @@ class UnifiedController {
   private activeViews: string[] = [];
   private profileWebviewProvider?: UserProfileWebviewProvider;
   private messagesInputPanel?: MessagesInputPanelProvider;
+  private commentsInputPanel?: CourseMemberCommentsInputPanelProvider;
   private wsService?: WebSocketService;
 
   constructor(context: vscode.ExtensionContext) {
@@ -567,6 +569,12 @@ class UnifiedController {
     this.messagesInputPanel = new MessagesInputPanelProvider(this.context.extensionUri, api);
     this.disposables.push(
       vscode.window.registerWebviewViewProvider(MessagesInputPanelProvider.viewType, this.messagesInputPanel)
+    );
+
+    // Course-member comments input panel (shared across lecturer + tutor views)
+    this.commentsInputPanel = new CourseMemberCommentsInputPanelProvider(this.context.extensionUri, api);
+    this.disposables.push(
+      vscode.window.registerWebviewViewProvider(CourseMemberCommentsInputPanelProvider.viewType, this.commentsInputPanel)
     );
 
     // Initialize WebSocket service for real-time messaging
@@ -1046,7 +1054,7 @@ class UnifiedController {
       filterTree.refresh();
     }));
 
-    const commands = new TutorCommands(this.context, tree, api, filterTree, this.messagesInputPanel, this.wsService);
+    const commands = new TutorCommands(this.context, tree, api, filterTree, this.messagesInputPanel, this.wsService, this.commentsInputPanel);
     commands.registerCommands();
   }
 
@@ -1120,7 +1128,7 @@ class UnifiedController {
       })
     );
 
-    const commands = new LecturerCommands(this.context, tree, api, this.messagesInputPanel, this.wsService);
+    const commands = new LecturerCommands(this.context, tree, api, this.messagesInputPanel, this.wsService, this.commentsInputPanel);
     commands.registerCommands();
 
     // Register example-related commands (search, upload from ZIP, etc.)

--- a/src/ui/panels/CourseMemberCommentsInputPanel.ts
+++ b/src/ui/panels/CourseMemberCommentsInputPanel.ts
@@ -1,0 +1,200 @@
+import * as vscode from 'vscode';
+import { ComputorApiService } from '../../services/ComputorApiService';
+import { CourseMemberCommentList } from '../../types/generated';
+
+interface InputPanelState {
+  courseMemberId?: string;
+  title?: string;
+  editingComment?: CourseMemberCommentList;
+  loading: boolean;
+}
+
+export class CourseMemberCommentsInputPanelProvider implements vscode.WebviewViewProvider {
+  public static readonly viewType = 'computor.courseMemberCommentsInputPanel';
+  private view?: vscode.WebviewView;
+  private state: InputPanelState = { loading: false };
+  private onCommentChangedCallback?: () => Promise<void>;
+
+  constructor(
+    private readonly extensionUri: vscode.Uri,
+    private readonly api: ComputorApiService
+  ) {}
+
+  resolveWebviewView(webviewView: vscode.WebviewView): void {
+    this.view = webviewView;
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [this.extensionUri]
+    };
+
+    webviewView.onDidChangeVisibility(() => {
+      if (webviewView.visible) {
+        this.postState();
+      }
+    });
+
+    webviewView.onDidDispose(() => {
+      this.view = undefined;
+    });
+
+    webviewView.webview.onDidReceiveMessage(async (message) => {
+      switch (message.command) {
+        case 'createComment':
+          await this.handleCreateComment(message.data);
+          break;
+        case 'updateComment':
+          await this.handleUpdateComment(message.data);
+          break;
+        case 'cancel':
+          this.clearEditing();
+          break;
+        case 'showWarning':
+          if (message.data) {
+            vscode.window.showWarningMessage(String(message.data));
+          }
+          break;
+        case 'ready':
+          this.postState();
+          break;
+      }
+    });
+
+    this.updateHtml();
+  }
+
+  public setOnCommentChanged(callback: () => Promise<void>): void {
+    this.onCommentChangedCallback = callback;
+  }
+
+  public setTarget(courseMemberId: string, title: string): void {
+    this.state.courseMemberId = courseMemberId;
+    this.state.title = title;
+    this.state.editingComment = undefined;
+    this.postState();
+  }
+
+  public setEditingComment(comment: CourseMemberCommentList): void {
+    this.state.editingComment = comment;
+    this.postState();
+  }
+
+  public clearEditing(): void {
+    this.state.editingComment = undefined;
+    this.postState();
+  }
+
+  public clearState(): void {
+    this.state = { loading: false };
+    if (this.view) {
+      this.updateHtml();
+    }
+  }
+
+  public async reveal(): Promise<void> {
+    if (this.view) {
+      this.view.show(false);
+    } else {
+      await vscode.commands.executeCommand('computor.courseMemberCommentsInputPanel.focus');
+    }
+  }
+
+  private postState(): void {
+    if (!this.view) {
+      return;
+    }
+    this.view.webview.postMessage({
+      command: 'updateState',
+      data: {
+        courseMemberId: this.state.courseMemberId,
+        title: this.state.title,
+        editingComment: this.state.editingComment,
+        loading: this.state.loading
+      }
+    });
+  }
+
+  private postLoading(loading: boolean): void {
+    this.state.loading = loading;
+    if (!this.view) {
+      return;
+    }
+    this.view.webview.postMessage({ command: 'setLoading', data: { loading } });
+  }
+
+  private async handleCreateComment(data: { message: string }): Promise<void> {
+    if (!this.state.courseMemberId) {
+      vscode.window.showWarningMessage('Select a course member to comment on first.');
+      return;
+    }
+    if (!data?.message?.trim()) {
+      vscode.window.showWarningMessage('Comment text is required.');
+      return;
+    }
+    try {
+      this.postLoading(true);
+      await this.api.createCourseMemberComment(this.state.courseMemberId, data.message);
+      this.clearEditing();
+      if (this.onCommentChangedCallback) {
+        await this.onCommentChangedCallback();
+      }
+    } catch (error: any) {
+      vscode.window.showErrorMessage(`Failed to create comment: ${error?.message || error}`);
+    } finally {
+      this.postLoading(false);
+    }
+  }
+
+  private async handleUpdateComment(data: { commentId: string; message: string }): Promise<void> {
+    if (!this.state.courseMemberId || !data?.commentId) {
+      return;
+    }
+    if (!data?.message?.trim()) {
+      vscode.window.showWarningMessage('Comment text is required.');
+      return;
+    }
+    try {
+      this.postLoading(true);
+      await this.api.updateCourseMemberComment(this.state.courseMemberId, data.commentId, data.message);
+      this.clearEditing();
+      if (this.onCommentChangedCallback) {
+        await this.onCommentChangedCallback();
+      }
+    } catch (error: any) {
+      vscode.window.showErrorMessage(`Failed to update comment: ${error?.message || error}`);
+    } finally {
+      this.postLoading(false);
+    }
+  }
+
+  private updateHtml(): void {
+    if (!this.view) {
+      return;
+    }
+
+    const nonce = Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+    const webview = this.view.webview;
+    const componentsCssUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'webview-ui', 'components', 'components.css'));
+    const stylesUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'webview-ui', 'comments-input.css'));
+    const componentsJsUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'webview-ui', 'components.js'));
+    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'webview-ui', 'comments-input.js'));
+
+    this.view.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="${componentsCssUri}" rel="stylesheet" />
+  <link href="${stylesUri}" rel="stylesheet" />
+</head>
+<body>
+  <div id="app"></div>
+  <script nonce="${nonce}">
+    window.vscodeApi = window.vscodeApi || acquireVsCodeApi();
+  </script>
+  <script nonce="${nonce}" src="${componentsJsUri}"></script>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+  }
+}

--- a/src/ui/panels/CourseMemberCommentsInputPanel.ts
+++ b/src/ui/panels/CourseMemberCommentsInputPanel.ts
@@ -90,10 +90,13 @@ export class CourseMemberCommentsInputPanelProvider implements vscode.WebviewVie
     }
   }
 
-  public async reveal(): Promise<void> {
+  public async reveal(opts?: { preserveFocus?: boolean }): Promise<void> {
+    const preserveFocus = opts?.preserveFocus ?? false;
     if (this.view) {
-      this.view.show(false);
-    } else {
+      this.view.show(preserveFocus);
+    } else if (!preserveFocus) {
+      // Only force-focus the view if the caller actually wants focus there;
+      // otherwise leave the view hidden until the user opens it themselves.
       await vscode.commands.executeCommand('computor.courseMemberCommentsInputPanel.focus');
     }
   }

--- a/src/ui/webviews/BaseWebviewProvider.ts
+++ b/src/ui/webviews/BaseWebviewProvider.ts
@@ -19,17 +19,17 @@ export abstract class BaseWebviewProvider {
     ];
   }
 
-  public async show(title: string, data?: any): Promise<void> {
+  public async show(title: string, data?: any, opts?: { preserveFocus?: boolean }): Promise<void> {
     // Store current data
     this.currentData = data;
-    
+
     if (this.panel) {
-      this.panel.reveal();
+      this.panel.reveal(undefined, opts?.preserveFocus ?? false);
     } else {
       this.panel = vscode.window.createWebviewPanel(
         this.viewType,
         title,
-        vscode.ViewColumn.One,
+        { viewColumn: vscode.ViewColumn.One, preserveFocus: opts?.preserveFocus ?? false },
         {
           enableScripts: true,
           retainContextWhenHidden: true,

--- a/src/ui/webviews/CourseMemberCommentsWebviewProvider.ts
+++ b/src/ui/webviews/CourseMemberCommentsWebviewProvider.ts
@@ -35,13 +35,17 @@ export class CourseMemberCommentsWebviewProvider extends BaseWebviewProvider {
     return data?.courseMemberId;
   }
 
-  async showComments(courseMemberId: string, title: string): Promise<void> {
+  async showComments(
+    courseMemberId: string,
+    title: string,
+    opts?: { preserveFocus?: boolean }
+  ): Promise<void> {
     const comments = await this.apiService.listCourseMemberComments(courseMemberId);
     const payload: CommentsWebviewData = { courseMemberId, title, comments };
-    await this.show(`Comments: ${title}`, payload);
+    await this.show(`Comments: ${title}`, payload, { preserveFocus: opts?.preserveFocus });
     if (this.inputPanel) {
       this.inputPanel.setTarget(courseMemberId, title);
-      void this.inputPanel.reveal();
+      void this.inputPanel.reveal({ preserveFocus: opts?.preserveFocus });
     }
   }
 

--- a/src/ui/webviews/CourseMemberCommentsWebviewProvider.ts
+++ b/src/ui/webviews/CourseMemberCommentsWebviewProvider.ts
@@ -73,6 +73,12 @@ export class CourseMemberCommentsWebviewProvider extends BaseWebviewProvider {
     </html>`;
   }
 
+  protected onPanelDisposed(): void {
+    // Reset the input panel so it shows its empty-state hint again,
+    // matching the behaviour of the messages view + input pair.
+    this.inputPanel?.clearState();
+  }
+
   protected async handleMessage(message: any): Promise<void> {
     if (!message) { return; }
 

--- a/src/ui/webviews/CourseMemberCommentsWebviewProvider.ts
+++ b/src/ui/webviews/CourseMemberCommentsWebviewProvider.ts
@@ -26,6 +26,15 @@ export class CourseMemberCommentsWebviewProvider extends BaseWebviewProvider {
     });
   }
 
+  public isOpen(): boolean {
+    return !!this.panel;
+  }
+
+  public getCurrentCourseMemberId(): string | undefined {
+    const data = this.currentData as CommentsWebviewData | undefined;
+    return data?.courseMemberId;
+  }
+
   async showComments(courseMemberId: string, title: string): Promise<void> {
     const comments = await this.apiService.listCourseMemberComments(courseMemberId);
     const payload: CommentsWebviewData = { courseMemberId, title, comments };

--- a/src/ui/webviews/CourseMemberCommentsWebviewProvider.ts
+++ b/src/ui/webviews/CourseMemberCommentsWebviewProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { BaseWebviewProvider } from './BaseWebviewProvider';
 import { ComputorApiService } from '../../services/ComputorApiService';
 import { CourseMemberCommentList } from '../../types/generated';
+import { CourseMemberCommentsInputPanelProvider } from '../panels/CourseMemberCommentsInputPanel';
 
 interface CommentsWebviewData {
   courseMemberId: string;
@@ -11,16 +12,28 @@ interface CommentsWebviewData {
 
 export class CourseMemberCommentsWebviewProvider extends BaseWebviewProvider {
   private apiService: ComputorApiService;
+  private inputPanel?: CourseMemberCommentsInputPanelProvider;
 
   constructor(context: vscode.ExtensionContext, apiService: ComputorApiService) {
     super(context, 'computor.courseMemberComments');
     this.apiService = apiService;
   }
 
+  public setInputPanel(inputPanel: CourseMemberCommentsInputPanelProvider): void {
+    this.inputPanel = inputPanel;
+    inputPanel.setOnCommentChanged(async () => {
+      await this.refreshComments();
+    });
+  }
+
   async showComments(courseMemberId: string, title: string): Promise<void> {
     const comments = await this.apiService.listCourseMemberComments(courseMemberId);
     const payload: CommentsWebviewData = { courseMemberId, title, comments };
     await this.show(`Comments: ${title}`, payload);
+    if (this.inputPanel) {
+      this.inputPanel.setTarget(courseMemberId, title);
+      void this.inputPanel.reveal();
+    }
   }
 
   protected async getWebviewContent(data?: CommentsWebviewData): Promise<string> {
@@ -64,11 +77,8 @@ export class CourseMemberCommentsWebviewProvider extends BaseWebviewProvider {
     if (!message) { return; }
 
     switch (message.command) {
-      case 'createComment':
-        await this.createComment(message.data);
-        break;
-      case 'updateComment':
-        await this.updateComment(message.data);
+      case 'editComment':
+        this.handleEditComment(message.data);
         break;
       case 'requestDeleteComment':
         await this.requestDeleteComment(message.data);
@@ -116,43 +126,17 @@ export class CourseMemberCommentsWebviewProvider extends BaseWebviewProvider {
     this.panel.webview.postMessage({ command: 'updateComments', data: comments });
   }
 
-  private async createComment(data: { message: string }): Promise<void> {
-    const courseMemberId = this.getCourseMemberId();
-    if (!courseMemberId) {
-      vscode.window.showWarningMessage('Unable to create comment: missing course member context.');
+  private handleEditComment(data: { commentId: string }): void {
+    if (!data?.commentId) { return; }
+    const current = this.currentData as CommentsWebviewData | undefined;
+    const comment = current?.comments.find(c => c.id === data.commentId);
+    if (!comment) { return; }
+    if (!this.inputPanel) {
+      vscode.window.showWarningMessage('Comment input panel is not available.');
       return;
     }
-
-    try {
-      this.postLoadingState(true);
-      const comments = await this.apiService.createCourseMemberComment(courseMemberId, data.message);
-      this.updateCurrentData(comments);
-      this.postComments(comments);
-      this.postLoadingState(false);
-      vscode.window.showInformationMessage('Comment added.');
-    } catch (error: any) {
-      vscode.window.showErrorMessage(`Failed to create comment: ${error?.message || error}`);
-      this.postLoadingState(false);
-    }
-  }
-
-  private async updateComment(data: { commentId: string; message: string }): Promise<void> {
-    const courseMemberId = this.getCourseMemberId();
-    if (!courseMemberId || !data?.commentId) {
-      return;
-    }
-
-    try {
-      this.postLoadingState(true);
-      const comments = await this.apiService.updateCourseMemberComment(courseMemberId, data.commentId, data.message);
-      this.updateCurrentData(comments);
-      this.postComments(comments);
-      this.postLoadingState(false);
-      vscode.window.showInformationMessage('Comment updated.');
-    } catch (error: any) {
-      vscode.window.showErrorMessage(`Failed to update comment: ${error?.message || error}`);
-      this.postLoadingState(false);
-    }
+    this.inputPanel.setEditingComment(comment);
+    void this.inputPanel.reveal();
   }
 
   private async requestDeleteComment(data: { commentId: string; courseMemberId?: string }): Promise<void> {
@@ -184,6 +168,8 @@ export class CourseMemberCommentsWebviewProvider extends BaseWebviewProvider {
       this.updateCurrentData(comments);
       this.postComments(comments);
       this.postLoadingState(false);
+      // If the input panel was editing this comment, clear that state.
+      this.inputPanel?.clearEditing();
       vscode.window.showInformationMessage('Comment deleted.');
     } catch (error: any) {
       vscode.window.showErrorMessage(`Failed to delete comment: ${error?.message || error}`);

--- a/webview-ui/comments-input.css
+++ b/webview-ui/comments-input.css
@@ -1,8 +1,23 @@
+html,
+body,
+#app {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--vscode-panel-background);
+  color: var(--vscode-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: 13px;
+}
+
 .comments-input-root {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px;
+  padding: 10px 12px 12px;
   height: 100%;
   box-sizing: border-box;
 }
@@ -12,6 +27,7 @@
   font-style: italic;
   margin: 0;
   padding: 12px 0;
+  text-align: center;
 }
 
 .comments-input-header {
@@ -19,6 +35,9 @@
   align-items: baseline;
   gap: 8px;
   flex-wrap: wrap;
+  flex-shrink: 0;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--vscode-editorWidget-border);
 }
 
 .comments-input-title {
@@ -31,17 +50,34 @@
 }
 
 .comments-input-textarea {
+  flex: 1 1 auto;
   width: 100%;
-  resize: vertical;
+  resize: none;
   min-height: 60px;
   font-family: var(--vscode-font-family);
+  font-size: inherit;
   box-sizing: border-box;
+  padding: 6px 8px;
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, transparent);
+  border-radius: 2px;
+}
+
+.comments-input-textarea:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
 }
 
 .comments-input-actions {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
+}
+
+.comments-input-actions .vscode-button {
+  flex: 0 0 auto;
 }
 
 .comments-input-hint {

--- a/webview-ui/comments-input.css
+++ b/webview-ui/comments-input.css
@@ -1,0 +1,51 @@
+.comments-input-root {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.comments-input-empty {
+  color: var(--vscode-descriptionForeground);
+  font-style: italic;
+  margin: 0;
+  padding: 12px 0;
+}
+
+.comments-input-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.comments-input-title {
+  font-weight: 600;
+}
+
+.comments-input-target {
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.9em;
+}
+
+.comments-input-textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 60px;
+  font-family: var(--vscode-font-family);
+  box-sizing: border-box;
+}
+
+.comments-input-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.comments-input-hint {
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.85em;
+  margin-left: auto;
+}

--- a/webview-ui/comments-input.js
+++ b/webview-ui/comments-input.js
@@ -1,0 +1,213 @@
+(function () {
+  const vscode = window.vscodeApi || acquireVsCodeApi();
+  const { createButton } = window.UIComponents || {};
+
+  const state = {
+    courseMemberId: undefined,
+    title: undefined,
+    editingComment: undefined,
+    loading: false,
+    draft: ''
+  };
+
+  const root = () => document.getElementById('app');
+
+  function setState(patch) {
+    Object.assign(state, patch);
+    render();
+  }
+
+  function escapeHtml(value) {
+    if (value === undefined || value === null) return '';
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function createElement(tag, options = {}) {
+    const el = document.createElement(tag);
+    if (options.className) el.className = options.className;
+    if (options.textContent !== undefined) el.textContent = options.textContent;
+    if (options.innerHTML !== undefined) el.innerHTML = options.innerHTML;
+    if (options.attributes) {
+      Object.entries(options.attributes).forEach(([k, v]) => {
+        if (v !== undefined && v !== null) el.setAttribute(k, v);
+      });
+    }
+    if (options.children) {
+      options.children.forEach((child) => {
+        if (!child) return;
+        if (typeof child === 'string') {
+          el.appendChild(document.createTextNode(child));
+        } else {
+          el.appendChild(child);
+        }
+      });
+    }
+    return el;
+  }
+
+  function submit(value) {
+    const message = (value || '').trim();
+    if (!message) {
+      vscode.postMessage({ command: 'showWarning', data: 'Comment text is required.' });
+      return;
+    }
+    if (state.editingComment) {
+      vscode.postMessage({
+        command: 'updateComment',
+        data: { commentId: state.editingComment.id, message }
+      });
+    } else {
+      vscode.postMessage({ command: 'createComment', data: { message } });
+    }
+  }
+
+  function render() {
+    const mount = root();
+    if (!mount) return;
+    mount.innerHTML = '';
+
+    const wrapper = createElement('div', { className: 'comments-input-root' });
+
+    if (!state.courseMemberId) {
+      wrapper.appendChild(
+        createElement('p', {
+          className: 'comments-input-empty',
+          textContent: 'Open a course member’s comments to add or edit a comment here.'
+        })
+      );
+      mount.appendChild(wrapper);
+      return;
+    }
+
+    const header = createElement('div', { className: 'comments-input-header' });
+    header.appendChild(createElement('span', {
+      className: 'comments-input-title',
+      textContent: state.editingComment ? 'Editing comment' : 'New comment'
+    }));
+    if (state.title) {
+      header.appendChild(createElement('span', {
+        className: 'comments-input-target',
+        textContent: state.title
+      }));
+    }
+    wrapper.appendChild(header);
+
+    const textarea = createElement('textarea', {
+      className: 'vscode-input comments-input-textarea',
+      attributes: {
+        rows: '4',
+        placeholder: state.editingComment ? 'Edit comment...' : 'Add a comment...',
+        'aria-label': 'Comment text'
+      }
+    });
+    textarea.value = state.editingComment
+      ? (state.editingComment.message || '')
+      : (state.draft || '');
+
+    textarea.addEventListener('input', (e) => {
+      state.draft = e.target.value;
+    });
+
+    textarea.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        submit(textarea.value);
+      } else if (e.key === 'Escape' && state.editingComment) {
+        e.preventDefault();
+        vscode.postMessage({ command: 'cancel' });
+      }
+    });
+
+    wrapper.appendChild(textarea);
+
+    const actions = createElement('div', { className: 'comments-input-actions' });
+    if (createButton) {
+      const submitBtn = createButton({
+        text: state.editingComment ? 'Save Changes' : 'Add Comment',
+        variant: 'primary',
+        loading: state.loading,
+        onClick: () => submit(textarea.value)
+      });
+      actions.appendChild(submitBtn.render());
+
+      if (state.editingComment) {
+        const cancelBtn = createButton({
+          text: 'Cancel',
+          variant: 'secondary',
+          onClick: () => vscode.postMessage({ command: 'cancel' })
+        });
+        actions.appendChild(cancelBtn.render());
+      }
+    } else {
+      const submitBtn = createElement('button', {
+        className: 'vscode-button vscode-button--primary',
+        textContent: state.editingComment ? 'Save Changes' : 'Add Comment',
+        attributes: { type: 'button' }
+      });
+      submitBtn.addEventListener('click', () => submit(textarea.value));
+      actions.appendChild(submitBtn);
+      if (state.editingComment) {
+        const cancelBtn = createElement('button', {
+          className: 'vscode-button vscode-button--secondary',
+          textContent: 'Cancel',
+          attributes: { type: 'button' }
+        });
+        cancelBtn.addEventListener('click', () => vscode.postMessage({ command: 'cancel' }));
+        actions.appendChild(cancelBtn);
+      }
+    }
+
+    const hint = createElement('span', {
+      className: 'comments-input-hint',
+      textContent: 'Ctrl/Cmd+Enter to submit'
+    });
+    actions.appendChild(hint);
+
+    wrapper.appendChild(actions);
+    mount.appendChild(wrapper);
+
+    // restore focus to textarea after re-render when editing or composing
+    textarea.focus();
+    if (state.editingComment) {
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    }
+  }
+
+  window.addEventListener('message', (event) => {
+    const message = event.data;
+    if (!message) return;
+    switch (message.command) {
+      case 'updateState':
+        setState({
+          courseMemberId: message.data?.courseMemberId,
+          title: message.data?.title,
+          editingComment: message.data?.editingComment,
+          loading: Boolean(message.data?.loading),
+          draft: message.data?.editingComment ? state.draft : ''
+        });
+        break;
+      case 'setLoading':
+        setState({ loading: Boolean(message.data?.loading) });
+        break;
+      default:
+        break;
+    }
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    render();
+    vscode.postMessage({ command: 'ready' });
+  });
+
+  // Render once immediately so first paint isn't blank
+  render();
+  vscode.postMessage({ command: 'ready' });
+
+  // Suppress unused lint
+  void escapeHtml;
+})();

--- a/webview-ui/comments.css
+++ b/webview-ui/comments.css
@@ -70,41 +70,10 @@
   gap: 8px;
 }
 
-.form-card {
-  border: 1px solid var(--vscode-editorWidget-border);
-  border-radius: 4px;
-  background: var(--vscode-editorWidget-background);
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.form-context {
-  margin: 0;
-  color: var(--vscode-descriptionForeground);
-  font-size: 12px;
-}
-
-.form-row {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.form-row label {
-  font-size: 12px;
-  color: var(--vscode-descriptionForeground);
-}
-
 .empty-state,
 .error-state {
   text-align: center;
   padding: 24px;
   border: 1px dashed var(--vscode-editorWidget-border);
   color: var(--vscode-descriptionForeground);
-}
-
-.comment-card.editing {
-  border-color: var(--vscode-focusBorder);
 }

--- a/webview-ui/comments.css
+++ b/webview-ui/comments.css
@@ -22,9 +22,6 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-height: 55vh;
-  overflow-y: auto;
-  padding-right: 4px;
 }
 
 .comment-card {

--- a/webview-ui/comments.css
+++ b/webview-ui/comments.css
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  padding-top: 12px;
 }
 
 .view-header h1 {

--- a/webview-ui/comments.js
+++ b/webview-ui/comments.js
@@ -8,7 +8,6 @@
     comments: [],
     loading: false,
     error: undefined,
-    editingComment: undefined,
     ...(window.__INITIAL_STATE__ || {})
   };
 
@@ -114,9 +113,7 @@
         return aTime.localeCompare(bTime);
       })
       .forEach((comment) => {
-        const card = createElement('article', {
-          className: `comment-card${state.editingComment?.id === comment.id ? ' editing' : ''}`
-        });
+        const card = createElement('article', { className: 'comment-card' });
 
         const authorName = comment.transmitter?.user
           ? `${comment.transmitter.user.given_name || ''} ${comment.transmitter.user.family_name || ''}`.trim() || comment.transmitter.user.username || comment.transmitter.user.email
@@ -146,7 +143,12 @@
             text: 'Edit',
             size: 'sm',
             variant: 'secondary',
-            onClick: () => setState({ editingComment: comment })
+            onClick: () => {
+              vscode.postMessage({
+                command: 'editComment',
+                data: { commentId: comment.id }
+              });
+            }
           });
           actions.appendChild(editBtn.render());
         }
@@ -154,7 +156,7 @@
         const deleteBtn = createElement('button', {
           className: 'vscode-button vscode-button--tertiary vscode-button--sm',
           textContent: 'Delete',
-          type: 'button'
+          attributes: { type: 'button' }
         });
 
         deleteBtn.addEventListener('click', () => {
@@ -169,78 +171,6 @@
 
         container.appendChild(card);
       });
-  }
-
-  function renderForm(wrapper) {
-    wrapper.innerHTML = '';
-
-    const textarea = createElement('textarea', {
-      className: 'vscode-input',
-      attributes: {
-        rows: '5',
-        placeholder: 'Add a comment…'
-      }
-    });
-    textarea.value = state.editingComment ? state.editingComment.message || '' : '';
-
-    const actions = createElement('div', { className: 'toolbar' });
-
-    if (createButton) {
-      const saveBtn = createButton({
-        text: state.editingComment ? 'Save Changes' : 'Add Comment',
-        variant: 'primary',
-        loading: state.loading,
-        onClick: () => {
-          const message = textarea.value.trim();
-          if (!message) {
-            vscode.postMessage({ command: 'showWarning', data: 'Comment text is required.' });
-            return;
-          }
-          setState({ loading: true });
-          if (state.editingComment) {
-            vscode.postMessage({
-              command: 'updateComment',
-              data: {
-                commentId: state.editingComment.id,
-                message
-              }
-            });
-          } else {
-            vscode.postMessage({
-              command: 'createComment',
-              data: { message }
-            });
-          }
-        }
-      });
-      actions.appendChild(saveBtn.render());
-
-      if (state.editingComment) {
-        const cancelBtn = createButton({
-          text: 'Cancel',
-          variant: 'secondary',
-          onClick: () => setState({ editingComment: undefined })
-        });
-        actions.appendChild(cancelBtn.render());
-      }
-    }
-
-    const bodyRow = createElement('div', { className: 'form-row' });
-    bodyRow.appendChild(createElement('label', { textContent: 'Comment', attributes: { for: 'comment-body' } }));
-    textarea.id = 'comment-body';
-    bodyRow.appendChild(textarea);
-
-    if (state.editingComment) {
-      wrapper.appendChild(
-        createElement('p', {
-          className: 'form-context',
-          textContent: 'Editing existing comment'
-        })
-      );
-    }
-
-    wrapper.appendChild(bodyRow);
-    wrapper.appendChild(actions);
   }
 
   function render() {
@@ -274,18 +204,9 @@
     const commentsContainer = createElement('div', { className: 'comments-container' });
     renderComments(commentsContainer);
 
-    const formCard = createElement('div', { className: 'form-card' });
-    formCard.appendChild(
-      createElement('h2', {
-        textContent: state.editingComment ? 'Edit Comment' : 'New Comment'
-      })
-    );
-    renderForm(formCard);
-
     view.appendChild(header);
     view.appendChild(toolbar);
     view.appendChild(commentsContainer);
-    view.appendChild(formCard);
 
     mount.appendChild(view);
   }
@@ -296,7 +217,7 @@
 
     switch (message.command) {
       case 'updateComments':
-        setState({ comments: message.data || [], loading: false, editingComment: undefined });
+        setState({ comments: message.data || [], loading: false });
         break;
       case 'setLoading':
         setState({ loading: Boolean(message.data?.loading) });
@@ -305,8 +226,6 @@
         setState({ error: message.data, loading: false });
         break;
       case 'updateState':
-        setState(message.data || {});
-        break;
       case 'update':
         setState(message.data || {});
         break;


### PR DESCRIPTION
## Summary

Mirrors the messages pattern: the comments webview is split into a **display-only** editor-area webview and a **bottom panel** input. Lecturer and tutor "Show Course Member Comments" both flow through the same shared input panel.

- New \`CourseMemberCommentsInputPanelProvider\` (WebviewViewProvider) — \`setTarget\` / \`setEditingComment\` / \`clearEditing\` / \`reveal\`. On submit it calls back into the display via \`setOnCommentChanged\` so the list refreshes.
- Display webview drops the form card; \"Edit\" posts \`editComment\` back to the extension which forwards to the input panel. \"Delete\" still uses the modal confirmation path on the display webview.
- Cmd/Ctrl+Enter submits, Esc cancels edit mode.
- New \`computor-comments-input\` panel container with a single Compose view registered at activation, shared by both lecturer + tutor command classes (constructor arg added).
- New \`webview-ui/comments-input.{js,css}\`; \`comments.{js,css}\` slimmed accordingly.

No WebSocket / typing / threading — comments are flat by model, and the user explicitly asked for none of the messages-specific extras here.

## Test plan

- [ ] In the lecturer view, right-click a course member → \"Show Course Member Comments\" → comments panel opens in editor area, \"Comment Input\" panel reveals at the bottom
- [ ] Type into the bottom panel → \"Add Comment\" appends a new comment; the editor-area list refreshes
- [ ] Click \"Edit\" on an existing comment → bottom panel switches to \"Editing comment\" with prefilled text and a Cancel button
- [ ] Save changes → list refreshes with updated content; bottom panel returns to compose mode
- [ ] Cancel edit (button or Esc) → returns to compose mode without changes
- [ ] Cmd/Ctrl+Enter submits the textarea
- [ ] Click \"Delete\" → modal confirmation → on confirm comment is removed
- [ ] Same flow works in the tutor view (right-click member → Show Course Member Comments)
- [ ] With no member selected, the \"Comment Input\" panel shows an empty-state hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)