### PR TITLE
fix(examples): merge lecturer-tree checkouts into one row + reveal

### DIFF
--- a/src/commands/LecturerExampleCommands.ts
+++ b/src/commands/LecturerExampleCommands.ts
@@ -459,10 +459,17 @@ export class LecturerExampleCommands {
         return;
       }
 
-      const directory = item.exampleInfo.directory || exampleData.directory;
+      // The lecturer assignment tree carries a synthetic `exampleInfo` stub
+      // (identifier + title only). Trust the download response for the real
+      // example id / directory / identifier so the local checkout merges
+      // back into the same row in the examples tree.
+      const exampleId = exampleData.example_id;
+      const directory = exampleData.directory;
+      const identifier = exampleData.identifier;
       const versionTag = item.exampleVersionInfo.version_tag || exampleData.version_tag;
+
       const metadata: CheckoutMetadata = {
-        exampleId: item.exampleInfo.id,
+        exampleId,
         repositoryId: item.exampleInfo.example_repository_id || '',
         directory,
         versionId: item.exampleVersionInfo.id,
@@ -496,6 +503,10 @@ export class LecturerExampleCommands {
       vscode.window.showInformationMessage(
         `Checked out '${item.exampleInfo.title || directory}' [${versionTag}]`
       );
+
+      // Reveal the (now merged) example row in the examples tree so the
+      // user can immediately see + interact with the local copy.
+      void this.treeProvider.revealExample({ identifier });
     } catch (error) {
       console.error('Failed to checkout assignment example:', error);
       vscode.window.showErrorMessage(`Failed to checkout: ${error}`);


### PR DESCRIPTION
## Summary

Two bugs in the lecturer assignment "Checkout Example" path, both rooted in the same place — \`checkoutAssignmentExample\` was reading from the synthetic \`exampleInfo\` stub on the assignment tree item (which only carries \`identifier\` + \`title\`) instead of the values the download response already provides.

1. **Duplicate row** in the examples tree: \`CheckoutMetadata.exampleId\` was being written as \`undefined\`. The merge logic in \`LecturerExampleTreeProvider.getMergedExamples\` keys local↔remote pairing on \`exampleId\`, so the local copy was treated as an orphan and rendered as a second tree item.
2. **No reveal**: after a successful checkout the user was dropped back into the lecturer tree with no indication of where the new local copy went.

Fix: read \`example_id\`, \`directory\`, and \`identifier\` from \`ExampleDownloadResponse\` (the API already returns them), and call \`treeProvider.revealExample({ identifier })\` after refresh.

## Test plan

- [ ] Right-click a lecturer assignment with an assigned example → "Checkout Example"
- [ ] Confirm the examples tree shows **one** row for that example, marked as local (\`exampleCheckedOut\`), not two
- [ ] Confirm the focused row is the example you just checked out (revealExample working)
- [ ] Right-click "Checkout Example" again on the same assignment, choose Overwrite → still one row
- [ ] Stale orphans from before this fix can be removed via right-click → Delete on the orphan row

🤖 Generated with [Claude Code](https://claude.com/claude-code)