### PR TITLE
feat(chat): Computor Chat — scope-grouped inbox view

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,6 +341,41 @@
         "category": "Computor Examples"
       },
       {
+        "command": "computor.chat.refresh",
+        "title": "Refresh Chat",
+        "icon": "$(refresh)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.showUnreadOnly",
+        "title": "Show Only Unread",
+        "icon": "$(eye-closed)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.showAll",
+        "title": "Show All",
+        "icon": "$(eye)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.markScopeRead",
+        "title": "Mark All as Read",
+        "icon": "$(check-all)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.markThreadRead",
+        "title": "Mark Thread as Read",
+        "icon": "$(check)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.openThread",
+        "title": "Open Conversation",
+        "category": "Computor Chat"
+      },
+      {
         "command": "computor.lecturer.checkoutMultipleExamples",
         "title": "Checkout Multiple Examples",
         "icon": "$(cloud-download)",
@@ -857,6 +892,12 @@
           "title": "Computor User Manager",
           "icon": "$(organization)",
           "when": "computor.user_manager.show"
+        },
+        {
+          "id": "computor-chat",
+          "title": "Computor Chat",
+          "icon": "$(comment-discussion)",
+          "when": "computor.chat.show"
         }
       ],
       "panel": [
@@ -937,6 +978,15 @@
           "when": "computor.user_manager.show"
         }
       ],
+      "computor-chat": [
+        {
+          "id": "computor.chat.inbox",
+          "name": "Inbox",
+          "icon": "$(comment-discussion)",
+          "contextualTitle": "Computor Chat",
+          "when": "computor.chat.show"
+        }
+      ],
       "computor-test-results": [
         {
           "id": "computor.testResultsPanel",
@@ -977,6 +1027,21 @@
           "command": "computor.lecturer.refreshExamples",
           "when": "view == computor.lecturer.examples",
           "group": "navigation@1"
+        },
+        {
+          "command": "computor.chat.refresh",
+          "when": "view == computor.chat.inbox",
+          "group": "navigation@1"
+        },
+        {
+          "command": "computor.chat.showUnreadOnly",
+          "when": "view == computor.chat.inbox && !computor.chat.unreadOnly",
+          "group": "navigation@2"
+        },
+        {
+          "command": "computor.chat.showAll",
+          "when": "view == computor.chat.inbox && computor.chat.unreadOnly",
+          "group": "navigation@2"
         },
         {
           "command": "computor.user.profile",
@@ -1110,6 +1175,16 @@
         }
       ],
       "view/item/context": [
+        {
+          "command": "computor.chat.markScopeRead",
+          "when": "view == computor.chat.inbox && viewItem == chatScope.unread",
+          "group": "1_actions@1"
+        },
+        {
+          "command": "computor.chat.markThreadRead",
+          "when": "view == computor.chat.inbox && viewItem == chatThread.unread",
+          "group": "1_actions@1"
+        },
         {
           "command": "computor.lecturer.createNewExample",
           "when": "view == computor.lecturer.examples && viewItem == exampleRepository",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,6 +225,7 @@ function createActiveSession(context: vscode.ExtensionContext, controller: Unifi
       await vscode.commands.executeCommand('setContext', 'computor.lecturer.show', false);
       await vscode.commands.executeCommand('setContext', 'computor.student.show', false);
       await vscode.commands.executeCommand('setContext', 'computor.tutor.show', false);
+      await vscode.commands.executeCommand('setContext', 'computor.chat.show', false);
       await context.globalState.update('computor.tutor.selection', undefined);
       backendConnectionService.stopHealthCheck();
     }),
@@ -679,7 +680,12 @@ class UnifiedController {
       await this.initializeUserManagerView(api);
     }
 
+    // Computor Chat is available to every authenticated user, regardless of role.
+    report('Setting up chat view...');
+    await this.initializeChatView(api);
+
     await setViewContextKeys(views, ['student', 'tutor', 'lecturer', 'user_manager']);
+    await vscode.commands.executeCommand('setContext', 'computor.chat.show', true);
   }
 
   private async focusHighestPriorityView(views: string[]): Promise<void> {
@@ -1166,6 +1172,67 @@ class UnifiedController {
 
     const commands = new UserManagerCommands(this.context, tree, api);
     commands.registerCommands();
+  }
+
+  private async initializeChatView(api: ComputorApiService): Promise<void> {
+    const { ChatInboxTreeProvider } = await import('./ui/tree/chat/ChatInboxTreeProvider');
+    const { ChatScopeItem, ChatThreadItem } = await import('./ui/tree/chat/ChatInboxTreeItems');
+
+    // The chat view drives the existing MessagesWebviewProvider + bottom Compose
+    // panel, so reuse the input panel + WebSocket service we already instantiated.
+    const messagesWebview = new (await import('./ui/webviews/MessagesWebviewProvider')).MessagesWebviewProvider(this.context, api);
+    if (this.messagesInputPanel) {
+      messagesWebview.setInputPanel(this.messagesInputPanel);
+    }
+    if (this.wsService) {
+      messagesWebview.setWebSocketService(this.wsService);
+    }
+
+    const tree = new ChatInboxTreeProvider(this.context, api, messagesWebview);
+    registerTreeView('computor.chat.inbox', {
+      provider: tree,
+      options: { showCollapseAll: true },
+      registerDataProvider: true,
+      onExpand: (event) => {
+        if (event.element instanceof ChatScopeItem) {
+          tree.recordExpanded(event.element.scope, true);
+        }
+      },
+      onCollapse: (event) => {
+        if (event.element instanceof ChatScopeItem) {
+          tree.recordExpanded(event.element.scope, false);
+        }
+      },
+      onVisibility: (event) => {
+        if (event.visible) {
+          tree.refresh();
+        }
+      }
+    }, this.disposables);
+
+    this.disposables.push(
+      vscode.commands.registerCommand('computor.chat.refresh', () => tree.refresh()),
+      vscode.commands.registerCommand('computor.chat.showUnreadOnly', () => tree.setUnreadOnly(true)),
+      vscode.commands.registerCommand('computor.chat.showAll', () => tree.setUnreadOnly(false)),
+      vscode.commands.registerCommand('computor.chat.openThread', (item: any) => {
+        if (item instanceof ChatThreadItem) {
+          void tree.openThread(item);
+        }
+      }),
+      vscode.commands.registerCommand('computor.chat.markScopeRead', (item: any) => {
+        if (item instanceof ChatScopeItem) {
+          void tree.markScopeRead(item);
+        }
+      }),
+      vscode.commands.registerCommand('computor.chat.markThreadRead', (item: any) => {
+        if (item instanceof ChatThreadItem) {
+          void tree.markThreadRead(item);
+        }
+      })
+    );
+
+    // Initial load.
+    tree.refresh();
   }
 
   async dispose(): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1233,6 +1233,28 @@ class UnifiedController {
 
     // Initial load.
     tree.refresh();
+
+    // VS Code can't declare the secondary (right) sidebar as a default location
+    // for a view container, so we move it there programmatically the first time
+    // a user activates the extension. Wrapped in best-effort: if the workbench
+    // command names ever change, the user can still drag it manually.
+    void this.moveChatToSecondarySidebarOnce();
+  }
+
+  private async moveChatToSecondarySidebarOnce(): Promise<void> {
+    const flagKey = 'computor.chat.movedToSecondarySidebar';
+    if (this.context.globalState.get<boolean>(flagKey)) {
+      return;
+    }
+    try {
+      // Reveal the chat view so the move targets the right element, then move it
+      // to the secondary (auxiliary) sidebar.
+      await vscode.commands.executeCommand('computor.chat.inbox.focus');
+      await vscode.commands.executeCommand('workbench.action.moveViewToAuxiliarySideBar');
+      await this.context.globalState.update(flagKey, true);
+    } catch (err) {
+      console.warn('[ChatInbox] Could not auto-move to secondary sidebar:', err);
+    }
   }
 
   async dispose(): Promise<void> {

--- a/src/ui/tree/chat/ChatInboxTreeItems.ts
+++ b/src/ui/tree/chat/ChatInboxTreeItems.ts
@@ -1,0 +1,179 @@
+import * as vscode from 'vscode';
+import type { MessageList } from '../../../types/generated';
+
+export type MessageScope =
+  | 'user'
+  | 'course_member'
+  | 'submission_group'
+  | 'course_group'
+  | 'course_content'
+  | 'course'
+  | 'course_family'
+  | 'organization'
+  | 'global';
+
+export interface ChatThread {
+  scope: MessageScope;
+  /** Target id for the scope (null for global). */
+  targetId: string | null;
+  /** Display title for the thread row. */
+  title: string;
+  /** Optional secondary text under the title. */
+  subtitle?: string;
+  /** Last message in the thread (for preview + sort key). */
+  lastMessage?: MessageList;
+  /** Per-thread unread count. */
+  unreadCount: number;
+  /** Total message count. */
+  messageCount: number;
+  /** All messages belonging to this thread (kept for the open-thread handler). */
+  messages: MessageList[];
+}
+
+const SCOPE_LABELS: Record<MessageScope, string> = {
+  user: 'Direct Messages',
+  course_member: 'Course Member DMs',
+  submission_group: 'Submission Groups',
+  course_group: 'Course Groups',
+  course_content: 'Course Content',
+  course: 'Courses',
+  course_family: 'Course Families',
+  organization: 'Organizations',
+  global: 'Global'
+};
+
+const SCOPE_ICONS: Record<MessageScope, string> = {
+  user: 'mail',
+  course_member: 'account',
+  submission_group: 'beaker',
+  course_group: 'organization',
+  course_content: 'symbol-file',
+  course: 'mortar-board',
+  course_family: 'folder-library',
+  organization: 'organization',
+  global: 'globe'
+};
+
+export function scopeLabel(scope: MessageScope): string {
+  return SCOPE_LABELS[scope];
+}
+
+export class ChatScopeItem extends vscode.TreeItem {
+  constructor(
+    public readonly scope: MessageScope,
+    public readonly threads: ChatThread[],
+    public readonly unreadCount: number,
+    expanded: boolean
+  ) {
+    super(
+      SCOPE_LABELS[scope],
+      threads.length === 0
+        ? vscode.TreeItemCollapsibleState.None
+        : expanded
+          ? vscode.TreeItemCollapsibleState.Expanded
+          : vscode.TreeItemCollapsibleState.Collapsed
+    );
+    this.id = `chat-scope-${scope}`;
+    this.contextValue = unreadCount > 0 ? 'chatScope.unread' : 'chatScope';
+    this.iconPath = new vscode.ThemeIcon(SCOPE_ICONS[scope]);
+    this.description = unreadCount > 0
+      ? `${unreadCount} unread · ${threads.length}`
+      : `${threads.length}`;
+    this.tooltip = unreadCount > 0
+      ? `${SCOPE_LABELS[scope]}: ${unreadCount} unread of ${threads.length} thread(s)`
+      : `${SCOPE_LABELS[scope]}: ${threads.length} thread(s)`;
+  }
+}
+
+export class ChatThreadItem extends vscode.TreeItem {
+  constructor(public readonly thread: ChatThread) {
+    super(thread.title, vscode.TreeItemCollapsibleState.None);
+    this.id = `chat-thread-${thread.scope}-${thread.targetId ?? 'none'}`;
+    this.contextValue = thread.unreadCount > 0 ? 'chatThread.unread' : 'chatThread';
+
+    if (thread.unreadCount > 0) {
+      this.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('charts.blue'));
+      // Bold-ish emphasis via leading marker; VS Code TreeItem doesn't expose font-weight.
+      this.label = {
+        label: thread.title,
+        highlights: [[0, thread.title.length]]
+      };
+    } else {
+      this.iconPath = new vscode.ThemeIcon('comment');
+    }
+
+    const subtitle = thread.subtitle ? `${thread.subtitle} · ` : '';
+    const preview = thread.lastMessage ? formatPreview(thread.lastMessage) : '';
+    this.description = thread.unreadCount > 0
+      ? `(${thread.unreadCount}) ${subtitle}${preview}`
+      : `${subtitle}${preview}`;
+
+    this.tooltip = buildTooltip(thread);
+
+    this.command = {
+      command: 'computor.chat.openThread',
+      title: 'Open Conversation',
+      arguments: [this]
+    };
+  }
+}
+
+export class ChatEmptyItem extends vscode.TreeItem {
+  constructor(message: string = 'No messages.') {
+    super(message, vscode.TreeItemCollapsibleState.None);
+    this.id = 'chat-empty';
+    this.iconPath = new vscode.ThemeIcon('inbox');
+    this.contextValue = 'chatEmpty';
+  }
+}
+
+export class ChatLoadingItem extends vscode.TreeItem {
+  constructor() {
+    super('Loading…', vscode.TreeItemCollapsibleState.None);
+    this.id = 'chat-loading';
+    this.iconPath = new vscode.ThemeIcon('loading~spin');
+    this.contextValue = 'chatLoading';
+  }
+}
+
+export class ChatErrorItem extends vscode.TreeItem {
+  constructor(message: string) {
+    super(message, vscode.TreeItemCollapsibleState.None);
+    this.id = 'chat-error';
+    this.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground'));
+    this.contextValue = 'chatError';
+  }
+}
+
+function formatPreview(message: MessageList): string {
+  const author = formatAuthor(message);
+  const text = (message.content || '').replace(/\s+/g, ' ').trim();
+  const snippet = text.length > 80 ? `${text.slice(0, 77)}…` : text;
+  return author ? `${author}: ${snippet}` : snippet;
+}
+
+function formatAuthor(message: MessageList): string {
+  const a = message.author;
+  if (!a) { return ''; }
+  const given = a.given_name || '';
+  const family = a.family_name || '';
+  const full = `${given} ${family}`.trim();
+  return full || (a as any).username || (a as any).email || '';
+}
+
+function buildTooltip(thread: ChatThread): string {
+  const parts: string[] = [thread.title];
+  if (thread.subtitle) { parts.push(thread.subtitle); }
+  parts.push(`Scope: ${scopeLabel(thread.scope)}`);
+  if (thread.unreadCount > 0) {
+    parts.push(`Unread: ${thread.unreadCount} of ${thread.messageCount}`);
+  } else {
+    parts.push(`Messages: ${thread.messageCount}`);
+  }
+  if (thread.lastMessage?.created_at) {
+    try {
+      parts.push(`Last activity: ${new Date(thread.lastMessage.created_at).toLocaleString()}`);
+    } catch { /* ignore parse errors */ }
+  }
+  return parts.join('\n');
+}

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -1,0 +1,524 @@
+import * as vscode from 'vscode';
+import { ComputorApiService } from '../../../services/ComputorApiService';
+import { MessagesWebviewProvider, MessageTargetContext } from '../../webviews/MessagesWebviewProvider';
+import type { MessageList } from '../../../types/generated';
+import {
+  ChatScopeItem,
+  ChatThreadItem,
+  ChatThread,
+  ChatEmptyItem,
+  ChatLoadingItem,
+  ChatErrorItem,
+  MessageScope,
+  scopeLabel
+} from './ChatInboxTreeItems';
+
+const SCOPE_ORDER: MessageScope[] = [
+  'user',
+  'course_member',
+  'submission_group',
+  'course_group',
+  'course_content',
+  'course',
+  'course_family',
+  'organization',
+  'global'
+];
+
+const STATE_KEY = 'computor.chat.inbox.state';
+
+interface PersistedState {
+  expandedScopes: MessageScope[];
+  unreadOnly: boolean;
+}
+
+type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem;
+
+export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeItem> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<AnyTreeItem | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private readonly api: ComputorApiService;
+  private readonly context: vscode.ExtensionContext;
+  private readonly messagesProvider: MessagesWebviewProvider;
+
+  private loading = false;
+  private loadError: string | undefined;
+  private scopeItems: ChatScopeItem[] = [];
+  private currentUserId?: string;
+
+  // Persisted UI state
+  private expandedScopes: Set<MessageScope> = new Set();
+  private unreadOnly = false;
+
+  // Label caches keyed by id
+  private readonly orgLabels = new Map<string, string>();
+  private readonly familyLabels = new Map<string, string>();
+  private readonly courseLabels = new Map<string, string>();
+  private readonly contentLabels = new Map<string, { title: string; subtitle?: string }>();
+  private readonly groupLabels = new Map<string, { title: string; subtitle?: string }>();
+  private readonly memberLabels = new Map<string, { title: string; subtitle?: string }>();
+
+  constructor(
+    context: vscode.ExtensionContext,
+    api: ComputorApiService,
+    messagesProvider: MessagesWebviewProvider
+  ) {
+    this.context = context;
+    this.api = api;
+    this.messagesProvider = messagesProvider;
+    this.loadPersistedState();
+  }
+
+  // ----- Public API -----
+
+  refresh(): void {
+    this.scopeItems = [];
+    this.loadError = undefined;
+    void this.reload();
+  }
+
+  isUnreadOnly(): boolean {
+    return this.unreadOnly;
+  }
+
+  setUnreadOnly(value: boolean): void {
+    if (this.unreadOnly === value) { return; }
+    this.unreadOnly = value;
+    void this.persistState();
+    void vscode.commands.executeCommand('setContext', 'computor.chat.unreadOnly', value);
+    this.refresh();
+  }
+
+  recordExpanded(scope: MessageScope, expanded: boolean): void {
+    if (expanded) {
+      this.expandedScopes.add(scope);
+    } else {
+      this.expandedScopes.delete(scope);
+    }
+    void this.persistState();
+  }
+
+  async openThread(threadItem: ChatThreadItem): Promise<void> {
+    const ctx = await this.buildTargetContext(threadItem.thread);
+    if (!ctx) {
+      vscode.window.showWarningMessage('Cannot open this conversation: target context unavailable.');
+      return;
+    }
+    await this.messagesProvider.showMessages(ctx);
+  }
+
+  async markThreadRead(threadItem: ChatThreadItem): Promise<void> {
+    const unread = threadItem.thread.messages.filter(m => !m.is_read);
+    if (unread.length === 0) { return; }
+    await Promise.all(unread.map(m => this.api.markMessageRead(m.id).catch(() => undefined)));
+    this.refresh();
+  }
+
+  async markScopeRead(scopeItem: ChatScopeItem): Promise<void> {
+    const ids = scopeItem.threads.flatMap(t => t.messages.filter(m => !m.is_read).map(m => m.id));
+    if (ids.length === 0) { return; }
+    await Promise.all(ids.map(id => this.api.markMessageRead(id).catch(() => undefined)));
+    this.refresh();
+  }
+
+  // ----- TreeDataProvider -----
+
+  getTreeItem(element: AnyTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(element?: AnyTreeItem): Promise<AnyTreeItem[]> {
+    if (!element) {
+      if (this.loading) { return [new ChatLoadingItem()]; }
+      if (this.loadError) { return [new ChatErrorItem(this.loadError)]; }
+      if (this.scopeItems.length === 0) { return [new ChatEmptyItem(this.unreadOnly ? 'No unread messages.' : 'No messages.')]; }
+      return this.scopeItems;
+    }
+
+    if (element instanceof ChatScopeItem) {
+      return element.threads.map(t => new ChatThreadItem(t));
+    }
+
+    return [];
+  }
+
+  // ----- Internals -----
+
+  private async reload(): Promise<void> {
+    this.loading = true;
+    this.loadError = undefined;
+    this._onDidChangeTreeData.fire(undefined);
+
+    try {
+      const [identity, messages] = await Promise.all([
+        this.api.getCurrentUser().catch(() => undefined),
+        this.api.listMessages(this.unreadOnly ? { unread: true } : {})
+      ]);
+      this.currentUserId = identity?.id;
+
+      const grouped = this.groupMessages(messages || []);
+      await this.resolveLabels(grouped);
+      this.scopeItems = this.buildScopeItems(grouped);
+    } catch (error: any) {
+      this.loadError = `Failed to load messages: ${error?.message || error}`;
+      this.scopeItems = [];
+    } finally {
+      this.loading = false;
+      this._onDidChangeTreeData.fire(undefined);
+    }
+  }
+
+  private groupMessages(messages: MessageList[]): Map<MessageScope, Map<string, MessageList[]>> {
+    const grouped = new Map<MessageScope, Map<string, MessageList[]>>();
+    for (const m of messages) {
+      const scope = (m.scope || 'global') as MessageScope;
+      const targetId = this.targetIdFor(scope, m) ?? '__none__';
+      if (!grouped.has(scope)) { grouped.set(scope, new Map()); }
+      const byTarget = grouped.get(scope)!;
+      if (!byTarget.has(targetId)) { byTarget.set(targetId, []); }
+      byTarget.get(targetId)!.push(m);
+    }
+    return grouped;
+  }
+
+  private targetIdFor(scope: MessageScope, m: MessageList): string | null {
+    switch (scope) {
+      case 'user': return m.user_id ?? null;
+      case 'course_member': return m.course_member_id ?? null;
+      case 'submission_group': return m.submission_group_id ?? null;
+      case 'course_group': return m.course_group_id ?? null;
+      case 'course_content': return m.course_content_id ?? null;
+      case 'course': return m.course_id ?? null;
+      case 'course_family': return m.course_family_id ?? null;
+      case 'organization': return m.organization_id ?? null;
+      case 'global': return null;
+    }
+  }
+
+  private async resolveLabels(grouped: Map<MessageScope, Map<string, MessageList[]>>): Promise<void> {
+    // Best-effort batched lookups; failures fall back to id truncation.
+    const tasks: Promise<unknown>[] = [];
+
+    for (const [scope, byTarget] of grouped) {
+      for (const [targetId] of byTarget) {
+        if (targetId === '__none__') { continue; }
+        tasks.push(this.ensureLabel(scope, targetId).catch(() => undefined));
+      }
+    }
+    await Promise.all(tasks);
+  }
+
+  private async ensureLabel(scope: MessageScope, targetId: string): Promise<void> {
+    switch (scope) {
+      case 'organization':
+        if (!this.orgLabels.has(targetId)) {
+          const org = await this.api.getOrganization(targetId);
+          this.orgLabels.set(targetId, org?.title || org?.path || shortId(targetId));
+        }
+        break;
+      case 'course_family':
+        if (!this.familyLabels.has(targetId)) {
+          const fam = await this.api.getCourseFamily(targetId);
+          this.familyLabels.set(targetId, fam?.title || fam?.path || shortId(targetId));
+        }
+        break;
+      case 'course':
+        if (!this.courseLabels.has(targetId)) {
+          const course = await this.api.getCourse(targetId);
+          this.courseLabels.set(targetId, course?.title || course?.path || shortId(targetId));
+        }
+        break;
+      case 'course_content':
+        if (!this.contentLabels.has(targetId)) {
+          const content = await this.api.getCourseContent(targetId);
+          if (content) {
+            const courseLabel = content.course_id
+              ? await this.resolveCourseLabelLazy(content.course_id)
+              : undefined;
+            this.contentLabels.set(targetId, {
+              title: content.title || content.path || shortId(targetId),
+              subtitle: courseLabel
+            });
+          } else {
+            this.contentLabels.set(targetId, { title: shortId(targetId) });
+          }
+        }
+        break;
+      case 'course_group':
+        if (!this.groupLabels.has(targetId)) {
+          const group = await this.api.getCourseGroup(targetId);
+          if (group) {
+            const courseLabel = group.course_id
+              ? await this.resolveCourseLabelLazy(group.course_id)
+              : undefined;
+            this.groupLabels.set(targetId, {
+              title: group.title || `Group ${shortId(targetId)}`,
+              subtitle: courseLabel
+            });
+          } else {
+            this.groupLabels.set(targetId, { title: `Group ${shortId(targetId)}` });
+          }
+        }
+        break;
+      case 'course_member':
+        if (!this.memberLabels.has(targetId)) {
+          const member = await this.api.getCourseMember(targetId);
+          if (member) {
+            const user = (member as any).user;
+            const name = user
+              ? `${user.given_name || ''} ${user.family_name || ''}`.trim() || user.username || user.email
+              : `Member ${shortId(targetId)}`;
+            const courseLabel = member.course_id
+              ? await this.resolveCourseLabelLazy(member.course_id)
+              : undefined;
+            this.memberLabels.set(targetId, { title: name, subtitle: courseLabel });
+          } else {
+            this.memberLabels.set(targetId, { title: `Member ${shortId(targetId)}` });
+          }
+        }
+        break;
+      default:
+        // user / submission_group: derived from the message data inline.
+        break;
+    }
+  }
+
+  private async resolveCourseLabelLazy(courseId: string): Promise<string | undefined> {
+    if (this.courseLabels.has(courseId)) { return this.courseLabels.get(courseId); }
+    try {
+      const course = await this.api.getCourse(courseId);
+      const label = course?.title || course?.path || shortId(courseId);
+      this.courseLabels.set(courseId, label);
+      return label;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private buildScopeItems(grouped: Map<MessageScope, Map<string, MessageList[]>>): ChatScopeItem[] {
+    const result: ChatScopeItem[] = [];
+
+    for (const scope of SCOPE_ORDER) {
+      const byTarget = grouped.get(scope);
+      if (!byTarget || byTarget.size === 0) { continue; }
+
+      const threads: ChatThread[] = [];
+      for (const [targetId, msgs] of byTarget) {
+        const sortedMessages = msgs.slice().sort((a, b) => compareCreated(a, b));
+        const lastMessage = sortedMessages[sortedMessages.length - 1];
+        const unreadCount = msgs.filter(m => !m.is_read).length;
+        if (this.unreadOnly && unreadCount === 0) { continue; }
+
+        const { title, subtitle } = this.threadLabels(scope, targetId === '__none__' ? null : targetId, msgs);
+        threads.push({
+          scope,
+          targetId: targetId === '__none__' ? null : targetId,
+          title,
+          subtitle,
+          lastMessage,
+          unreadCount,
+          messageCount: msgs.length,
+          messages: sortedMessages
+        });
+      }
+
+      if (threads.length === 0) { continue; }
+
+      threads.sort((a, b) => {
+        if ((b.unreadCount > 0 ? 1 : 0) !== (a.unreadCount > 0 ? 1 : 0)) {
+          return (b.unreadCount > 0 ? 1 : 0) - (a.unreadCount > 0 ? 1 : 0);
+        }
+        return compareThreadRecency(b, a);
+      });
+
+      const totalUnread = threads.reduce((acc, t) => acc + t.unreadCount, 0);
+      const expanded = this.expandedScopes.has(scope) || totalUnread > 0;
+      result.push(new ChatScopeItem(scope, threads, totalUnread, expanded));
+    }
+
+    return result;
+  }
+
+  private threadLabels(scope: MessageScope, targetId: string | null, msgs: MessageList[]): { title: string; subtitle?: string } {
+    switch (scope) {
+      case 'global':
+        return { title: 'Global Announcements' };
+      case 'organization': {
+        const label = targetId ? this.orgLabels.get(targetId) || shortId(targetId) : 'Organization';
+        return { title: label };
+      }
+      case 'course_family': {
+        const label = targetId ? this.familyLabels.get(targetId) || shortId(targetId) : 'Course Family';
+        return { title: label };
+      }
+      case 'course': {
+        const label = targetId ? this.courseLabels.get(targetId) || shortId(targetId) : 'Course';
+        return { title: label };
+      }
+      case 'course_content': {
+        const info = targetId ? this.contentLabels.get(targetId) : undefined;
+        return { title: info?.title || (targetId ? shortId(targetId) : 'Course Content'), subtitle: info?.subtitle };
+      }
+      case 'course_group': {
+        const info = targetId ? this.groupLabels.get(targetId) : undefined;
+        return { title: info?.title || (targetId ? `Group ${shortId(targetId)}` : 'Course Group'), subtitle: info?.subtitle };
+      }
+      case 'course_member': {
+        const info = targetId ? this.memberLabels.get(targetId) : undefined;
+        return { title: info?.title || (targetId ? `Member ${shortId(targetId)}` : 'Course Member'), subtitle: info?.subtitle };
+      }
+      case 'submission_group': {
+        // Try to find a useful subtitle from any message that carries course_content_id (sibling field).
+        const sample = msgs[0];
+        const contentId = sample?.course_content_id;
+        const contentLabel = contentId ? this.contentLabels.get(contentId)?.title : undefined;
+        return {
+          title: contentLabel || (targetId ? `Submission Group ${shortId(targetId)}` : 'Submission Group'),
+          subtitle: contentLabel ? 'Submission group' : undefined
+        };
+      }
+      case 'user': {
+        // DM target: pick the "other person" from the messages.
+        const other = msgs
+          .map(m => m.author)
+          .find(a => a && this.currentUserId && (a as any).id !== this.currentUserId);
+        if (other) {
+          const name = `${other.given_name || ''} ${other.family_name || ''}`.trim()
+            || (other as any).username
+            || (other as any).email
+            || (targetId ? shortId(targetId) : 'User');
+          return { title: name };
+        }
+        return { title: targetId ? `User ${shortId(targetId)}` : 'User' };
+      }
+    }
+  }
+
+  private async buildTargetContext(thread: ChatThread): Promise<MessageTargetContext | undefined> {
+    const { scope, targetId } = thread;
+    const labels = this.threadLabels(scope, targetId, thread.messages);
+    const titleSegments: string[] = [];
+    if (labels.subtitle) { titleSegments.push(labels.subtitle); }
+    titleSegments.push(labels.title);
+    const title = titleSegments.join(' / ');
+
+    const baseQuery: Record<string, string> = {};
+    const basePayload: Record<string, unknown> = {};
+    let wsChannel: string | undefined;
+
+    switch (scope) {
+      case 'global':
+        return undefined;
+      case 'organization':
+        if (!targetId) { return undefined; }
+        baseQuery.organization_id = targetId;
+        basePayload.organization_id = targetId;
+        wsChannel = `organization:${targetId}`;
+        break;
+      case 'course_family':
+        if (!targetId) { return undefined; }
+        baseQuery.course_family_id = targetId;
+        basePayload.course_family_id = targetId;
+        wsChannel = `course_family:${targetId}`;
+        break;
+      case 'course':
+        if (!targetId) { return undefined; }
+        baseQuery.course_id = targetId;
+        basePayload.course_id = targetId;
+        wsChannel = `course:${targetId}`;
+        break;
+      case 'course_content': {
+        if (!targetId) { return undefined; }
+        baseQuery.course_content_id = targetId;
+        basePayload.course_content_id = targetId;
+        const contentInfo = this.contentLabels.get(targetId);
+        if (contentInfo) {
+          // Course content lookup may have set the course relation; surface it for create payloads.
+          // We don't have direct course_id here unless the message carried it, so leave as is.
+        }
+        wsChannel = `course_content:${targetId}`;
+        break;
+      }
+      case 'course_group':
+        if (!targetId) { return undefined; }
+        baseQuery.course_group_id = targetId;
+        basePayload.course_group_id = targetId;
+        wsChannel = `course_group:${targetId}`;
+        break;
+      case 'submission_group':
+        if (!targetId) { return undefined; }
+        baseQuery.submission_group_id = targetId;
+        basePayload.submission_group_id = targetId;
+        wsChannel = `submission_group:${targetId}`;
+        break;
+      case 'course_member':
+        if (!targetId) { return undefined; }
+        baseQuery.course_member_id = targetId;
+        basePayload.course_member_id = targetId;
+        wsChannel = `course_member:${targetId}`;
+        break;
+      case 'user':
+        if (!targetId) { return undefined; }
+        baseQuery.user_id = targetId;
+        basePayload.user_id = targetId;
+        wsChannel = `user:${targetId}`;
+        break;
+    }
+
+    return {
+      title,
+      subtitle: scopeLabel(scope),
+      query: baseQuery,
+      createPayload: basePayload,
+      wsChannel
+    };
+  }
+
+  // ----- Persistence -----
+
+  private loadPersistedState(): void {
+    try {
+      const stored = this.context.globalState.get<PersistedState>(STATE_KEY);
+      if (stored) {
+        if (Array.isArray(stored.expandedScopes)) {
+          this.expandedScopes = new Set(stored.expandedScopes);
+        }
+        if (typeof stored.unreadOnly === 'boolean') {
+          this.unreadOnly = stored.unreadOnly;
+        }
+      }
+    } catch (err) {
+      console.warn('[ChatInbox] Failed to load persisted state:', err);
+    }
+    void vscode.commands.executeCommand('setContext', 'computor.chat.unreadOnly', this.unreadOnly);
+  }
+
+  private async persistState(): Promise<void> {
+    const state: PersistedState = {
+      expandedScopes: Array.from(this.expandedScopes),
+      unreadOnly: this.unreadOnly
+    };
+    try {
+      await this.context.globalState.update(STATE_KEY, state);
+    } catch (err) {
+      console.warn('[ChatInbox] Failed to persist state:', err);
+    }
+  }
+}
+
+function shortId(id: string): string {
+  return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+function compareCreated(a: MessageList, b: MessageList): number {
+  const ta = a.created_at ? Date.parse(a.created_at) : 0;
+  const tb = b.created_at ? Date.parse(b.created_at) : 0;
+  return ta - tb;
+}
+
+function compareThreadRecency(a: ChatThread, b: ChatThread): number {
+  const ta = a.lastMessage?.created_at ? Date.parse(a.lastMessage.created_at) : 0;
+  const tb = b.lastMessage?.created_at ? Date.parse(b.lastMessage.created_at) : 0;
+  return ta - tb;
+}


### PR DESCRIPTION
Closes #78

## Summary

Introduces the **Computor Chat** view: a new view container for the activity bar (drag to the secondary sidebar for the right-side experience) that lists every message visible to the current user, grouped by backend message scope, with unread-first ordering and unread badges. Existing message right-click flows are unchanged — this is an additional surface, not a replacement.

The conversation pane on click is the **existing** \`MessagesWebviewProvider\` + bottom \`MessagesInputPanel\`, so threading, editing, replying, WebSocket-driven message updates within a thread, etc. all work out of the box.

## What's in the PR

- New \`ChatInboxTreeProvider\` + tree items in \`src/ui/tree/chat/\`. Fetches \`/messages\` with no target filter (or \`unread=true\` when the toggle is on), groups by \`scope\` + per-scope target id, sorts unread-first then by last activity.
- Scope rows show \`N unread · total\` and use scope-specific icons; thread rows show author + preview, an unread highlight + \`(N)\` marker when unread.
- Labels for org / family / course / course content / course group / course member resolved on demand via the existing API helpers, cached in-memory.
- View-title actions: **Refresh**, **Show Only Unread** / **Show All** toggle (state persisted in \`globalState\`).
- Item-context actions: **Mark Thread as Read**, **Mark All as Read** (per scope).
- New view container \`computor-chat\` + view \`computor.chat.inbox\` in \`package.json\`, gated by a \`computor.chat.show\` context key set after auth.

## What's deliberately out of scope (per #78)

- Live updates via WebSocket on the **inbox** itself — within an open conversation, WS still works through \`MessagesWebviewProvider\`, but inbox refreshes are user-triggered (Refresh button) for now.
- Composing a new conversation from inside the chat view — creation still happens through the role-tree right-click flows.
- Tag/search filters and tag-prefix scoping (the API supports them).

## Test plan

- [ ] After login, the **Computor Chat** activity-bar item appears (drag to the secondary sidebar / right side as desired).
- [ ] Inbox shows scope groups: Direct Messages / Course Member DMs / Submission Groups / Course Groups / Course Content / Courses / Course Families / Organizations / Global. Empty scopes are hidden.
- [ ] Each scope row shows \`X unread · Y\` when unread > 0, \`Y\` otherwise.
- [ ] Each thread shows author + preview; unread threads are highlighted and prefixed with \`(N)\`.
- [ ] Clicking a thread opens the existing messages webview (and reveals the bottom Compose panel) targeted at that conversation. Sending a reply from the bottom panel updates the conversation; refreshing the chat tree afterwards shows the read state correctly.
- [ ] **Show Only Unread** toolbar button hides read threads and persists across reloads. **Show All** restores.
- [ ] **Mark All as Read** on a scope row clears its unread badge after refresh.
- [ ] **Mark Thread as Read** on a thread row clears that row's unread highlight after refresh.
- [ ] Logout clears the chat view container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)