### PR TITLE
Messages refactor + tutor tree polish

### DIFF
--- a/docs/client-endpoints.md
+++ b/docs/client-endpoints.md
@@ -29,6 +29,7 @@
 | `refreshLocalTokenAuthRefreshLocalPost` | POST | `/auth/refresh/local` | `LocalTokenRefreshRequest` | `LocalTokenRefreshResponse` |
 | `registerUserAuthRegisterPost` | POST | `/auth/register` | `UserRegistrationRequest` | `UserRegistrationResponse` |
 | `ssoSuccessAuthSuccessGet` | GET | `/auth/success` | — | `void` |
+| `verifyCoderAccessAuthVerifyCoderAccessGet` | GET | `/auth/verify-coder-access` | — | `void` |
 | `handleCallbackAuthProviderCallbackGet` | GET | `/auth/{provider}/callback` | — | `void` |
 | `initiateLoginAuthProviderLoginGet` | GET | `/auth/{provider}/login` | — | `void` |
 
@@ -80,9 +81,9 @@
 | `createCourseContentsCourseContentsPost` | POST | `/course-contents` | `CourseContentCreate` | `CourseContentGet` |
 | `getCourseDeploymentSummaryCourseContentsCoursesCourseIdDeploymentSummaryGet` | GET | `/course-contents/courses/{course_id}/deployment-summary` | — | `DeploymentSummary` |
 | `getDeploymentStatusWithWorkflowCourseContentsDeploymentContentIdGet` | GET | `/course-contents/deployment/{content_id}` | — | `Record<string, unknown> & Record<string, unknown>` |
-| `assignExampleToContentCourseContentsContentIdAssignExamplePost` | POST | `/course-contents/{content_id}/assign-example` | `computor_types__deployment__AssignExampleRequest` | `DeploymentWithHistory` |
 | `getContentDeploymentCourseContentsContentIdDeploymentGet` | GET | `/course-contents/{content_id}/deployment` | — | `DeploymentWithHistory | null` |
 | `unassignExampleFromContentCourseContentsContentIdExampleDelete` | DELETE | `/course-contents/{content_id}/example` | — | `Record<string, unknown> & Record<string, string>` |
+| `moveCourseContentCourseContentsContentIdMovePatch` | PATCH | `/course-contents/{content_id}/move` | `CourseContentMoveRequest` | `CourseContentGet` |
 | `getAvailableTeamsCourseContentsCourseContentIdSubmissionGroupsAvailableGet` | GET | `/course-contents/{course_content_id}/submission-groups/available` | — | `AvailableTeam[]` |
 | `leaveMyTeamCourseContentsCourseContentIdSubmissionGroupsMyTeamDelete` | DELETE | `/course-contents/{course_content_id}/submission-groups/my-team` | — | `LeaveTeamResponse` |
 | `getMyTeamCourseContentsCourseContentIdSubmissionGroupsMyTeamGet` | GET | `/course-contents/{course_content_id}/submission-groups/my-team` | — | `TeamResponse` |
@@ -91,6 +92,7 @@
 | `getCourseContentsCourseContentsIdGet` | GET | `/course-contents/{id}` | — | `CourseContentGet` |
 | `updateCourseContentsCourseContentsIdPatch` | PATCH | `/course-contents/{id}` | `CourseContentUpdate` | `CourseContentGet` |
 | `routeCourseContentsCourseContentsIdArchivePatch` | PATCH | `/course-contents/{id}/archive` | — | `void` |
+| `unarchiveCourseContentsCourseContentsIdUnarchivePatch` | PATCH | `/course-contents/{id}/unarchive` | — | `void` |
 
 ## CourseFamiliesClient
 - Base path: `/course-families`
@@ -100,9 +102,31 @@
 | --- | --- | --- | --- | --- |
 | `listCourseFamiliesCourseFamiliesGet` | GET | `/course-families` | — | `CourseFamilyList[]` |
 | `createCourseFamiliesCourseFamiliesPost` | POST | `/course-families` | `CourseFamilyCreate` | `CourseFamilyGet` |
+| `deleteCourseFamilyEndpointCourseFamiliesCourseFamilyIdDelete` | DELETE | `/course-families/{course_family_id}` | — | `CascadeDeleteResult` |
 | `deleteCourseFamiliesCourseFamiliesIdDelete` | DELETE | `/course-families/{id}` | — | `void` |
 | `getCourseFamiliesCourseFamiliesIdGet` | GET | `/course-families/{id}` | — | `CourseFamilyGet` |
 | `updateCourseFamiliesCourseFamiliesIdPatch` | PATCH | `/course-families/{id}` | `CourseFamilyUpdate` | `CourseFamilyGet` |
+
+## CourseFamilyMembersClient
+- Base path: `/course-family-members`
+- Note: custom operations discovered from OpenAPI schema
+
+| TS Method | HTTP | Path | Request | Response |
+| --- | --- | --- | --- | --- |
+| `listCourseFamilyMembersCourseFamilyMembersGet` | GET | `/course-family-members` | — | `CourseFamilyMemberList[]` |
+| `createCourseFamilyMembersCourseFamilyMembersPost` | POST | `/course-family-members` | `CourseFamilyMemberCreate` | `CourseFamilyMemberGet` |
+| `deleteCourseFamilyMembersCourseFamilyMembersIdDelete` | DELETE | `/course-family-members/{id}` | — | `void` |
+| `getCourseFamilyMembersCourseFamilyMembersIdGet` | GET | `/course-family-members/{id}` | — | `CourseFamilyMemberGet` |
+| `updateCourseFamilyMembersCourseFamilyMembersIdPatch` | PATCH | `/course-family-members/{id}` | `CourseFamilyMemberUpdate` | `CourseFamilyMemberGet` |
+
+## CourseFamilyRolesClient
+- Base path: `/course-family-roles`
+- Note: custom operations discovered from OpenAPI schema
+
+| TS Method | HTTP | Path | Request | Response |
+| --- | --- | --- | --- | --- |
+| `listCourseFamilyRolesCourseFamilyRolesGet` | GET | `/course-family-roles` | — | `CourseFamilyRoleList[]` |
+| `getCourseFamilyRolesCourseFamilyRolesIdGet` | GET | `/course-family-roles/{id}` | — | `CourseFamilyRoleGet` |
 
 ## CourseGroupsClient
 - Base path: `/course-groups`
@@ -173,6 +197,7 @@
 | --- | --- | --- | --- | --- |
 | `listCoursesCoursesGet` | GET | `/courses` | — | `CourseList[]` |
 | `createCoursesCoursesPost` | POST | `/courses` | `CourseCreate` | `CourseGet` |
+| `deleteCourseEndpointCoursesCourseIdDelete` | DELETE | `/courses/{course_id}` | — | `CascadeDeleteResult` |
 | `deleteCoursesCoursesIdDelete` | DELETE | `/courses/{id}` | — | `void` |
 | `getCoursesCoursesIdGet` | GET | `/courses/{id}` | — | `CourseGet` |
 | `updateCoursesCoursesIdPatch` | PATCH | `/courses/{id}` | `CourseUpdate` | `CourseGet` |
@@ -196,6 +221,7 @@
 | TS Method | HTTP | Path | Request | Response |
 | --- | --- | --- | --- | --- |
 | `listExamplesExamplesGet` | GET | `/examples` | — | `ExampleList[]` |
+| `deleteExamplesByPatternEndpointExamplesByPatternDelete` | DELETE | `/examples/by-pattern` | — | `ExampleBulkDeleteResult` |
 | `removeDependencyExamplesDependenciesDependencyIdDelete` | DELETE | `/examples/dependencies/{dependency_id}` | — | `void` |
 | `downloadExampleVersionExamplesDownloadVersionIdGet` | GET | `/examples/download/{version_id}` | — | `ExampleDownloadResponse` |
 | `uploadExampleExamplesUploadPost` | POST | `/examples/upload` | `ExampleUploadRequest` | `ExampleVersionGet` |
@@ -266,12 +292,14 @@
 | --- | --- | --- | --- | --- |
 | `lecturerListCourseContentsEndpointLecturersCourseContentsGet` | GET | `/lecturers/course-contents` | — | `CourseContentLecturerList[]` |
 | `lecturerGetCourseContentsEndpointLecturersCourseContentsCourseContentIdGet` | GET | `/lecturers/course-contents/{course_content_id}` | — | `CourseContentLecturerGet` |
-| `assignExampleToCourseContentLecturersCourseContentsCourseContentIdAssignExamplePost` | POST | `/lecturers/course-contents/{course_content_id}/assign-example` | `computor_types__lecturer_deployments__AssignExampleRequest` | `AssignExampleResponse` |
+| `assignExampleToCourseContentLecturersCourseContentsCourseContentIdAssignExamplePost` | POST | `/lecturers/course-contents/{course_content_id}/assign-example` | `AssignExampleRequest` | `AssignExampleResponse` |
 | `unassignExampleFromCourseContentLecturersCourseContentsCourseContentIdDeploymentDelete` | DELETE | `/lecturers/course-contents/{course_content_id}/deployment` | — | `UnassignExampleResponse` |
 | `getCourseContentDeploymentLecturersCourseContentsCourseContentIdDeploymentGet` | GET | `/lecturers/course-contents/{course_content_id}/deployment` | — | `DeploymentGet` |
 | `syncMemberGitlabPermissionsEndpointLecturersCourseMembersCourseMemberIdSyncGitlabPost` | POST | `/lecturers/course-members/{course_member_id}/sync-gitlab` | `GitLabSyncRequest` | `GitLabSyncResult` |
 | `lecturerListCoursesEndpointLecturersCoursesGet` | GET | `/lecturers/courses` | — | `CourseList[]` |
 | `lecturerGetCoursesEndpointLecturersCoursesCourseIdGet` | GET | `/lecturers/courses/{course_id}` | — | `CourseGet` |
+| `getCourseDeploymentsEndpointLecturersCoursesCourseIdDeploymentsGet` | GET | `/lecturers/courses/{course_id}/deployments` | — | `CourseDeploymentGet` |
+| `batchUpgradeVersionsEndpointLecturersCoursesCourseIdUpgradeVersionsPost` | POST | `/lecturers/courses/{course_id}/upgrade-versions` | `VersionUpgradeCreate` | `VersionUpgradeGet` |
 | `validateCourseContentBatchLecturersCoursesCourseIdValidatePost` | POST | `/lecturers/courses/{course_id}/validate` | `ContentValidationCreate` | `ContentValidationGet` |
 
 ## MessagesClient
@@ -288,6 +316,7 @@
 | `getMessageAuditMessagesIdAuditGet` | GET | `/messages/{id}/audit` | — | `void` |
 | `markMessageUnreadMessagesIdReadsDelete` | DELETE | `/messages/{id}/reads` | — | `void` |
 | `markMessageReadMessagesIdReadsPost` | POST | `/messages/{id}/reads` | — | `void` |
+| `getMessageThreadEndpointMessagesIdThreadGet` | GET | `/messages/{id}/thread` | — | `MessageThread` |
 
 ## MiscClient
 - Base path: `/`
@@ -296,6 +325,27 @@
 | TS Method | HTTP | Path | Request | Response |
 | --- | --- | --- | --- | --- |
 | `getStatusHeadHead` | HEAD | `/` | — | `void` |
+
+## OrganizationMembersClient
+- Base path: `/organization-members`
+- Note: custom operations discovered from OpenAPI schema
+
+| TS Method | HTTP | Path | Request | Response |
+| --- | --- | --- | --- | --- |
+| `listOrganizationMembersOrganizationMembersGet` | GET | `/organization-members` | — | `OrganizationMemberList[]` |
+| `createOrganizationMembersOrganizationMembersPost` | POST | `/organization-members` | `OrganizationMemberCreate` | `OrganizationMemberGet` |
+| `deleteOrganizationMembersOrganizationMembersIdDelete` | DELETE | `/organization-members/{id}` | — | `void` |
+| `getOrganizationMembersOrganizationMembersIdGet` | GET | `/organization-members/{id}` | — | `OrganizationMemberGet` |
+| `updateOrganizationMembersOrganizationMembersIdPatch` | PATCH | `/organization-members/{id}` | `OrganizationMemberUpdate` | `OrganizationMemberGet` |
+
+## OrganizationRolesClient
+- Base path: `/organization-roles`
+- Note: custom operations discovered from OpenAPI schema
+
+| TS Method | HTTP | Path | Request | Response |
+| --- | --- | --- | --- | --- |
+| `listOrganizationRolesOrganizationRolesGet` | GET | `/organization-roles` | — | `OrganizationRoleList[]` |
+| `getOrganizationRolesOrganizationRolesIdGet` | GET | `/organization-roles/{id}` | — | `OrganizationRoleGet` |
 
 ## OrganizationsClient
 - Base path: `/organizations`
@@ -309,6 +359,8 @@
 | `getOrganizationsOrganizationsIdGet` | GET | `/organizations/{id}` | — | `OrganizationGet` |
 | `updateOrganizationsOrganizationsIdPatch` | PATCH | `/organizations/{id}` | `OrganizationUpdate` | `OrganizationGet` |
 | `routeOrganizationsOrganizationsIdArchivePatch` | PATCH | `/organizations/{id}/archive` | — | `void` |
+| `unarchiveOrganizationsOrganizationsIdUnarchivePatch` | PATCH | `/organizations/{id}/unarchive` | — | `void` |
+| `deleteOrganizationEndpointOrganizationsOrganizationIdDelete` | DELETE | `/organizations/{organization_id}` | — | `CascadeDeleteResult` |
 | `patchOrganizationsTokenOrganizationsOrganizationIdTokenPatch` | PATCH | `/organizations/{organization_id}/token` | `OrganizationUpdateTokenUpdate` | `void` |
 
 ## ProfilesClient
@@ -375,6 +427,7 @@
 | --- | --- | --- | --- | --- |
 | `listServicesEndpointServiceAccountsGet` | GET | `/service-accounts` | — | `ServiceGet[]` |
 | `createServiceEndpointServiceAccountsPost` | POST | `/service-accounts` | `ServiceCreate` | `ServiceGet` |
+| `getServiceMeServiceAccountsMeGet` | GET | `/service-accounts/me` | — | `ServiceGet` |
 | `deleteServiceEndpointServiceAccountsServiceIdDelete` | DELETE | `/service-accounts/{service_id}` | — | `void` |
 | `getServiceEndpointServiceAccountsServiceIdGet` | GET | `/service-accounts/{service_id}` | — | `ServiceGet` |
 | `updateServiceEndpointServiceAccountsServiceIdPatch` | PATCH | `/service-accounts/{service_id}` | `ServiceUpdate` | `ServiceGet` |
@@ -478,12 +531,13 @@
 | `getSubmissionArtifactSubmissionsArtifactsArtifactIdGet` | GET | `/submissions/artifacts/{artifact_id}` | — | `SubmissionArtifactGet` |
 | `updateSubmissionArtifactSubmissionsArtifactsArtifactIdPatch` | PATCH | `/submissions/artifacts/{artifact_id}` | `SubmissionArtifactUpdate` | `SubmissionArtifactGet` |
 | `downloadSubmissionArtifactSubmissionsArtifactsArtifactIdDownloadGet` | GET | `/submissions/artifacts/{artifact_id}/download` | — | `void` |
-| `listArtifactGradesSubmissionsArtifactsArtifactIdGradesGet` | GET | `/submissions/artifacts/{artifact_id}/grades` | — | `SubmissionGradeListItem[]` |
+| `listArtifactGradesSubmissionsArtifactsArtifactIdGradesGet` | GET | `/submissions/artifacts/{artifact_id}/grades` | — | `SubmissionGradeList[]` |
 | `createArtifactGradeEndpointSubmissionsArtifactsArtifactIdGradesPost` | POST | `/submissions/artifacts/{artifact_id}/grades` | `SubmissionGradeCreate` | `SubmissionGradeDetail` |
 | `listArtifactReviewsSubmissionsArtifactsArtifactIdReviewsGet` | GET | `/submissions/artifacts/{artifact_id}/reviews` | — | `SubmissionReviewListItem[]` |
 | `createArtifactReviewSubmissionsArtifactsArtifactIdReviewsPost` | POST | `/submissions/artifacts/{artifact_id}/reviews` | `SubmissionReviewCreate` | `SubmissionReviewListItem` |
 | `createTestResultSubmissionsArtifactsArtifactIdTestPost` | POST | `/submissions/artifacts/{artifact_id}/test` | `ResultCreate` | `ResultList` |
 | `listArtifactTestResultsSubmissionsArtifactsArtifactIdTestsGet` | GET | `/submissions/artifacts/{artifact_id}/tests` | — | `ResultGet[]` |
+| `listGradesSubmissionsGradesGet` | GET | `/submissions/grades` | — | `SubmissionGradeList[]` |
 | `deleteArtifactGradeSubmissionsGradesGradeIdDelete` | DELETE | `/submissions/grades/{grade_id}` | — | `void` |
 | `updateArtifactGradeSubmissionsGradesGradeIdPatch` | PATCH | `/submissions/grades/{grade_id}` | `SubmissionGradeUpdate` | `SubmissionGradeDetail` |
 | `deleteArtifactReviewSubmissionsReviewsReviewIdDelete` | DELETE | `/submissions/reviews/{review_id}` | — | `void` |
@@ -505,6 +559,11 @@
 | `createOrganizationAsyncSystemDeployOrganizationsPost` | POST | `/system/deploy/organizations` | `OrganizationTaskRequest` | `TaskResponse` |
 | `createHierarchySystemHierarchyCreatePost` | POST | `/system/hierarchy/create` | `Record<string, unknown> & Record<string, unknown>` | `Record<string, unknown> & Record<string, unknown>` |
 | `getHierarchyStatusSystemHierarchyStatusWorkflowIdGet` | GET | `/system/hierarchy/status/{workflow_id}` | — | `Record<string, unknown> & Record<string, unknown>` |
+| `activateMaintenanceSystemMaintenanceActivatePost` | POST | `/system/maintenance/activate` | `MaintenanceActivate` | `void` |
+| `deactivateMaintenanceSystemMaintenanceDeactivatePost` | POST | `/system/maintenance/deactivate` | — | `void` |
+| `cancelScheduledMaintenanceSystemMaintenanceScheduleDelete` | DELETE | `/system/maintenance/schedule` | — | `void` |
+| `scheduleMaintenanceSystemMaintenanceSchedulePost` | POST | `/system/maintenance/schedule` | `MaintenanceSchedule` | `void` |
+| `getMaintenanceStatusSystemMaintenanceStatusGet` | GET | `/system/maintenance/status` | — | `MaintenanceStatusGet` |
 
 ## TasksClient
 - Base path: `/tasks`
@@ -562,9 +621,13 @@
 | `tutorGetCoursesEndpointTutorsCoursesCourseIdGet` | GET | `/tutors/courses/{course_id}` | — | `CourseTutorGet` |
 | `tutorListSubmissionGroupsEndpointTutorsSubmissionGroupsGet` | GET | `/tutors/submission-groups` | — | `TutorSubmissionGroupList[]` |
 | `tutorGetSubmissionGroupEndpointTutorsSubmissionGroupsSubmissionGroupIdGet` | GET | `/tutors/submission-groups/{submission_group_id}` | — | `TutorSubmissionGroupGet` |
-| `getTutorTestStatusTutorsTestsTestIdGet` | GET | `/tutors/tests/{test_id}` | — | `TutorTestStatus` |
-| `downloadTutorTestArtifactsTutorsTestsTestIdArtifactsGet` | GET | `/tutors/tests/{test_id}/artifacts` | — | `void` |
-| `listTutorTestArtifactsEndpointTutorsTestsTestIdArtifactsListGet` | GET | `/tutors/tests/{test_id}/artifacts/list` | — | `TutorTestArtifactList` |
+| `getTutorTestEndpointTutorsTestsTestIdGet` | GET | `/tutors/tests/{test_id}` | — | `TutorTestGet` |
+| `listTutorTestArtifactsEndpointTutorsTestsTestIdArtifactsGet` | GET | `/tutors/tests/{test_id}/artifacts` | — | `TutorTestArtifactList` |
+| `downloadTutorTestArtifactsTutorsTestsTestIdArtifactsDownloadGet` | GET | `/tutors/tests/{test_id}/artifacts/download` | — | `void` |
+| `uploadTutorTestArtifactsTutorsTestsTestIdArtifactsUploadPost` | POST | `/tutors/tests/{test_id}/artifacts/upload` | — | `void` |
+| `downloadTutorTestInputTutorsTestsTestIdInputDownloadGet` | GET | `/tutors/tests/{test_id}/input/download` | — | `void` |
+| `submitTutorTestResultsTutorsTestsTestIdResultsPost` | POST | `/tutors/tests/{test_id}/results` | `Record<string, unknown> & Record<string, unknown>` | `void` |
+| `getTutorTestStatusEndpointTutorsTestsTestIdStatusGet` | GET | `/tutors/tests/{test_id}/status` | — | `TutorTestStatus` |
 
 ## UserClient
 - Base path: `/user`
@@ -576,6 +639,7 @@
 | `registerCurrentUserCourseAccountUserCoursesCourseIdRegisterPost` | POST | `/user/courses/{course_id}/register` | `CourseMemberProviderAccountUpdate` | `CourseMemberReadinessStatus` |
 | `validateCurrentUserCourseUserCoursesCourseIdValidatePost` | POST | `/user/courses/{course_id}/validate` | `CourseMemberValidationRequest` | `CourseMemberReadinessStatus` |
 | `setUserPasswordEndpointUserPasswordPost` | POST | `/user/password` | `UserPassword` | `void` |
+| `getCurrentUserScopesUserScopesGet` | GET | `/user/scopes` | — | `UserScopes` |
 | `getCourseViewsForCurrentUserUserViewsGet` | GET | `/user/views` | — | `string[]` |
 | `getCourseViewsForCurrentUserByCourseUserViewsCourseIdGet` | GET | `/user/views/{course_id}` | — | `string[]` |
 
@@ -602,3 +666,14 @@
 | `getUsersUsersIdGet` | GET | `/users/{id}` | — | `UserGet` |
 | `updateUsersUsersIdPatch` | PATCH | `/users/{id}` | `UserUpdate` | `UserGet` |
 | `routeUsersUsersIdArchivePatch` | PATCH | `/users/{id}/archive` | — | `void` |
+| `unarchiveUsersUsersIdUnarchivePatch` | PATCH | `/users/{id}/unarchive` | — | `void` |
+
+## WorkspacesClient
+- Base path: `/workspaces`
+- Note: custom operations discovered from OpenAPI schema
+
+| TS Method | HTTP | Path | Request | Response |
+| --- | --- | --- | --- | --- |
+| `assignRoleWorkspacesRolesAssignPost` | POST | `/workspaces/roles/assign` | `WorkspaceRoleAssign` | `WorkspaceRoleUser` |
+| `listUsersWorkspacesRolesUsersGet` | GET | `/workspaces/roles/users` | — | `WorkspaceRoleUser[]` |
+| `removeRoleWorkspacesRolesUsersUserIdRoleIdDelete` | DELETE | `/workspaces/roles/users/{user_id}/{role_id}` | — | `void` |

--- a/package.json
+++ b/package.json
@@ -1247,6 +1247,16 @@
         },
         {
           "command": "computor.lecturer.showMessages",
+          "when": "view == computor.lecturer.courses && viewItem == organization",
+          "group": "2_discussion@1"
+        },
+        {
+          "command": "computor.lecturer.showMessages",
+          "when": "view == computor.lecturer.courses && viewItem == courseFamily",
+          "group": "2_discussion@1"
+        },
+        {
+          "command": "computor.lecturer.showMessages",
           "when": "view == computor.lecturer.courses && viewItem == course",
           "group": "2_discussion@1"
         },

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -29,6 +29,7 @@ import type { OrganizationList, OrganizationTaskRequest } from '../types/generat
 import type { GitLabCredentials } from '../types/generated/common';
 import type { CourseDeploymentList } from '../types/generated';
 import { LecturerRepositoryManager } from '../services/LecturerRepositoryManager';
+import { canPostToCourseFamily, canPostToOrganization } from '../services/MessagePermissions';
 import type { MessagesInputPanelProvider } from '../ui/panels/MessagesInputPanel';
 import type { WebSocketService } from '../services/WebSocketService';
 import { commandRegistrar } from './commandHelpers';
@@ -140,7 +141,7 @@ export class LecturerCommands {
       await this.createAssignment(item);
     });
 
-    register('computor.lecturer.showMessages', async (item: CourseTreeItem | CourseGroupTreeItem | CourseContentTreeItem) => {
+    register('computor.lecturer.showMessages', async (item: OrganizationTreeItem | CourseFamilyTreeItem | CourseTreeItem | CourseGroupTreeItem | CourseContentTreeItem) => {
       await this.showMessages(item);
     });
 
@@ -1181,11 +1182,37 @@ export class LecturerCommands {
     return type.course_content_kind?.submittable || false;
   }
 
-  private async showMessages(item: CourseTreeItem | CourseGroupTreeItem | CourseContentTreeItem): Promise<void> {
+  private async showMessages(item: OrganizationTreeItem | CourseFamilyTreeItem | CourseTreeItem | CourseGroupTreeItem | CourseContentTreeItem): Promise<void> {
     try {
       let target: MessageTargetContext | undefined;
 
-      if (item instanceof CourseTreeItem) {
+      if (item instanceof OrganizationTreeItem) {
+        const scopes = await this.apiService.getUserScopes();
+        const canPost = canPostToOrganization(scopes, item.organization.id);
+        target = {
+          title: item.organization.title || item.organization.path,
+          subtitle: 'Organization',
+          query: { organization_id: item.organization.id },
+          createPayload: { organization_id: item.organization.id },
+          sourceRole: 'lecturer',
+          wsChannel: `organization:${item.organization.id}`,
+          readOnly: !canPost,
+          readOnlyReason: canPost ? undefined : 'Posting to this organization requires manager or owner role.'
+        };
+      } else if (item instanceof CourseFamilyTreeItem) {
+        const scopes = await this.apiService.getUserScopes();
+        const canPost = canPostToCourseFamily(scopes, item.courseFamily.id);
+        target = {
+          title: item.courseFamily.title || item.courseFamily.path,
+          subtitle: `${item.organization.title || item.organization.path} › Course Family`,
+          query: { course_family_id: item.courseFamily.id },
+          createPayload: { course_family_id: item.courseFamily.id },
+          sourceRole: 'lecturer',
+          wsChannel: `course_family:${item.courseFamily.id}`,
+          readOnly: !canPost,
+          readOnlyReason: canPost ? undefined : 'Posting to this course family requires manager or owner role.'
+        };
+      } else if (item instanceof CourseTreeItem) {
         target = {
           title: item.course.title || item.course.path,
           subtitle: this.buildCourseSubtitle(item.course, item.courseFamily, item.organization),

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -30,6 +30,7 @@ import type { GitLabCredentials } from '../types/generated/common';
 import type { CourseDeploymentList } from '../types/generated';
 import { LecturerRepositoryManager } from '../services/LecturerRepositoryManager';
 import { canPostToCourseFamily, canPostToOrganization } from '../services/MessagePermissions';
+import { runLockedWithProgress } from '../utils/progressLock';
 import type { MessagesInputPanelProvider } from '../ui/panels/MessagesInputPanel';
 import type { WebSocketService } from '../services/WebSocketService';
 import { commandRegistrar } from './commandHelpers';
@@ -268,7 +269,7 @@ export class LecturerCommands {
     register('computor.lecturer.showCourseMemberProgress', async (itemOrId: CourseMemberTreeItem | string, memberName?: string) => {
       if (typeof itemOrId === 'string') {
         // Called with course member ID directly (from overview webview)
-        await this.courseMemberProgressWebviewProvider.showMemberProgress(itemOrId, memberName);
+        await this.showCourseMemberProgressById(itemOrId, memberName);
       } else {
         // Called with tree item
         await this.showCourseMemberProgress(itemOrId);
@@ -2411,39 +2412,71 @@ export class LecturerCommands {
   }
 
   private async showCourseProgressOverview(item: CourseTreeItem): Promise<void> {
-    try {
-      const course = await this.apiService.getCourse(item.course.id);
-      if (!course) {
-        vscode.window.showErrorMessage('Failed to load course details');
-        return;
+    const courseLabel = item.course.title || item.course.path;
+    await runLockedWithProgress(
+      {
+        key: `course-progress:${item.course.id}`,
+        title: `Loading course progress: ${courseLabel}`,
+        duplicateMessage: 'Course progress is already loading…'
+      },
+      async () => {
+        try {
+          const course = await this.apiService.getCourse(item.course.id);
+          if (!course) {
+            vscode.window.showErrorMessage('Failed to load course details');
+            return;
+          }
+          await this.courseProgressOverviewWebviewProvider.showCourseProgress(course);
+        } catch (error) {
+          vscode.window.showErrorMessage(`Failed to show course progress: ${error}`);
+        }
       }
-      await this.courseProgressOverviewWebviewProvider.showCourseProgress(course);
-    } catch (error) {
-      vscode.window.showErrorMessage(`Failed to show course progress: ${error}`);
-    }
+    );
   }
 
   private async showCourseProgressOverviewById(courseId: string): Promise<void> {
-    try {
-      const course = await this.apiService.getCourse(courseId);
-      if (!course) {
-        vscode.window.showErrorMessage('Failed to load course details');
-        return;
+    await runLockedWithProgress(
+      {
+        key: `course-progress:${courseId}`,
+        title: 'Loading course progress…',
+        duplicateMessage: 'Course progress is already loading…'
+      },
+      async () => {
+        try {
+          const course = await this.apiService.getCourse(courseId);
+          if (!course) {
+            vscode.window.showErrorMessage('Failed to load course details');
+            return;
+          }
+          await this.courseProgressOverviewWebviewProvider.showCourseProgress(course);
+        } catch (error) {
+          vscode.window.showErrorMessage(`Failed to show course progress: ${error}`);
+        }
       }
-      await this.courseProgressOverviewWebviewProvider.showCourseProgress(course);
-    } catch (error) {
-      vscode.window.showErrorMessage(`Failed to show course progress: ${error}`);
-    }
+    );
   }
 
   private async showCourseMemberProgress(item: CourseMemberTreeItem): Promise<void> {
-    try {
-      const memberName = item.member.user
-        ? [item.member.user.given_name, item.member.user.family_name].filter(Boolean).join(' ') || item.member.user.username || undefined
-        : undefined;
-      await this.courseMemberProgressWebviewProvider.showMemberProgress(item.member.id, memberName);
-    } catch (error) {
-      vscode.window.showErrorMessage(`Failed to show member progress: ${error}`);
-    }
+    const memberName = item.member.user
+      ? [item.member.user.given_name, item.member.user.family_name].filter(Boolean).join(' ') || item.member.user.username || undefined
+      : undefined;
+    await this.showCourseMemberProgressById(item.member.id, memberName);
+  }
+
+  private async showCourseMemberProgressById(memberId: string, memberName?: string): Promise<void> {
+    await runLockedWithProgress(
+      {
+        key: `member-progress:${memberId}`,
+        title: `Loading progress: ${memberName || 'student'}`,
+        duplicateMessage: 'Student progress is already loading…'
+      },
+      async () => {
+        try {
+          await this.courseMemberProgressWebviewProvider.showMemberProgress(memberId, memberName);
+        } catch (error) {
+          vscode.window.showErrorMessage(`Failed to show member progress: ${error}`);
+        }
+      }
+    );
   }
 }

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -1219,7 +1219,10 @@ export class LecturerCommands {
           query: { course_id: item.course.id },
           createPayload: { course_id: item.course.id },
           sourceRole: 'lecturer',
-          // Lecturers subscribe to course channel to receive ALL messages including submission groups
+          // Course channel only carries course-scoped messages now — the
+          // hierarchical cascade (submission_group → course) was dropped
+          // along with the single-target invariant. The chat inbox covers
+          // cross-scope live updates via the per-user channel.
           wsChannel: `course:${item.course.id}`
         };
       } else if (item instanceof CourseGroupTreeItem) {

--- a/src/exceptions/error-catalog.json
+++ b/src/exceptions/error-catalog.json
@@ -1,0 +1,1876 @@
+{
+  "version": "1.0.0",
+  "generated_at": "2026-04-28T11:46:47.213693",
+  "error_count": 66,
+  "errors": {
+    "AUTH_001": {
+      "code": "AUTH_001",
+      "http_status": 401,
+      "category": "authentication",
+      "severity": "warning",
+      "title": "Authentication Required",
+      "message": {
+        "plain": "You must be authenticated to access this resource.",
+        "markdown": "**Authentication Required**\n\nYou must be authenticated to access this resource. Please log in and try again.",
+        "html": "<strong>Authentication Required</strong><p>You must be authenticated to access this resource. Please log in and try again.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/authentication",
+      "internal_description": "User attempted to access a protected endpoint without valid authentication credentials",
+      "affected_functions": [
+        "get_current_principal",
+        "verify_token"
+      ],
+      "common_causes": [
+        "Missing or invalid authentication token",
+        "Expired session",
+        "Token not included in request headers"
+      ],
+      "resolution_steps": [
+        "Ensure you are logged in",
+        "Check that the authentication token is included in the Authorization header",
+        "Verify the token has not expired"
+      ]
+    },
+    "AUTH_002": {
+      "code": "AUTH_002",
+      "http_status": 401,
+      "category": "authentication",
+      "severity": "warning",
+      "title": "Invalid Credentials",
+      "message": {
+        "plain": "The username or password provided is incorrect.",
+        "markdown": "**Invalid Credentials**\n\nThe username or password you provided is incorrect. Please check your credentials and try again.",
+        "html": "<strong>Invalid Credentials</strong><p>The username or password you provided is incorrect. Please check your credentials and try again.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/authentication",
+      "internal_description": "User provided incorrect username or password during basic authentication",
+      "affected_functions": [
+        "verify_basic_auth",
+        "authenticate_user"
+      ],
+      "common_causes": [
+        "Incorrect password",
+        "Username does not exist",
+        "Account locked or disabled"
+      ],
+      "resolution_steps": [
+        "Verify your username and password",
+        "Check for typos in credentials",
+        "Contact administrator if account is locked"
+      ]
+    },
+    "AUTH_003": {
+      "code": "AUTH_003",
+      "http_status": 401,
+      "category": "authentication",
+      "severity": "warning",
+      "title": "Token Expired",
+      "message": {
+        "plain": "Your authentication token has expired. Please log in again.",
+        "markdown": "**Token Expired**\n\nYour authentication token has expired. Please log in again to continue.",
+        "html": "<strong>Token Expired</strong><p>Your authentication token has expired. Please log in again to continue.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/authentication#token-refresh",
+      "internal_description": "JWT or session token has expired and needs renewal",
+      "affected_functions": [
+        "verify_token",
+        "decode_jwt"
+      ],
+      "common_causes": [
+        "Session timeout reached",
+        "Token TTL exceeded",
+        "Server time synchronization issues"
+      ],
+      "resolution_steps": [
+        "Log in again to obtain a new token",
+        "Enable auto-refresh if available"
+      ]
+    },
+    "AUTH_004": {
+      "code": "AUTH_004",
+      "http_status": 401,
+      "category": "authentication",
+      "severity": "error",
+      "title": "SSO Authentication Failed",
+      "message": {
+        "plain": "Single Sign-On authentication failed. Please try again or contact support.",
+        "markdown": "**SSO Authentication Failed**\n\nSingle Sign-On authentication failed. Please try again or contact support if the problem persists.",
+        "html": "<strong>SSO Authentication Failed</strong><p>Single Sign-On authentication failed. Please try again or contact support if the problem persists.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/authentication#sso",
+      "internal_description": "Keycloak or other SSO provider authentication failed",
+      "affected_functions": [
+        "sso_callback",
+        "verify_sso_token"
+      ],
+      "common_causes": [
+        "SSO provider is unavailable",
+        "Invalid SSO configuration",
+        "User not authorized in SSO provider"
+      ],
+      "resolution_steps": [
+        "Retry authentication",
+        "Check SSO provider status",
+        "Contact administrator to verify SSO configuration"
+      ]
+    },
+    "AUTHZ_001": {
+      "code": "AUTHZ_001",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "warning",
+      "title": "Insufficient Permissions",
+      "message": {
+        "plain": "You do not have permission to perform this action.",
+        "markdown": "**Insufficient Permissions**\n\nYou do not have the required permissions to perform this action.",
+        "html": "<strong>Insufficient Permissions</strong><p>You do not have the required permissions to perform this action.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/permissions",
+      "internal_description": "User lacks required permissions for the requested operation",
+      "affected_functions": [
+        "check_course_permissions",
+        "check_admin"
+      ],
+      "common_causes": [
+        "User role insufficient for operation",
+        "Course membership missing or insufficient",
+        "Admin privileges required but not granted"
+      ],
+      "resolution_steps": [
+        "Contact course administrator to request appropriate permissions",
+        "Verify you are enrolled in the course with correct role",
+        "Check if admin privileges are required"
+      ]
+    },
+    "AUTHZ_002": {
+      "code": "AUTHZ_002",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "warning",
+      "title": "Admin Access Required",
+      "message": {
+        "plain": "This operation requires administrator privileges.",
+        "markdown": "**Admin Access Required**\n\nThis operation requires administrator privileges. Please contact your system administrator.",
+        "html": "<strong>Admin Access Required</strong><p>This operation requires administrator privileges. Please contact your system administrator.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/permissions#admin",
+      "internal_description": "Operation requires admin role but user is not an admin",
+      "affected_functions": [
+        "check_admin",
+        "require_admin"
+      ],
+      "common_causes": [
+        "User is not an administrator",
+        "Admin role not assigned"
+      ],
+      "resolution_steps": [
+        "Contact system administrator",
+        "Request admin privileges if appropriate"
+      ]
+    },
+    "AUTHZ_003": {
+      "code": "AUTHZ_003",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "warning",
+      "title": "Course Access Denied",
+      "message": {
+        "plain": "You do not have access to this course.",
+        "markdown": "**Course Access Denied**\n\nYou do not have access to this course. Please enroll or contact the course instructor.",
+        "html": "<strong>Course Access Denied</strong><p>You do not have access to this course. Please enroll or contact the course instructor.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/courses#enrollment",
+      "internal_description": "User attempted to access course resources without proper enrollment",
+      "affected_functions": [
+        "check_course_permissions",
+        "get_permitted_course_ids"
+      ],
+      "common_causes": [
+        "Not enrolled in course",
+        "Enrollment pending approval",
+        "Course archived or disabled"
+      ],
+      "resolution_steps": [
+        "Enroll in the course",
+        "Contact course instructor",
+        "Verify course is active"
+      ]
+    },
+    "AUTHZ_004": {
+      "code": "AUTHZ_004",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "warning",
+      "title": "Insufficient Course Role",
+      "message": {
+        "plain": "Your course role is insufficient for this operation.",
+        "markdown": "**Insufficient Course Role**\n\nYour current role in this course does not allow this operation. Required role: {required_role}.",
+        "html": "<strong>Insufficient Course Role</strong><p>Your current role in this course does not allow this operation. Required role: <code>{required_role}</code>.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/permissions#course-roles",
+      "internal_description": "User's course role is below required level for operation",
+      "affected_functions": [
+        "check_course_permissions"
+      ],
+      "common_causes": [
+        "Student trying to perform lecturer action",
+        "Tutor trying to perform maintainer action",
+        "Role hierarchy not satisfied"
+      ],
+      "resolution_steps": [
+        "Contact course administrator to request role upgrade",
+        "Verify operation requirements"
+      ]
+    },
+    "AUTHZ_005": {
+      "code": "AUTHZ_005",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "error",
+      "title": "Role Escalation Denied",
+      "message": {
+        "plain": "You cannot assign a role higher than your own.",
+        "markdown": "**Role Escalation Denied**\n\nYou cannot assign the role '{target_role}'. Your role '{user_role}' can only assign roles at or below your privilege level.",
+        "html": "<strong>Role Escalation Denied</strong><p>You cannot assign the role <code>{target_role}</code>. Your role <code>{user_role}</code> can only assign roles at or below your privilege level.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/permissions#role-assignment",
+      "internal_description": "User attempted to assign a course role higher than their own privilege level",
+      "affected_functions": [
+        "import_course_member",
+        "update_course_member"
+      ],
+      "common_causes": [
+        "Lecturer trying to assign maintainer or owner role",
+        "Tutor trying to assign lecturer role",
+        "Privilege escalation attempt"
+      ],
+      "resolution_steps": [
+        "Request a user with higher privileges to perform this action",
+        "Assign a role at or below your own privilege level"
+      ]
+    },
+    "VAL_001": {
+      "code": "VAL_001",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Invalid Request Data",
+      "message": {
+        "plain": "The request data is invalid or malformed.",
+        "markdown": "**Invalid Request Data**\n\nThe request data you provided is invalid or malformed. Please check your input and try again.",
+        "html": "<strong>Invalid Request Data</strong><p>The request data you provided is invalid or malformed. Please check your input and try again.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/validation",
+      "internal_description": "Request body failed Pydantic validation",
+      "affected_functions": [
+        "parse_request_body",
+        "validate_dto"
+      ],
+      "common_causes": [
+        "Missing required fields",
+        "Invalid data types",
+        "Format constraints violated"
+      ],
+      "resolution_steps": [
+        "Check API documentation for required fields",
+        "Verify data types match schema",
+        "Review validation error details"
+      ]
+    },
+    "VAL_002": {
+      "code": "VAL_002",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Missing Required Field",
+      "message": {
+        "plain": "A required field is missing from the request.",
+        "markdown": "**Missing Required Field**\n\nA required field is missing from your request: `{field_name}`.",
+        "html": "<strong>Missing Required Field</strong><p>A required field is missing from your request: <code>{field_name}</code>.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/validation",
+      "internal_description": "Required field not provided in request",
+      "affected_functions": [
+        "validate_dto"
+      ],
+      "common_causes": [
+        "Field omitted from request body",
+        "Null value provided for required field"
+      ],
+      "resolution_steps": [
+        "Include the required field in request",
+        "Check API documentation for required fields"
+      ]
+    },
+    "VAL_003": {
+      "code": "VAL_003",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Invalid Field Format",
+      "message": {
+        "plain": "A field has an invalid format.",
+        "markdown": "**Invalid Field Format**\n\nThe field `{field_name}` has an invalid format. Expected: {expected_format}.",
+        "html": "<strong>Invalid Field Format</strong><p>The field <code>{field_name}</code> has an invalid format. Expected: <code>{expected_format}</code>.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/validation",
+      "internal_description": "Field value does not match expected format or pattern",
+      "affected_functions": [
+        "validate_email",
+        "validate_uuid",
+        "validate_url"
+      ],
+      "common_causes": [
+        "Invalid email format",
+        "Malformed UUID",
+        "URL format incorrect"
+      ],
+      "resolution_steps": [
+        "Check field format requirements",
+        "Use valid format for the field type"
+      ]
+    },
+    "VAL_004": {
+      "code": "VAL_004",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Invalid File Upload",
+      "message": {
+        "plain": "The uploaded file is invalid or exceeds size limits.",
+        "markdown": "**Invalid File Upload**\n\nThe uploaded file is invalid or exceeds size limits. Maximum size: {max_size}.",
+        "html": "<strong>Invalid File Upload</strong><p>The uploaded file is invalid or exceeds size limits. Maximum size: <code>{max_size}</code>.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/file-uploads",
+      "internal_description": "File upload validation failed",
+      "affected_functions": [
+        "validate_file_upload",
+        "upload_file"
+      ],
+      "common_causes": [
+        "File too large",
+        "Invalid file type",
+        "Corrupted file"
+      ],
+      "resolution_steps": [
+        "Reduce file size",
+        "Use supported file types",
+        "Verify file is not corrupted"
+      ]
+    },
+    "NF_001": {
+      "code": "NF_001",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Resource Not Found",
+      "message": {
+        "plain": "The requested resource was not found.",
+        "markdown": "**Resource Not Found**\n\nThe requested resource was not found. It may have been deleted or the URL is incorrect.",
+        "html": "<strong>Resource Not Found</strong><p>The requested resource was not found. It may have been deleted or the URL is incorrect.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/resources",
+      "internal_description": "Database query returned no results for the requested resource",
+      "affected_functions": [
+        "get_by_id",
+        "query.first()"
+      ],
+      "common_causes": [
+        "Resource deleted",
+        "Invalid ID provided",
+        "Resource archived",
+        "Typo in URL or ID"
+      ],
+      "resolution_steps": [
+        "Verify the resource ID is correct",
+        "Check if resource was deleted",
+        "Review URL for typos"
+      ]
+    },
+    "NF_002": {
+      "code": "NF_002",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "User Not Found",
+      "message": {
+        "plain": "The specified user was not found.",
+        "markdown": "**User Not Found**\n\nThe specified user was not found in the system.",
+        "html": "<strong>User Not Found</strong><p>The specified user was not found in the system.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/users",
+      "internal_description": "User lookup failed - no user with given ID or email",
+      "affected_functions": [
+        "get_user_by_id",
+        "get_user_by_email"
+      ],
+      "common_causes": [
+        "Invalid user ID",
+        "User account deleted",
+        "Email address not registered"
+      ],
+      "resolution_steps": [
+        "Verify user ID or email",
+        "Check if user account exists"
+      ]
+    },
+    "NF_003": {
+      "code": "NF_003",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Course Not Found",
+      "message": {
+        "plain": "The specified course was not found.",
+        "markdown": "**Course Not Found**\n\nThe specified course was not found or you do not have permission to access it.",
+        "html": "<strong>Course Not Found</strong><p>The specified course was not found or you do not have permission to access it.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/courses",
+      "internal_description": "Course lookup failed or user lacks permission to view",
+      "affected_functions": [
+        "get_course_by_id",
+        "check_course_permissions"
+      ],
+      "common_causes": [
+        "Invalid course ID",
+        "Course archived or deleted",
+        "Insufficient permissions to view course"
+      ],
+      "resolution_steps": [
+        "Verify course ID",
+        "Check course enrollment status",
+        "Contact administrator"
+      ]
+    },
+    "NF_004": {
+      "code": "NF_004",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Endpoint Not Found",
+      "message": {
+        "plain": "The requested API endpoint does not exist.",
+        "markdown": "**Endpoint Not Found**\n\nThe requested API endpoint does not exist. Please check the URL and API version.",
+        "html": "<strong>Endpoint Not Found</strong><p>The requested API endpoint does not exist. Please check the URL and API version.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api",
+      "internal_description": "HTTP route not registered in FastAPI application",
+      "affected_functions": [
+        "fastapi_router"
+      ],
+      "common_causes": [
+        "Typo in URL path",
+        "Endpoint deprecated or removed",
+        "Wrong API version",
+        "Wrong HTTP method"
+      ],
+      "resolution_steps": [
+        "Check API documentation for correct endpoint",
+        "Verify API version",
+        "Check HTTP method (GET, POST, etc.)"
+      ]
+    },
+    "CONFLICT_001": {
+      "code": "CONFLICT_001",
+      "http_status": 409,
+      "category": "conflict",
+      "severity": "warning",
+      "title": "Resource Already Exists",
+      "message": {
+        "plain": "A resource with this identifier already exists.",
+        "markdown": "**Resource Already Exists**\n\nA resource with this identifier already exists. Use a different identifier or update the existing resource.",
+        "html": "<strong>Resource Already Exists</strong><p>A resource with this identifier already exists. Use a different identifier or update the existing resource.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/conflicts",
+      "internal_description": "Unique constraint violation - duplicate key",
+      "affected_functions": [
+        "create_entity",
+        "db.add()"
+      ],
+      "common_causes": [
+        "Duplicate email address",
+        "Duplicate name or identifier",
+        "Unique constraint violation"
+      ],
+      "resolution_steps": [
+        "Use a different identifier",
+        "Update existing resource instead",
+        "Check for duplicate entries"
+      ]
+    },
+    "CONFLICT_002": {
+      "code": "CONFLICT_002",
+      "http_status": 409,
+      "category": "conflict",
+      "severity": "warning",
+      "title": "Concurrent Modification",
+      "message": {
+        "plain": "The resource was modified by another user. Please refresh and try again.",
+        "markdown": "**Concurrent Modification**\n\nThe resource was modified by another user. Please refresh and try again.",
+        "html": "<strong>Concurrent Modification</strong><p>The resource was modified by another user. Please refresh and try again.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/concurrency",
+      "internal_description": "Optimistic locking failure - resource modified since read",
+      "affected_functions": [
+        "update_entity",
+        "db.commit()"
+      ],
+      "common_causes": [
+        "Resource updated by another user",
+        "Stale data in request",
+        "Race condition"
+      ],
+      "resolution_steps": [
+        "Refresh resource data",
+        "Retry operation",
+        "Merge changes if appropriate"
+      ]
+    },
+    "RATE_001": {
+      "code": "RATE_001",
+      "http_status": 429,
+      "category": "rate_limit",
+      "severity": "warning",
+      "title": "Rate Limit Exceeded",
+      "message": {
+        "plain": "You have exceeded the rate limit. Please try again later.",
+        "markdown": "**Rate Limit Exceeded**\n\nYou have exceeded the rate limit. Please try again in {retry_after} seconds.",
+        "html": "<strong>Rate Limit Exceeded</strong><p>You have exceeded the rate limit. Please try again in <code>{retry_after}</code> seconds.</p>"
+      },
+      "retry_after": 60,
+      "documentation_url": "/docs/api/rate-limits",
+      "internal_description": "Request rate exceeded configured limits",
+      "affected_functions": [
+        "rate_limit_middleware",
+        "check_rate_limit"
+      ],
+      "common_causes": [
+        "Too many requests in short time",
+        "API abuse",
+        "Missing request throttling"
+      ],
+      "resolution_steps": [
+        "Wait for retry_after period",
+        "Implement request throttling",
+        "Use batch endpoints if available"
+      ]
+    },
+    "RATE_002": {
+      "code": "RATE_002",
+      "http_status": 429,
+      "category": "rate_limit",
+      "severity": "warning",
+      "title": "Login Rate Limit Exceeded",
+      "message": {
+        "plain": "Too many login attempts. Please try again later.",
+        "markdown": "**Login Rate Limit Exceeded**\n\nToo many login attempts for this username. Please wait {retry_after} seconds before trying again.",
+        "html": "<strong>Login Rate Limit Exceeded</strong><p>Too many login attempts for this username. Please wait <code>{retry_after}</code> seconds before trying again.</p>"
+      },
+      "retry_after": 60,
+      "documentation_url": "/docs/authentication#rate-limits",
+      "internal_description": "Username-specific login rate limiting triggered",
+      "affected_functions": [
+        "login_endpoint",
+        "authenticate_user"
+      ],
+      "common_causes": [
+        "Multiple failed login attempts",
+        "Automated login attempts",
+        "Brute force attack"
+      ],
+      "resolution_steps": [
+        "Wait for the retry period (60 seconds)",
+        "Verify correct credentials",
+        "Contact administrator if locked out"
+      ]
+    },
+    "RATE_003": {
+      "code": "RATE_003",
+      "http_status": 429,
+      "category": "rate_limit",
+      "severity": "warning",
+      "title": "Test Request Rate Limit Exceeded",
+      "message": {
+        "plain": "Too many test requests. Please wait before submitting another test.",
+        "markdown": "**Test Request Rate Limit Exceeded**\n\nYou are submitting tests too quickly. Please wait {retry_after} second before trying again.",
+        "html": "<strong>Test Request Rate Limit Exceeded</strong><p>You are submitting tests too quickly. Please wait <code>{retry_after}</code> second before trying again.</p>"
+      },
+      "retry_after": 1,
+      "documentation_url": "/docs/testing#rate-limits",
+      "internal_description": "User-specific test submission rate limiting triggered to prevent abuse",
+      "affected_functions": [
+        "create_test_run",
+        "check_user_rate_limit"
+      ],
+      "common_causes": [
+        "Submitting tests too rapidly",
+        "Automated test submissions",
+        "Multiple concurrent test requests"
+      ],
+      "resolution_steps": [
+        "Wait 1 second between test requests",
+        "Avoid rapid successive test submissions",
+        "Ensure only one test is submitted at a time"
+      ]
+    },
+    "CONTENT_001": {
+      "code": "CONTENT_001",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Course Content Not Found",
+      "message": {
+        "plain": "The requested course content was not found.",
+        "markdown": "**Course Content Not Found**\n\nThe requested course content (assignment, exercise, etc.) was not found or you do not have permission to access it.",
+        "html": "<strong>Course Content Not Found</strong><p>The requested course content was not found or you do not have permission to access it.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/course-content",
+      "internal_description": "Course content lookup failed or user lacks permission",
+      "affected_functions": [
+        "get_course_content",
+        "update_course_content"
+      ],
+      "common_causes": [
+        "Invalid course content ID",
+        "Content archived or deleted",
+        "Insufficient permissions"
+      ],
+      "resolution_steps": [
+        "Verify course content ID",
+        "Check enrollment status",
+        "Contact course instructor"
+      ]
+    },
+    "CONTENT_002": {
+      "code": "CONTENT_002",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "warning",
+      "title": "Content Type Not Configured",
+      "message": {
+        "plain": "The content type for this assignment is not configured.",
+        "markdown": "**Content Type Not Configured**\n\nThe content type for this assignment is not properly configured. Please contact your instructor.",
+        "html": "<strong>Content Type Not Configured</strong><p>The content type for this assignment is not properly configured. Please contact your instructor.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/course-content#types",
+      "internal_description": "CourseContentType missing or misconfigured",
+      "affected_functions": [
+        "get_course_content_type",
+        "validate_content_type"
+      ],
+      "common_causes": [
+        "Content type deleted",
+        "Invalid content type ID",
+        "Database inconsistency"
+      ],
+      "resolution_steps": [
+        "Contact course administrator",
+        "Verify content type configuration"
+      ]
+    },
+    "CONTENT_003": {
+      "code": "CONTENT_003",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Invalid Content Type Operation",
+      "message": {
+        "plain": "This operation is not valid for this content type.",
+        "markdown": "**Invalid Content Type Operation**\n\nThis operation cannot be performed on this content type. For example, you cannot assign examples to non-submittable content.",
+        "html": "<strong>Invalid Content Type Operation</strong><p>This operation cannot be performed on this content type.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/course-content#operations",
+      "internal_description": "Operation not supported for content type (e.g., examples on non-submittable)",
+      "affected_functions": [
+        "assign_examples",
+        "validate_content_operation"
+      ],
+      "common_causes": [
+        "Assigning examples to non-submittable content",
+        "Invalid operation for content kind"
+      ],
+      "resolution_steps": [
+        "Check content type properties",
+        "Use correct operation for content type",
+        "Consult API documentation"
+      ]
+    },
+    "CONTENT_004": {
+      "code": "CONTENT_004",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Example Not Found",
+      "message": {
+        "plain": "The requested example was not found.",
+        "markdown": "**Example Not Found**\n\nThe requested example or example version was not found.",
+        "html": "<strong>Example Not Found</strong><p>The requested example or example version was not found.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/examples",
+      "internal_description": "Example lookup by ID or identifier failed",
+      "affected_functions": [
+        "get_example",
+        "get_example_by_identifier"
+      ],
+      "common_causes": [
+        "Invalid example ID or identifier",
+        "Example deleted",
+        "No matching example"
+      ],
+      "resolution_steps": [
+        "Verify example ID or identifier",
+        "Check if example was deleted"
+      ]
+    },
+    "CONTENT_005": {
+      "code": "CONTENT_005",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Example Version Not Found",
+      "message": {
+        "plain": "The requested example version was not found.",
+        "markdown": "**Example Version Not Found**\n\nThe requested version of this example was not found. It may not exist or may have been deleted.",
+        "html": "<strong>Example Version Not Found</strong><p>The requested version of this example was not found.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/examples#versions",
+      "internal_description": "Example version lookup failed - no version with given tag/ID",
+      "affected_functions": [
+        "get_example_version",
+        "get_version_by_tag"
+      ],
+      "common_causes": [
+        "Invalid version tag",
+        "No versions exist",
+        "Version deleted"
+      ],
+      "resolution_steps": [
+        "Verify version tag",
+        "Check available versions",
+        "Use 'latest' for most recent version"
+      ]
+    },
+    "CONTENT_006": {
+      "code": "CONTENT_006",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Deletion Blocked by Student Submissions",
+      "message": {
+        "plain": "Cannot delete this course content because students have already submitted work. Use archive instead.",
+        "markdown": "**Deletion Blocked**\n\nThis course content cannot be deleted because students have already submitted work. Use **archive** instead to hide the content while preserving student data.",
+        "html": "<strong>Deletion Blocked</strong><p>This course content cannot be deleted because students have already submitted work. Use <em>archive</em> instead to hide the content while preserving student data.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": null,
+      "internal_description": "Attempted to delete a course content that has SubmissionArtifacts linked via its SubmissionGroups",
+      "affected_functions": [
+        "_validate_course_content_deletion",
+        "delete_entity"
+      ],
+      "common_causes": [
+        "Students have submitted work for this assignment",
+        "Content is part of a running course"
+      ],
+      "resolution_steps": [
+        "Use archive instead of delete to preserve student data",
+        "If deletion is truly required, remove all submission artifacts first"
+      ]
+    },
+    "CONTENT_007": {
+      "code": "CONTENT_007",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Deletion Blocked by Descendant Submissions",
+      "message": {
+        "plain": "Cannot delete this course content because descendant items have student submissions. Use archive instead.",
+        "markdown": "**Deletion Blocked**\n\nThis course content cannot be deleted because it contains descendant items with student submissions. Use **archive** instead to hide the content while preserving student data.",
+        "html": "<strong>Deletion Blocked</strong><p>This course content cannot be deleted because it contains descendant items with student submissions. Use <em>archive</em> instead to hide the content while preserving student data.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": null,
+      "internal_description": "Attempted to delete a course content whose Ltree descendants have SubmissionArtifacts",
+      "affected_functions": [
+        "_validate_course_content_deletion",
+        "delete_entity"
+      ],
+      "common_causes": [
+        "Child assignments have student submissions",
+        "Content hierarchy includes active assignments"
+      ],
+      "resolution_steps": [
+        "Use archive instead of delete to preserve student data",
+        "If deletion is truly required, archive or remove descendant submissions first"
+      ]
+    },
+    "VERSION_001": {
+      "code": "VERSION_001",
+      "http_status": 409,
+      "category": "conflict",
+      "severity": "warning",
+      "title": "Example Version Already Exists",
+      "message": {
+        "plain": "This version already exists for this example.",
+        "markdown": "**Example Version Already Exists**\n\nVersion `{version_tag}` already exists for this example. To update it, set `update_existing: true` in meta.yaml or use a different version tag.",
+        "html": "<strong>Example Version Already Exists</strong><p>Version <code>{version_tag}</code> already exists for this example. To update it, set <code>update_existing: true</code> in meta.yaml or use a different version tag.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/examples#version-management",
+      "internal_description": "User attempted to create an example version that already exists without setting update_existing flag",
+      "affected_functions": [
+        "create_example_version",
+        "upload_example"
+      ],
+      "common_causes": [
+        "Version tag already used",
+        "Attempting to recreate existing version",
+        "Missing update_existing flag in meta.yaml"
+      ],
+      "resolution_steps": [
+        "Set 'update_existing: true' in meta.yaml to update the existing version",
+        "Use a different version tag (e.g., increment version number)",
+        "Check existing versions before creating new ones"
+      ]
+    },
+    "DEPLOY_001": {
+      "code": "DEPLOY_001",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "warning",
+      "title": "Assignment Not Released",
+      "message": {
+        "plain": "This assignment has not been released yet.",
+        "markdown": "**Assignment Not Released**\n\nThis assignment has not been released to students yet. Please wait for your instructor to release it.",
+        "html": "<strong>Assignment Not Released</strong><p>This assignment has not been released to students yet.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/assignments#deployment",
+      "internal_description": "CourseContentDeployment not found or not yet deployed",
+      "affected_functions": [
+        "get_deployment",
+        "check_deployment_status"
+      ],
+      "common_causes": [
+        "Assignment not yet deployed",
+        "Deployment pending",
+        "Deployment deleted"
+      ],
+      "resolution_steps": [
+        "Wait for instructor to release assignment",
+        "Contact instructor for release date"
+      ]
+    },
+    "DEPLOY_002": {
+      "code": "DEPLOY_002",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Deployment Not Found",
+      "message": {
+        "plain": "The requested deployment was not found.",
+        "markdown": "**Deployment Not Found**\n\nThe requested deployment configuration was not found.",
+        "html": "<strong>Deployment Not Found</strong><p>The requested deployment configuration was not found.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/deployments",
+      "internal_description": "Deployment lookup by ID failed",
+      "affected_functions": [
+        "get_deployment_by_id"
+      ],
+      "common_causes": [
+        "Invalid deployment ID",
+        "Deployment deleted"
+      ],
+      "resolution_steps": [
+        "Verify deployment ID",
+        "Check deployment status"
+      ]
+    },
+    "DEPLOY_003": {
+      "code": "DEPLOY_003",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "error",
+      "title": "Repository Not Configured",
+      "message": {
+        "plain": "The GitLab repository is not configured for this resource.",
+        "markdown": "**Repository Not Configured**\n\nThe GitLab repository has not been configured. Please contact your administrator.",
+        "html": "<strong>Repository Not Configured</strong><p>The GitLab repository has not been configured. Please contact your administrator.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/integrations/gitlab#configuration",
+      "internal_description": "GitLab repository configuration missing from properties",
+      "affected_functions": [
+        "validate_gitlab_config",
+        "get_repository_config"
+      ],
+      "common_causes": [
+        "Organization GitLab not configured",
+        "Course repository not created",
+        "Student repository not initialized"
+      ],
+      "resolution_steps": [
+        "Contact administrator to configure GitLab",
+        "Verify organization settings",
+        "Wait for repository creation workflow"
+      ]
+    },
+    "DEPLOY_004": {
+      "code": "DEPLOY_004",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Missing Deployment Information",
+      "message": {
+        "plain": "Required deployment information is missing.",
+        "markdown": "**Missing Deployment Information**\n\nRequired deployment information (path, version, etc.) is missing. The assignment may not be properly configured.",
+        "html": "<strong>Missing Deployment Information</strong><p>Required deployment information is missing.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/assignments#deployment",
+      "internal_description": "Deployment missing required fields (deployment_path, version_identifier)",
+      "affected_functions": [
+        "validate_deployment",
+        "create_test_run"
+      ],
+      "common_causes": [
+        "Incomplete deployment configuration",
+        "Missing version identifier",
+        "Missing deployment path"
+      ],
+      "resolution_steps": [
+        "Contact instructor",
+        "Wait for proper deployment"
+      ]
+    },
+    "DEPLOY_005": {
+      "code": "DEPLOY_005",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "error",
+      "title": "Duplicate Example in Course",
+      "message": {
+        "plain": "This example is already assigned to another content item in this course.",
+        "markdown": "**Duplicate Example in Course**\n\nThis example is already assigned to another content item in this course. Each example can only be assigned once per course, regardless of version.",
+        "html": "<strong>Duplicate Example in Course</strong><p>This example is already assigned to another content item in this course. Each example can only be assigned once per course, regardless of version.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/assignments#deployment",
+      "internal_description": "Attempted to assign an example that is already deployed to another course content in the same course",
+      "affected_functions": [
+        "assign_example_to_content",
+        "batch_validate_content"
+      ],
+      "common_causes": [
+        "Example already assigned to a different assignment in the same course",
+        "Attempting to assign a different version of an already-used example"
+      ],
+      "resolution_steps": [
+        "Use a different example for this assignment",
+        "Unassign the example from the other content first"
+      ]
+    },
+    "SUBMIT_001": {
+      "code": "SUBMIT_001",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Submission Artifact Not Found",
+      "message": {
+        "plain": "The requested submission artifact was not found.",
+        "markdown": "**Submission Artifact Not Found**\n\nThe requested submission artifact was not found. You may need to submit first.",
+        "html": "<strong>Submission Artifact Not Found</strong><p>The requested submission artifact was not found.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/submissions",
+      "internal_description": "SubmissionArtifact lookup failed",
+      "affected_functions": [
+        "get_submission_artifact",
+        "create_test_run"
+      ],
+      "common_causes": [
+        "Invalid artifact ID",
+        "No submission made yet",
+        "Artifact deleted"
+      ],
+      "resolution_steps": [
+        "Verify artifact ID",
+        "Check if submission was made",
+        "Submit assignment first"
+      ]
+    },
+    "SUBMIT_002": {
+      "code": "SUBMIT_002",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Submission Group Not Found",
+      "message": {
+        "plain": "The requested submission group was not found.",
+        "markdown": "**Submission Group Not Found**\n\nThe requested submission group was not found or you do not have access to it.",
+        "html": "<strong>Submission Group Not Found</strong><p>The requested submission group was not found or you do not have access to it.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/assignments#groups",
+      "internal_description": "SubmissionGroup lookup failed or permission denied",
+      "affected_functions": [
+        "get_submission_group",
+        "check_group_membership"
+      ],
+      "common_causes": [
+        "Invalid submission group ID",
+        "Not a member of group",
+        "Group deleted"
+      ],
+      "resolution_steps": [
+        "Verify submission group ID",
+        "Check group membership",
+        "Contact instructor"
+      ]
+    },
+    "SUBMIT_003": {
+      "code": "SUBMIT_003",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Test Already Running",
+      "message": {
+        "plain": "A test is already running for this submission.",
+        "markdown": "**Test Already Running**\n\nA test is already running for this submission. Please wait for it to complete before starting another test.",
+        "html": "<strong>Test Already Running</strong><p>A test is already running for this submission.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/testing#status",
+      "internal_description": "Duplicate test attempt while existing test still running",
+      "affected_functions": [
+        "create_test_run",
+        "check_existing_test"
+      ],
+      "common_causes": [
+        "Multiple test requests",
+        "Test already in progress"
+      ],
+      "resolution_steps": [
+        "Wait for current test to complete",
+        "Check test status"
+      ]
+    },
+    "SUBMIT_004": {
+      "code": "SUBMIT_004",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Maximum Test Runs Exceeded",
+      "message": {
+        "plain": "You have reached the maximum number of test runs for this submission.",
+        "markdown": "**Maximum Test Runs Exceeded**\n\nYou have reached the maximum number of test runs allowed for this submission.",
+        "html": "<strong>Maximum Test Runs Exceeded</strong><p>You have reached the maximum number of test runs allowed.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/testing#limits",
+      "internal_description": "Submission group max_test_runs limit reached",
+      "affected_functions": [
+        "create_test_run",
+        "check_test_limit"
+      ],
+      "common_causes": [
+        "Test limit configured on assignment",
+        "Too many test attempts"
+      ],
+      "resolution_steps": [
+        "Review previous test results",
+        "Contact instructor for additional test runs"
+      ]
+    },
+    "SUBMIT_005": {
+      "code": "SUBMIT_005",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Execution Backend Not Configured",
+      "message": {
+        "plain": "The execution backend for this assignment is not configured.",
+        "markdown": "**Execution Backend Not Configured**\n\nThe execution backend for this assignment is not properly configured. Please contact your instructor.",
+        "html": "<strong>Execution Backend Not Configured</strong><p>The execution backend is not configured.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/testing#backends",
+      "internal_description": "CourseContent missing execution_backend_id or ExecutionBackend not found",
+      "affected_functions": [
+        "create_test_run",
+        "validate_execution_backend"
+      ],
+      "common_causes": [
+        "Execution backend not assigned",
+        "Backend deleted or misconfigured"
+      ],
+      "resolution_steps": [
+        "Contact instructor",
+        "Verify assignment configuration"
+      ]
+    },
+    "SUBMIT_006": {
+      "code": "SUBMIT_006",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Version Identifier Required",
+      "message": {
+        "plain": "A version identifier (commit) is required for testing.",
+        "markdown": "**Version Identifier Required**\n\nA version identifier (commit hash) is required to test your submission. Please ensure your submission includes version information.",
+        "html": "<strong>Version Identifier Required</strong><p>A version identifier is required for testing.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/testing#versioning",
+      "internal_description": "No version_identifier found in artifact or request",
+      "affected_functions": [
+        "create_test_run",
+        "validate_version"
+      ],
+      "common_causes": [
+        "Missing commit information",
+        "Artifact missing version_identifier"
+      ],
+      "resolution_steps": [
+        "Submit with proper version information",
+        "Contact administrator"
+      ]
+    },
+    "SUBMIT_007": {
+      "code": "SUBMIT_007",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Test Identifier Required",
+      "message": {
+        "plain": "You must provide either an artifact ID or submission group ID to test.",
+        "markdown": "**Test Identifier Required**\n\nYou must provide either an artifact ID or submission group ID to identify what to test.",
+        "html": "<strong>Test Identifier Required</strong><p>You must provide an identifier for what to test.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/testing",
+      "internal_description": "Neither artifact_id nor submission_group_id provided in request",
+      "affected_functions": [
+        "create_test_run"
+      ],
+      "common_causes": [
+        "Missing required parameters",
+        "Invalid test request"
+      ],
+      "resolution_steps": [
+        "Provide artifact_id or submission_group_id",
+        "Check API documentation"
+      ]
+    },
+    "SUBMIT_008": {
+      "code": "SUBMIT_008",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Artifact Already Tested",
+      "message": {
+        "plain": "You have already tested this artifact. Multiple tests are not allowed unless the previous test crashed or was cancelled.",
+        "markdown": "**Artifact Already Tested**\n\nYou have already successfully tested this artifact. Multiple tests are not allowed unless the previous test crashed or was cancelled.",
+        "html": "<strong>Artifact Already Tested</strong><p>You have already tested this artifact. Multiple tests are not allowed unless the previous test crashed or was cancelled.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/testing#duplicate-tests",
+      "internal_description": "User attempted to test an artifact that already has a successful test result",
+      "affected_functions": [
+        "create_test_run",
+        "check_existing_test"
+      ],
+      "common_causes": [
+        "Duplicate test attempt",
+        "Previous test completed successfully"
+      ],
+      "resolution_steps": [
+        "Review your previous test results",
+        "Submit a new version if you need to test again",
+        "Contact instructor if test needs to be reset"
+      ]
+    },
+    "TASK_001": {
+      "code": "TASK_001",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Task Not Found",
+      "message": {
+        "plain": "The requested task execution was not found.",
+        "markdown": "**Task Not Found**\n\nThe requested task execution was not found or you do not have permission to view it.",
+        "html": "<strong>Task Not Found</strong><p>The requested task execution was not found.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/api/tasks",
+      "internal_description": "Result (task execution) lookup failed",
+      "affected_functions": [
+        "get_test_status",
+        "get_task_result"
+      ],
+      "common_causes": [
+        "Invalid task/result ID",
+        "Task deleted",
+        "Permission denied"
+      ],
+      "resolution_steps": [
+        "Verify task ID",
+        "Check task history",
+        "Verify permissions"
+      ]
+    },
+    "TASK_002": {
+      "code": "TASK_002",
+      "http_status": 500,
+      "category": "internal",
+      "severity": "error",
+      "title": "Task Submission Failed",
+      "message": {
+        "plain": "Failed to submit the task for execution.",
+        "markdown": "**Task Submission Failed**\n\nFailed to submit the task to the execution system. Please try again or contact support.",
+        "html": "<strong>Task Submission Failed</strong><p>Failed to submit the task for execution.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/workflows#troubleshooting",
+      "internal_description": "Temporal workflow submission failed",
+      "affected_functions": [
+        "task_executor.submit_task",
+        "create_test_run"
+      ],
+      "common_causes": [
+        "Temporal service unavailable",
+        "Invalid workflow parameters",
+        "Network error"
+      ],
+      "resolution_steps": [
+        "Retry operation",
+        "Check Temporal service status",
+        "Contact administrator"
+      ]
+    },
+    "TASK_003": {
+      "code": "TASK_003",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Unsupported Execution Backend",
+      "message": {
+        "plain": "The execution backend type is not supported.",
+        "markdown": "**Unsupported Execution Backend**\n\nThe execution backend type configured for this assignment is not supported.",
+        "html": "<strong>Unsupported Execution Backend</strong><p>The execution backend type is not supported.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/testing#backends",
+      "internal_description": "ExecutionBackend.type not recognized or supported",
+      "affected_functions": [
+        "create_test_run",
+        "validate_backend_type"
+      ],
+      "common_causes": [
+        "Invalid backend type configuration",
+        "Backend not implemented"
+      ],
+      "resolution_steps": [
+        "Contact administrator",
+        "Verify backend configuration"
+      ]
+    },
+    "TASK_004": {
+      "code": "TASK_004",
+      "http_status": 404,
+      "category": "not_found",
+      "severity": "info",
+      "title": "Course Membership Not Found",
+      "message": {
+        "plain": "You are not a member of this course.",
+        "markdown": "**Course Membership Not Found**\n\nYou are not enrolled as a member of this course.",
+        "html": "<strong>Course Membership Not Found</strong><p>You are not enrolled in this course.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/courses#enrollment",
+      "internal_description": "CourseMember lookup failed for user and course",
+      "affected_functions": [
+        "get_course_member",
+        "check_course_membership"
+      ],
+      "common_causes": [
+        "Not enrolled in course",
+        "Enrollment pending",
+        "Enrollment removed"
+      ],
+      "resolution_steps": [
+        "Enroll in the course",
+        "Contact instructor",
+        "Check enrollment status"
+      ]
+    },
+    "GITLAB_001": {
+      "code": "GITLAB_001",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "GitLab Not Configured",
+      "message": {
+        "plain": "GitLab integration is not configured for this course.",
+        "markdown": "**GitLab Not Configured**\n\nGitLab integration has not been set up for this course. Please contact your instructor.",
+        "html": "<strong>GitLab Not Configured</strong><p>GitLab integration has not been set up for this course. Please contact your instructor.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/integrations/gitlab",
+      "internal_description": "Course organization does not have GitLab provider configured",
+      "affected_functions": [
+        "validate_user_course",
+        "register_user_course_account"
+      ],
+      "common_causes": [
+        "Organization missing GitLab URL",
+        "GitLab integration not enabled",
+        "Course not configured for GitLab"
+      ],
+      "resolution_steps": [
+        "Contact course administrator",
+        "Verify course supports GitLab integration"
+      ]
+    },
+    "GITLAB_002": {
+      "code": "GITLAB_002",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "info",
+      "title": "GitLab Account Not Registered",
+      "message": {
+        "plain": "You have not registered your GitLab account for this course.",
+        "markdown": "**GitLab Account Not Registered**\n\nYou need to register your GitLab account to access course repositories. Please register via `/user/courses/{course_id}/register`.",
+        "html": "<strong>GitLab Account Not Registered</strong><p>You need to register your GitLab account to access course repositories.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/integrations/gitlab#registration",
+      "internal_description": "User has not linked GitLab account via Account table",
+      "affected_functions": [
+        "validate_user_course"
+      ],
+      "common_causes": [
+        "First time accessing course",
+        "Account not yet linked"
+      ],
+      "resolution_steps": [
+        "Register your GitLab username and access token",
+        "Use POST /user/courses/{course_id}/register endpoint"
+      ]
+    },
+    "GITLAB_003": {
+      "code": "GITLAB_003",
+      "http_status": 401,
+      "category": "authentication",
+      "severity": "warning",
+      "title": "GitLab Token Mismatch",
+      "message": {
+        "plain": "The GitLab access token does not match your registered account.",
+        "markdown": "**GitLab Token Mismatch**\n\nThe access token you provided belongs to GitLab user `{actual_username}`, but your registered account is `{expected_username}`.",
+        "html": "<strong>GitLab Token Mismatch</strong><p>The access token belongs to a different GitLab user than your registered account.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/integrations/gitlab#tokens",
+      "internal_description": "GitLab /user endpoint returned different username than Account.provider_account_id",
+      "affected_functions": [
+        "validate_user_course",
+        "register_user_course_account"
+      ],
+      "common_causes": [
+        "Using wrong personal access token",
+        "Token belongs to different GitLab user",
+        "Multiple GitLab accounts"
+      ],
+      "resolution_steps": [
+        "Use token from your registered GitLab account",
+        "Verify token username matches registered username",
+        "Re-register with correct account if needed"
+      ]
+    },
+    "GITLAB_004": {
+      "code": "GITLAB_004",
+      "http_status": 409,
+      "category": "conflict",
+      "severity": "warning",
+      "title": "GitLab Account Already Linked",
+      "message": {
+        "plain": "This GitLab username is already linked to another user.",
+        "markdown": "**GitLab Account Already Linked**\n\nThe GitLab username `{username}` is already linked to another user account in this course.",
+        "html": "<strong>GitLab Account Already Linked</strong><p>This GitLab username is already linked to another user account.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/integrations/gitlab#registration",
+      "internal_description": "Account table constraint violation - provider_account_id already exists for different user",
+      "affected_functions": [
+        "register_user_course_account"
+      ],
+      "common_causes": [
+        "GitLab username already registered by another student",
+        "Duplicate registration attempt",
+        "Shared GitLab account (not allowed)"
+      ],
+      "resolution_steps": [
+        "Use a different GitLab username",
+        "Contact administrator if this is an error",
+        "Ensure each student uses their own GitLab account"
+      ]
+    },
+    "GITLAB_005": {
+      "code": "GITLAB_005",
+      "http_status": 401,
+      "category": "authentication",
+      "severity": "warning",
+      "title": "GitLab Token Required",
+      "message": {
+        "plain": "A GitLab personal access token is required for this operation.",
+        "markdown": "**GitLab Token Required**\n\nPlease provide your GitLab personal access token to register or validate your account. The token must have `api` scope.",
+        "html": "<strong>GitLab Token Required</strong><p>Please provide your GitLab personal access token with <code>api</code> scope.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/integrations/gitlab#tokens",
+      "internal_description": "GitLab access token missing from request when required",
+      "affected_functions": [
+        "validate_user_course",
+        "register_user_course_account"
+      ],
+      "common_causes": [
+        "Token field empty or null",
+        "Request missing provider_access_token field"
+      ],
+      "resolution_steps": [
+        "Generate GitLab personal access token with api scope",
+        "Include token in request payload",
+        "Verify token is not expired"
+      ]
+    },
+    "GITLAB_006": {
+      "code": "GITLAB_006",
+      "http_status": 502,
+      "category": "external_service",
+      "severity": "error",
+      "title": "GitLab Token Invalid",
+      "message": {
+        "plain": "The GitLab access token is invalid or has been revoked.",
+        "markdown": "**GitLab Token Invalid**\n\nThe GitLab access token you provided is invalid, expired, or has been revoked. Please generate a new token with `api` scope.",
+        "html": "<strong>GitLab Token Invalid</strong><p>The GitLab access token is invalid, expired, or revoked. Please generate a new token.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/integrations/gitlab#tokens",
+      "internal_description": "GitLab API returned 401/403 when validating token via /user endpoint",
+      "affected_functions": [
+        "_fetch_gitlab_user_profile"
+      ],
+      "common_causes": [
+        "Token expired",
+        "Token revoked or deleted",
+        "Token missing required scopes (api)",
+        "Token belongs to deleted GitLab user"
+      ],
+      "resolution_steps": [
+        "Generate new GitLab personal access token",
+        "Ensure token has api scope",
+        "Re-register with new token"
+      ]
+    },
+    "GITLAB_007": {
+      "code": "GITLAB_007",
+      "http_status": 503,
+      "category": "external_service",
+      "severity": "error",
+      "title": "GitLab API Unreachable",
+      "message": {
+        "plain": "Unable to connect to GitLab API. Please try again later.",
+        "markdown": "**GitLab API Unreachable**\n\nUnable to connect to the GitLab API to verify your account. Please try again later.",
+        "html": "<strong>GitLab API Unreachable</strong><p>Unable to connect to GitLab. Please try again later.</p>"
+      },
+      "retry_after": 60,
+      "documentation_url": "/docs/integrations/gitlab",
+      "internal_description": "Network error or timeout when calling GitLab API",
+      "affected_functions": [
+        "_fetch_gitlab_user_profile"
+      ],
+      "common_causes": [
+        "GitLab server temporarily down",
+        "Network connectivity issues",
+        "DNS resolution failure",
+        "Firewall blocking request"
+      ],
+      "resolution_steps": [
+        "Wait and retry in a few moments",
+        "Check GitLab service status",
+        "Contact administrator if persists"
+      ]
+    },
+    "GITLAB_008": {
+      "code": "GITLAB_008",
+      "http_status": 400,
+      "category": "validation",
+      "severity": "warning",
+      "title": "Invalid GitLab Username",
+      "message": {
+        "plain": "The GitLab username format is invalid.",
+        "markdown": "**Invalid GitLab Username**\n\nThe provided GitLab username is empty or has invalid format. Please provide a valid GitLab username.",
+        "html": "<strong>Invalid GitLab Username</strong><p>Please provide a valid GitLab username.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/integrations/gitlab#registration",
+      "internal_description": "Provider account ID is empty or whitespace-only",
+      "affected_functions": [
+        "register_user_course_account"
+      ],
+      "common_causes": [
+        "Empty username field",
+        "Whitespace-only username",
+        "Missing provider_account_id"
+      ],
+      "resolution_steps": [
+        "Provide your GitLab username",
+        "Verify username is not empty"
+      ]
+    },
+    "EXT_001": {
+      "code": "EXT_001",
+      "http_status": 503,
+      "category": "external_service",
+      "severity": "error",
+      "title": "GitLab Service Unavailable",
+      "message": {
+        "plain": "GitLab service is temporarily unavailable.",
+        "markdown": "**GitLab Service Unavailable**\n\nThe GitLab service is temporarily unavailable. Please try again later.",
+        "html": "<strong>GitLab Service Unavailable</strong><p>The GitLab service is temporarily unavailable. Please try again later.</p>"
+      },
+      "retry_after": 300,
+      "documentation_url": "/docs/integrations/gitlab",
+      "internal_description": "GitLab API request failed or timed out",
+      "affected_functions": [
+        "gitlab_client.request",
+        "create_gitlab_group",
+        "create_gitlab_repository"
+      ],
+      "common_causes": [
+        "GitLab server down",
+        "Network connectivity issues",
+        "GitLab API rate limiting"
+      ],
+      "resolution_steps": [
+        "Wait and retry",
+        "Check GitLab status page",
+        "Verify network connectivity"
+      ]
+    },
+    "EXT_002": {
+      "code": "EXT_002",
+      "http_status": 502,
+      "category": "external_service",
+      "severity": "error",
+      "title": "GitLab Authentication Failed",
+      "message": {
+        "plain": "Failed to authenticate with GitLab.",
+        "markdown": "**GitLab Authentication Failed**\n\nFailed to authenticate with GitLab. Please check API token configuration.",
+        "html": "<strong>GitLab Authentication Failed</strong><p>Failed to authenticate with GitLab. Please check API token configuration.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/integrations/gitlab#authentication",
+      "internal_description": "GitLab API token invalid or expired",
+      "affected_functions": [
+        "gitlab_client.authenticate"
+      ],
+      "common_causes": [
+        "Invalid GitLab token",
+        "Token expired",
+        "Insufficient token permissions"
+      ],
+      "resolution_steps": [
+        "Verify GitLab token is valid",
+        "Check token permissions",
+        "Generate new token if needed"
+      ]
+    },
+    "EXT_003": {
+      "code": "EXT_003",
+      "http_status": 503,
+      "category": "external_service",
+      "severity": "error",
+      "title": "MinIO Service Unavailable",
+      "message": {
+        "plain": "Object storage service is temporarily unavailable.",
+        "markdown": "**MinIO Service Unavailable**\n\nThe object storage service is temporarily unavailable. Please try again later.",
+        "html": "<strong>MinIO Service Unavailable</strong><p>The object storage service is temporarily unavailable. Please try again later.</p>"
+      },
+      "retry_after": 60,
+      "documentation_url": "/docs/storage",
+      "internal_description": "MinIO/S3 service connection failed",
+      "affected_functions": [
+        "storage_service.upload_file",
+        "storage_service.download_file"
+      ],
+      "common_causes": [
+        "MinIO server down",
+        "Network issues",
+        "Storage quota exceeded"
+      ],
+      "resolution_steps": [
+        "Retry operation",
+        "Check MinIO service status",
+        "Verify storage quota"
+      ]
+    },
+    "EXT_004": {
+      "code": "EXT_004",
+      "http_status": 503,
+      "category": "external_service",
+      "severity": "error",
+      "title": "Temporal Service Unavailable",
+      "message": {
+        "plain": "Workflow service is temporarily unavailable.",
+        "markdown": "**Temporal Service Unavailable**\n\nThe workflow orchestration service is temporarily unavailable. Please try again later.",
+        "html": "<strong>Temporal Service Unavailable</strong><p>The workflow orchestration service is temporarily unavailable. Please try again later.</p>"
+      },
+      "retry_after": 120,
+      "documentation_url": "/docs/workflows",
+      "internal_description": "Temporal server connection failed",
+      "affected_functions": [
+        "task_executor.submit_task",
+        "temporal_client.connect"
+      ],
+      "common_causes": [
+        "Temporal server down",
+        "Network connectivity issues",
+        "Worker not running"
+      ],
+      "resolution_steps": [
+        "Check Temporal server status",
+        "Verify worker is running",
+        "Retry operation"
+      ]
+    },
+    "EXT_005": {
+      "code": "EXT_005",
+      "http_status": 503,
+      "category": "external_service",
+      "severity": "error",
+      "title": "Task Queue Unavailable",
+      "message": {
+        "plain": "No worker available for the specified task queue.",
+        "markdown": "**Task Queue Unavailable**\n\nNo worker is available to process tasks on the specified queue. The testing service may be misconfigured or the worker is not running.",
+        "html": "<strong>Task Queue Unavailable</strong><p>No worker is available to process tasks on the specified queue. The testing service may be misconfigured or the worker is not running.</p>"
+      },
+      "retry_after": 120,
+      "documentation_url": "/docs/testing-services",
+      "internal_description": "Temporal task queue has no available workers or queue configuration is invalid",
+      "affected_functions": [
+        "create_test_run",
+        "submit_task"
+      ],
+      "common_causes": [
+        "Service configuration missing 'temporal.task_queue' setting",
+        "Task queue name incorrectly configured (not nested under 'temporal')",
+        "Worker not running for the specified queue",
+        "Temporal service unavailable"
+      ],
+      "resolution_steps": [
+        "Verify service configuration includes 'temporal.task_queue' setting",
+        "Ensure configuration follows the correct structure: {\"temporal\": {\"task_queue\": \"queue-name\"}}",
+        "Check that a worker is running for the specified task queue",
+        "Contact administrator to verify testing service setup"
+      ]
+    },
+    "DB_001": {
+      "code": "DB_001",
+      "http_status": 503,
+      "category": "database",
+      "severity": "critical",
+      "title": "Database Connection Failed",
+      "message": {
+        "plain": "Unable to connect to the database.",
+        "markdown": "**Database Connection Failed**\n\nUnable to connect to the database. The service is temporarily unavailable.",
+        "html": "<strong>Database Connection Failed</strong><p>Unable to connect to the database. The service is temporarily unavailable.</p>"
+      },
+      "retry_after": 120,
+      "documentation_url": "/docs/database",
+      "internal_description": "PostgreSQL connection failed or timed out",
+      "affected_functions": [
+        "get_db",
+        "database.connect"
+      ],
+      "common_causes": [
+        "Database server down",
+        "Connection pool exhausted",
+        "Network issues",
+        "Invalid credentials"
+      ],
+      "resolution_steps": [
+        "Check database server status",
+        "Verify database credentials",
+        "Check connection pool settings"
+      ]
+    },
+    "DB_002": {
+      "code": "DB_002",
+      "http_status": 500,
+      "category": "database",
+      "severity": "error",
+      "title": "Database Query Failed",
+      "message": {
+        "plain": "A database query failed. Please try again.",
+        "markdown": "**Database Query Failed**\n\nA database query failed. Please try again or contact support if the problem persists.",
+        "html": "<strong>Database Query Failed</strong><p>A database query failed. Please try again or contact support if the problem persists.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/database",
+      "internal_description": "SQL query execution failed",
+      "affected_functions": [
+        "db.query()",
+        "db.execute()"
+      ],
+      "common_causes": [
+        "SQL syntax error",
+        "Constraint violation",
+        "Database timeout"
+      ],
+      "resolution_steps": [
+        "Retry operation",
+        "Check query parameters",
+        "Contact administrator"
+      ]
+    },
+    "DB_003": {
+      "code": "DB_003",
+      "http_status": 500,
+      "category": "database",
+      "severity": "error",
+      "title": "Transaction Failed",
+      "message": {
+        "plain": "Database transaction failed and was rolled back.",
+        "markdown": "**Transaction Failed**\n\nThe database transaction failed and was rolled back. No changes were made.",
+        "html": "<strong>Transaction Failed</strong><p>The database transaction failed and was rolled back. No changes were made.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/database#transactions",
+      "internal_description": "Database commit failed, transaction rolled back",
+      "affected_functions": [
+        "db.commit()"
+      ],
+      "common_causes": [
+        "Constraint violation",
+        "Deadlock",
+        "Connection lost during transaction"
+      ],
+      "resolution_steps": [
+        "Retry operation",
+        "Check for conflicting updates",
+        "Verify data integrity"
+      ]
+    },
+    "INT_001": {
+      "code": "INT_001",
+      "http_status": 500,
+      "category": "internal",
+      "severity": "critical",
+      "title": "Internal Server Error",
+      "message": {
+        "plain": "An unexpected error occurred. Please try again later.",
+        "markdown": "**Internal Server Error**\n\nAn unexpected error occurred. Please try again later or contact support.",
+        "html": "<strong>Internal Server Error</strong><p>An unexpected error occurred. Please try again later or contact support.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/support",
+      "internal_description": "Unhandled exception or unexpected error condition",
+      "affected_functions": [
+        "generic_handler"
+      ],
+      "common_causes": [
+        "Unhandled exception",
+        "Bug in code",
+        "Resource exhaustion"
+      ],
+      "resolution_steps": [
+        "Retry operation",
+        "Contact support with error details",
+        "Check server logs"
+      ]
+    },
+    "INT_002": {
+      "code": "INT_002",
+      "http_status": 500,
+      "category": "internal",
+      "severity": "critical",
+      "title": "Configuration Error",
+      "message": {
+        "plain": "Server configuration error. Please contact administrator.",
+        "markdown": "**Configuration Error**\n\nA server configuration error occurred. Please contact your administrator.",
+        "html": "<strong>Configuration Error</strong><p>A server configuration error occurred. Please contact your administrator.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/configuration",
+      "internal_description": "Invalid or missing configuration settings",
+      "affected_functions": [
+        "load_settings",
+        "initialize_service"
+      ],
+      "common_causes": [
+        "Missing environment variables",
+        "Invalid configuration values",
+        "Service misconfiguration"
+      ],
+      "resolution_steps": [
+        "Contact administrator",
+        "Check server configuration",
+        "Verify environment variables"
+      ]
+    },
+    "NIMPL_001": {
+      "code": "NIMPL_001",
+      "http_status": 501,
+      "category": "not_implemented",
+      "severity": "info",
+      "title": "Feature Not Implemented",
+      "message": {
+        "plain": "This feature is not yet implemented.",
+        "markdown": "**Feature Not Implemented**\n\nThis feature is not yet implemented. Check the documentation for available alternatives.",
+        "html": "<strong>Feature Not Implemented</strong><p>This feature is not yet implemented. Check the documentation for available alternatives.</p>"
+      },
+      "retry_after": null,
+      "documentation_url": "/docs/roadmap",
+      "internal_description": "Requested feature exists in API but not implemented",
+      "affected_functions": [
+        "not_implemented_handler"
+      ],
+      "common_causes": [
+        "Feature under development",
+        "Deprecated endpoint",
+        "Future functionality"
+      ],
+      "resolution_steps": [
+        "Check roadmap for implementation timeline",
+        "Use alternative endpoints",
+        "Contact support for updates"
+      ]
+    }
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1189,7 +1189,7 @@ class UnifiedController {
     }
 
     const tree = new ChatInboxTreeProvider(this.context, api, messagesWebview);
-    registerTreeView('computor.chat.inbox', {
+    const chatTreeView = registerTreeView('computor.chat.inbox', {
       provider: tree,
       options: { showCollapseAll: true },
       registerDataProvider: true,
@@ -1209,6 +1209,14 @@ class UnifiedController {
         }
       }
     }, this.disposables);
+
+    this.disposables.push(
+      tree.onDidChangeUnread((count) => {
+        chatTreeView.badge = count > 0
+          ? { value: count, tooltip: `${count} unread message${count === 1 ? '' : 's'}` }
+          : undefined;
+      })
+    );
 
     this.disposables.push(
       vscode.commands.registerCommand('computor.chat.refresh', () => tree.refresh()),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -973,11 +973,16 @@ class UnifiedController {
     editorDecorationService.connectToSelectionService(selection);
 
     // Register filter tree (replaces webview filter panel)
-    const filterTree = new TutorFilterTreeProvider(api, selection);
+    const tutorSettingsManager = new ComputorSettingsManager(this.context);
+    const filterTree = new TutorFilterTreeProvider(api, selection, tutorSettingsManager);
     registerTreeView('computor.tutor.filters', {
       provider: filterTree,
       options: { showCollapseAll: true },
       onExpand: async (event) => {
+        const id = event.element.id;
+        if (id) {
+          await filterTree.setNodeExpanded(id, true);
+        }
         if (event.element instanceof TutorCourseFilterItem) {
           const course = event.element.course;
           const currentCourseId = selection.getCurrentCourseId();
@@ -985,6 +990,12 @@ class UnifiedController {
             await selection.selectCourse(course.id, course.title || course.path || course.name || course.id);
             filterTree.refresh();
           }
+        }
+      },
+      onCollapse: async (event) => {
+        const id = event.element.id;
+        if (id) {
+          await filterTree.setNodeExpanded(id, false);
         }
       }
     }, this.disposables);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1189,6 +1189,9 @@ class UnifiedController {
     }
 
     const tree = new ChatInboxTreeProvider(this.context, api, messagesWebview);
+    if (this.wsService) {
+      tree.setWebSocketService(this.wsService);
+    }
     const chatTreeView = registerTreeView('computor.chat.inbox', {
       provider: tree,
       options: { showCollapseAll: true },

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -51,6 +51,7 @@ import {
   UserPassword,
   UserGet,
   UserList,
+  UserScopes,
   UserUpdate,
   CourseMemberValidationRequest,
   TaskResponse,
@@ -1482,6 +1483,36 @@ export class ComputorApiService {
     }
   }
 
+  async getUserScopes(options?: { force?: boolean }): Promise<UserScopes | undefined> {
+    const cacheKey = 'userScopes';
+
+    if (options?.force) {
+      multiTierCache.delete(cacheKey);
+    } else {
+      const cached = multiTierCache.get<UserScopes>(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
+
+    try {
+      const result = await errorRecoveryService.executeWithRecovery(async () => {
+        const client = await this.getHttpClient();
+        const response = await client.get<UserScopes>('/user/scopes');
+        return response.data;
+      }, {
+        maxRetries: 2,
+        exponentialBackoff: true
+      });
+
+      multiTierCache.set(cacheKey, result, 'warm');
+      return result;
+    } catch (error) {
+      console.error('Failed to get user scopes:', error);
+      return undefined;
+    }
+  }
+
   async updateUserAccount(updates: UserUpdate): Promise<UserGet> {
     try {
       const client = await this.getHttpClient();
@@ -2401,42 +2432,8 @@ export class ComputorApiService {
   async listMessages(params: MessageQuery = {}): Promise<MessageList[]> {
     return errorRecoveryService.executeWithRecovery(async () => {
       const client = await this.getHttpClient();
-
-      // If both course_content_id and submission_group_id are present,
-      // make two separate calls and merge results (backend does AND, we want OR)
-      if (params.course_content_id && params.submission_group_id) {
-        // Extract filter params (everything except the target IDs, scope, and course_member_id)
-        const { course_content_id, submission_group_id, scope, course_member_id, ...filterParams } = params;
-        void scope; // scope is intentionally excluded - we set it explicitly below
-        void course_member_id; // only used for cache invalidation, not API queries
-        const cleanFilters = Object.fromEntries(
-          Object.entries(filterParams).filter(([, value]) => value !== undefined && value !== null)
-        );
-
-        const [contentMessages, submissionMessages] = await Promise.all([
-          // For course_content_id, restrict to 'course_content' scope to avoid
-          // fetching all child submission_group messages
-          client.get<MessageList[]>('/messages', {
-            course_content_id,
-            scope: 'course_content',
-            ...cleanFilters
-          }).then(r => r.data),
-          client.get<MessageList[]>('/messages', {
-            submission_group_id,
-            ...cleanFilters
-          }).then(r => r.data)
-        ]);
-
-        // Merge and deduplicate by message id
-        const messageMap = new Map<string, MessageList>();
-        for (const msg of [...contentMessages, ...submissionMessages]) {
-          messageMap.set(msg.id, msg);
-        }
-        return Array.from(messageMap.values());
-      }
-
-      // Otherwise, make a single call with all params
-      // Exclude course_member_id as it's only used for cache invalidation, not API queries
+      // course_member_id is carried in the params for cache invalidation hooks
+      // upstream but isn't a backend query parameter — strip it before sending.
       const query = Object.fromEntries(
         Object.entries(params).filter(([key, value]) =>
           value !== undefined && value !== null && key !== 'course_member_id'

--- a/src/services/MessagePermissions.ts
+++ b/src/services/MessagePermissions.ts
@@ -1,0 +1,39 @@
+import type { UserScopes } from '../types/generated';
+
+const POSTING_ROLES = new Set(['_owner', '_manager']);
+
+function hasPostingRole(roles: string[] | undefined): boolean {
+  if (!roles) {
+    return false;
+  }
+  for (const role of roles) {
+    if (POSTING_ROLES.has(role)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function canPostToOrganization(scopes: UserScopes | undefined, organizationId: string): boolean {
+  if (!scopes) {
+    return false;
+  }
+  if (scopes.is_admin) {
+    return true;
+  }
+  return hasPostingRole(scopes.organization?.[organizationId]);
+}
+
+export function canPostToCourseFamily(scopes: UserScopes | undefined, courseFamilyId: string): boolean {
+  if (!scopes) {
+    return false;
+  }
+  if (scopes.is_admin) {
+    return true;
+  }
+  return hasPostingRole(scopes.course_family?.[courseFamilyId]);
+}
+
+export function canPostGlobal(scopes: UserScopes | undefined): boolean {
+  return scopes?.is_admin === true;
+}

--- a/src/services/MessagePermissions.ts
+++ b/src/services/MessagePermissions.ts
@@ -2,6 +2,44 @@ import type { UserScopes } from '../types/generated';
 
 const POSTING_ROLES = new Set(['_owner', '_manager']);
 
+// Scopes where threading replies makes sense. Broadcast-style scopes
+// (course/family/org/global, plus course_group / course_content) host one-way
+// announcements — a reply thread on those quickly turns into noise that's
+// visible to everyone who sees the original. Replies are restricted to
+// conversational scopes only.
+type ScopeName =
+  | 'user'
+  | 'course_member'
+  | 'submission_group'
+  | 'course_group'
+  | 'course_content'
+  | 'course'
+  | 'course_family'
+  | 'organization'
+  | 'global';
+
+const REPLY_ALLOWED_SCOPES: ReadonlySet<ScopeName> = new Set<ScopeName>([
+  'user',
+  'course_member',
+  'submission_group'
+]);
+
+export function deriveScopeFromCreatePayload(payload: Record<string, unknown>): ScopeName {
+  if (typeof payload.user_id === 'string' && payload.user_id) { return 'user'; }
+  if (typeof payload.course_member_id === 'string' && payload.course_member_id) { return 'course_member'; }
+  if (typeof payload.submission_group_id === 'string' && payload.submission_group_id) { return 'submission_group'; }
+  if (typeof payload.course_group_id === 'string' && payload.course_group_id) { return 'course_group'; }
+  if (typeof payload.course_content_id === 'string' && payload.course_content_id) { return 'course_content'; }
+  if (typeof payload.course_id === 'string' && payload.course_id) { return 'course'; }
+  if (typeof payload.course_family_id === 'string' && payload.course_family_id) { return 'course_family'; }
+  if (typeof payload.organization_id === 'string' && payload.organization_id) { return 'organization'; }
+  return 'global';
+}
+
+export function canReplyInScope(scope: ScopeName): boolean {
+  return REPLY_ALLOWED_SCOPES.has(scope);
+}
+
 function hasPostingRole(roles: string[] | undefined): boolean {
   if (!roles) {
     return false;

--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -36,6 +36,8 @@ export interface WsReadUpdate {
   channel: string;
   message_id: string;
   user_id: string;
+  /** True when marked read, false when marked unread. Optional for older payloads. */
+  read?: boolean;
 }
 
 export interface WsPong {
@@ -149,7 +151,7 @@ export interface WebSocketEventHandlers {
   onMessageUpdate?: (channel: string, messageId: string, data: Record<string, unknown>) => void;
   onMessageDelete?: (channel: string, messageId: string) => void;
   onTypingUpdate?: (channel: string, userId: string, userName: string, isTyping: boolean) => void;
-  onReadUpdate?: (channel: string, messageId: string, userId: string) => void;
+  onReadUpdate?: (channel: string, messageId: string, userId: string, read?: boolean) => void;
   onMaintenanceActivated?: (message: string, activatedAt: string) => void;
   onMaintenanceDeactivated?: (message: string) => void;
   onMaintenanceScheduled?: (scheduledAt: string, message: string) => void;
@@ -492,7 +494,7 @@ export class WebSocketService {
 
         case 'read:update':
           this.eventHandlers.forEach((handlers) => {
-            handlers.onReadUpdate?.(message.channel, message.message_id, message.user_id);
+            handlers.onReadUpdate?.(message.channel, message.message_id, message.user_id, message.read);
           });
           break;
 

--- a/src/settings/ComputorSettingsManager.ts
+++ b/src/settings/ComputorSettingsManager.ts
@@ -154,9 +154,9 @@ export class ComputorSettingsManager {
   async setStudentNodeExpandedState(nodeId: string, expanded: boolean): Promise<void> {
     const settings = await this.settingsStorage.load();
     if (!settings.ui) {
-      settings.ui = { 
+      settings.ui = {
         lecturerTree: { expandedStates: {} },
-        studentTree: { expandedStates: {} } 
+        studentTree: { expandedStates: {} }
       };
     }
     if (!settings.ui.studentTree) {
@@ -172,7 +172,35 @@ export class ComputorSettingsManager {
     }
     await this.settingsStorage.save(settings);
   }
-  
+
+  // Tutor tree expanded states
+  async getTutorTreeExpandedStates(): Promise<Record<string, boolean>> {
+    const settings = await this.settingsStorage.load();
+    return settings.ui?.tutorTree?.expandedStates || {};
+  }
+
+  async setTutorNodeExpandedState(nodeId: string, expanded: boolean): Promise<void> {
+    const settings = await this.settingsStorage.load();
+    if (!settings.ui) {
+      settings.ui = {
+        lecturerTree: { expandedStates: {} },
+        tutorTree: { expandedStates: {} }
+      };
+    }
+    if (!settings.ui.tutorTree) {
+      settings.ui.tutorTree = { expandedStates: {} };
+    }
+    if (!settings.ui.tutorTree.expandedStates) {
+      settings.ui.tutorTree.expandedStates = {};
+    }
+    if (expanded) {
+      settings.ui.tutorTree.expandedStates[nodeId] = true;
+    } else {
+      delete settings.ui.tutorTree.expandedStates[nodeId];
+    }
+    await this.settingsStorage.save(settings);
+  }
+
   async clearSettings(): Promise<void> {
     await this.settingsStorage.clear();
   }

--- a/src/types/SettingsTypes.ts
+++ b/src/types/SettingsTypes.ts
@@ -22,6 +22,9 @@ export interface UISettings {
   studentTree?: {
     expandedStates: Record<string, boolean>; // Maps tree node ID to expanded state
   };
+  tutorTree?: {
+    expandedStates: Record<string, boolean>; // Maps tree node ID to expanded state
+  };
 }
 
 export const defaultSettings: ComputorSettings = {

--- a/src/types/generated/auth.ts
+++ b/src/types/generated/auth.ts
@@ -20,22 +20,6 @@ export interface CoderLoginRequest {
   redirect_url?: string | null;
 }
 
-/**
- * Query parameters for updating organization token.
- */
-export interface OrganizationUpdateTokenQuery {
-  /** Token type (e.g., 'gitlab', 'github') */
-  type: string;
-}
-
-/**
- * Payload for updating organization provider token.
- */
-export interface OrganizationUpdateTokenUpdate {
-  /** Provider access token */
-  token: string;
-}
-
 export interface AuthConfig {
 }
 
@@ -199,6 +183,39 @@ export interface TokenRefreshResponse {
   refresh_token?: string | null;
 }
 
+export interface GradingAuthor {
+  /** Author's given name */
+  given_name?: string | null;
+  /** Author's family name */
+  family_name?: string | null;
+}
+
+/**
+ * Alternative authentication via external provider for password initialization.
+ */
+export interface ProviderAuthCredentials {
+  /** Authentication method */
+  method: "gitlab_pat";
+  /** Provider-specific credentials */
+  credentials: GitLabPATCredentials;
+}
+
+/**
+ * Query parameters for updating organization token.
+ */
+export interface OrganizationUpdateTokenQuery {
+  /** Token type (e.g., 'gitlab', 'github') */
+  type: string;
+}
+
+/**
+ * Payload for updating organization provider token.
+ */
+export interface OrganizationUpdateTokenUpdate {
+  /** Provider access token */
+  token: string;
+}
+
 /**
  * Author information for a message.
  */
@@ -221,23 +238,6 @@ export interface MessageAuthorCourseMember {
   course_role_id: string;
   /** Course ID */
   course_id: string;
-}
-
-export interface GradingAuthor {
-  /** Author's given name */
-  given_name?: string | null;
-  /** Author's family name */
-  family_name?: string | null;
-}
-
-/**
- * Alternative authentication via external provider for password initialization.
- */
-export interface ProviderAuthCredentials {
-  /** Authentication method */
-  method: "gitlab_pat";
-  /** Provider-specific credentials */
-  credentials: GitLabPATCredentials;
 }
 
 /**

--- a/src/types/generated/common.ts
+++ b/src/types/generated/common.ts
@@ -31,195 +31,474 @@ export interface CoderSessionResponse {
   message: string;
 }
 
-export interface StudentProfileCreate {
-  student_id?: string | null;
-  student_email?: string | null;
-  user_id?: string | null;
-  organization_id: string;
+/**
+ * Information about a team member (for display in team lists).
+ */
+export interface TeamMemberInfo {
+  course_member_id: string;
+  user_id: string;
+  given_name?: string | null;
+  family_name?: string | null;
+  email?: string | null;
 }
 
-export interface StudentProfileGet {
-  student_id?: string | null;
-  student_email?: string | null;
+/**
+ * Team formation rules resolved from Course and CourseContent.
+ */
+export interface TeamFormationRules {
+  mode?: string;
+  max_group_size: number;
+  min_group_size?: number;
+  formation_deadline?: string | null;
+  allow_student_group_creation?: boolean;
+  allow_student_join_groups?: boolean;
+  allow_student_leave_groups?: boolean;
+  auto_assign_unmatched?: boolean;
+  lock_teams_at_deadline?: boolean;
+  require_approval?: boolean;
+}
+
+/**
+ * Request to create a new team.
+ */
+export interface TeamCreate {
+  /** Optional team name (default: generated from members) */
+  team_name?: string | null;
+}
+
+/**
+ * Response when team is created or retrieved.
+ */
+export interface TeamResponse {
+  id: string;
+  course_content_id: string;
+  course_id: string;
+  max_group_size: number;
+  status?: string;
+  created_by?: string;
+  join_code?: string | null;
+  members: TeamMemberInfo[];
+  member_count: number;
+  can_join: boolean;
+  locked_at?: string | null;
+}
+
+/**
+ * Team available for joining (limited info for privacy).
+ */
+export interface AvailableTeam {
+  id: string;
+  member_count: number;
+  max_group_size: number;
+  join_code?: string | null;
+  requires_approval: boolean;
+  status: string;
+  members: TeamMemberInfo[];
+}
+
+/**
+ * Request to join a team.
+ */
+export interface JoinTeamRequest {
+  /** Optional join code for direct access */
+  join_code?: string | null;
+}
+
+/**
+ * Response when joining a team.
+ */
+export interface JoinTeamResponse {
+  id: string;
+  status: string;
+  message: string;
+}
+
+/**
+ * Response when leaving a team.
+ */
+export interface LeaveTeamResponse {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Request to lock a team (instructor only).
+ */
+export interface TeamLockRequest {
+  /** Optional reason for locking */
+  reason?: string | null;
+}
+
+/**
+ * Response when team is locked.
+ */
+export interface TeamLockResponse {
+  id: string;
+  locked_at: string;
+  message: string;
+}
+
+export interface SessionCreate {
+  /** Associated user ID */
   user_id: string;
-  organization_id: string;
+  /** Hashed session token */
+  session_id: string;
+  /** Hashed refresh token (binary) */
+  refresh_token_hash?: any | null;
+  /** IP address at session creation */
+  created_ip: string;
+  /** Last seen IP address */
+  last_ip?: string | null;
+  /** User agent string */
+  user_agent?: string | null;
+  /** Human-readable device description */
+  device_label?: string | null;
+  /** Session expiration time */
+  expires_at?: string | null;
+  /** Refresh token expiration */
+  refresh_expires_at?: string | null;
+  /** Additional session properties */
+  properties?: any | null;
+}
+
+export interface SessionGet {
+  /** Session creation time */
+  created_at: string;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  /** Session unique identifier */
+  id: string;
+  /** Unique session ID per device */
+  sid: string;
+  /** Associated user ID */
+  user_id: string;
+  /** Hashed session token */
+  session_id: string;
+  /** Last activity time */
+  last_seen_at?: string | null;
+  /** Expiration time */
+  expires_at?: string | null;
+  /** Revocation timestamp */
+  revoked_at?: string | null;
+  /** Reason for revocation */
+  revocation_reason?: string | null;
+  /** End timestamp (logout) */
+  ended_at?: string | null;
+  /** Number of token refreshes */
+  refresh_counter?: number;
+  /** IP at creation */
+  created_ip: string;
+  /** Last seen IP */
+  last_ip?: string | null;
+  /** Device description */
+  device_label?: string | null;
+  /** Additional properties */
+  properties?: any | null;
+  /** Deprecated: use ended_at */
+  logout_time?: string | null;
+  /** Deprecated: use created_ip */
+  ip_address?: string | null;
+}
+
+export interface SessionList {
+  /** Session creation time */
+  created_at: string;
+  /** Update timestamp */
+  updated_at?: string | null;
+  /** Session unique identifier */
+  id: string;
+  /** Unique session ID per device */
+  sid: string;
+  /** Associated user ID */
+  user_id: string;
+  /** Hashed session token */
+  session_id: string;
+  /** Last activity time */
+  last_seen_at?: string | null;
+  /** Expiration time */
+  expires_at?: string | null;
+  /** Revocation timestamp */
+  revoked_at?: string | null;
+  /** End timestamp */
+  ended_at?: string | null;
+  /** IP at creation */
+  created_ip: string;
+  /** Last seen IP */
+  last_ip?: string | null;
+  /** Device description */
+  device_label?: string | null;
+  /** Refresh count */
+  refresh_counter?: number;
+  /** Deprecated */
+  logout_time?: string | null;
+  /** Deprecated */
+  ip_address?: string | null;
+}
+
+export interface SessionUpdate {
+  /** Logout timestamp */
+  logout_time?: string | null;
+  /** Additional properties */
+  properties?: any | null;
+}
+
+export interface SessionQuery {
+  skip?: number | null;
+  limit?: number | null;
+  /** Filter by session ID */
+  id?: string | null;
+  /** Filter by user ID */
+  user_id?: string | null;
+  /** Filter by session identifier */
+  session_id?: string | null;
+  /** Filter for active sessions only */
+  active_only?: boolean | null;
+  /** Filter by IP address */
+  ip_address?: string | null;
+}
+
+export interface GitCommit {
+  hash: string;
+  date: string;
+  message: string;
+  author: string;
+}
+
+/**
+ * GitLab connection credentials.
+ */
+export interface GitLabCredentials {
+  gitlab_url: string;
+  gitlab_token: string;
+}
+
+/**
+ * Per-item override for release commit selection.
+ */
+export interface ReleaseOverride {
+  course_content_id: string;
+  /** Commit SHA to use for this content */
+  version_identifier: string;
+}
+
+/**
+ * Selection of contents and commits for a release.
+ */
+export interface ReleaseSelection {
+  /** Explicit list of course content IDs to release */
+  course_content_ids?: string[] | null;
+  /** Parent content ID; combined with include_descendants */
+  parent_id?: string | null;
+  /** Whether to include descendants of parent_id */
+  include_descendants?: boolean;
+  /** Select all contents in the course */
+  all?: boolean;
+  /** Commit SHA to apply to all selected contents (overridden by per-item overrides) */
+  global_commit?: string | null;
+  /** Per-content commit overrides */
+  overrides?: ReleaseOverride[] | null;
+}
+
+/**
+ * Request to generate student template.
+ */
+export interface GenerateTemplateRequest {
+  /** Custom commit message (optional) */
+  commit_message?: string | null;
+  /** Force redeployment of already deployed content */
+  force_redeploy?: boolean;
+  /** Selection of contents and commits to release */
+  release?: ReleaseSelection | null;
+}
+
+/**
+ * Response for template generation request.
+ */
+export interface GenerateTemplateResponse {
+  workflow_id: string;
+  status?: string;
+  contents_to_process: number;
+}
+
+/**
+ * Request to generate the assignments repository from Example Library.
+ */
+export interface GenerateAssignmentsRequest {
+  assignments_url?: string | null;
+  course_content_ids?: string[] | null;
+  parent_id?: string | null;
+  include_descendants?: boolean;
+  all?: boolean;
+  /** skip_if_exists|force_update */
+  overwrite_strategy?: string;
+  commit_message?: string | null;
+}
+
+export interface GenerateAssignmentsResponse {
+  workflow_id: string;
+  status?: string;
+  contents_to_process: number;
+}
+
+/**
+ * DTO for creating a new service account.
+ */
+export interface ServiceCreate {
+  /** URL-safe slug identifier (lowercase, alphanumeric, dots, hyphens) */
+  slug: string;
+  /** Human-readable service name */
+  name: string;
+  /** Service description */
+  description?: string | null;
+  /** Service type (e.g., 'temporal_worker', 'grading', 'notification') */
+  service_type: string;
+  /** Username for service user (defaults to slug) */
+  username?: string | null;
+  /** Email for service user */
+  email?: string | null;
+  /** Given name for service user (defaults to first word of name) */
+  given_name?: string | null;
+  /** Family name for service user (defaults to rest of name) */
+  family_name?: string | null;
+  /** Password for service user (optional - use API tokens instead) */
+  password?: string | null;
+  /** Service-specific configuration */
+  config?: Record<string, any> | null;
+  /** Whether the service is enabled */
+  enabled?: boolean | null;
+}
+
+/**
+ * DTO for updating a service account.
+ */
+export interface ServiceUpdate {
+  name?: string | null;
+  description?: string | null;
+  config?: Record<string, any> | null;
+  enabled?: boolean | null;
+  /** Last heartbeat timestamp */
+  last_seen_at?: string | null;
+  properties?: Record<string, any> | null;
+}
+
+/**
+ * DTO for retrieving a service account.
+ */
+export interface ServiceGet {
   /** Creation timestamp */
   created_at?: string | null;
   /** Update timestamp */
   updated_at?: string | null;
   created_by?: string | null;
   updated_by?: string | null;
+  /** Service UUID */
   id: string;
-  organization?: OrganizationGet | null;
-}
-
-export interface StudentProfileList {
-  id: string;
-  student_id?: string | null;
-  student_email?: string | null;
+  slug: string;
+  name: string;
+  description?: string | null;
+  /** ServiceType UUID */
+  service_type_id?: string | null;
+  /** ServiceType path (e.g., 'testing.python') */
+  service_type_path?: string | null;
   user_id: string;
-  organization_id: string;
+  config?: Record<string, any>;
+  enabled: boolean;
+  last_seen_at?: string | null;
+  /** Additional properties */
+  properties?: Record<string, any> | null;
 }
 
-export interface StudentProfileUpdate {
-  student_id?: string | null;
-  student_email?: string | null;
-  properties?: any | null;
-  organization_id?: string | null;
+/**
+ * DTO for listing services.
+ */
+export interface ServiceList {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  items: ServiceGet[];
 }
 
-export interface StudentProfileQuery {
+/**
+ * DTO for querying services.
+ */
+export interface ServiceQuery {
   skip?: number | null;
   limit?: number | null;
+  /** Filter by service UUID */
   id?: string | null;
-  student_id?: string | null;
-  student_email?: string | null;
+  /** Filter by service slug */
+  slug?: string | null;
+  /** Filter by service type UUID */
+  service_type_id?: string | null;
+  /** Filter by enabled status */
+  enabled?: boolean | null;
+  /** Filter by user ID */
   user_id?: string | null;
-  organization_id?: string | null;
 }
 
-export interface GroupCreate {
-  /** Group title */
-  title: string;
-  /** Group slug identifier */
-  slug: string;
-  /** Group description */
-  description?: string | null;
-  /** Type of group (fixed or dynamic) */
-  type: GroupType;
-  /** Additional group properties */
-  properties?: any | null;
+/**
+ * Count of deleted entities by type.
+ */
+export interface EntityDeleteCount {
+  courses?: number;
+  course_families?: number;
+  course_members?: number;
+  course_groups?: number;
+  course_content_types?: number;
+  course_contents?: number;
+  submission_groups?: number;
+  submission_group_members?: number;
+  submission_artifacts?: number;
+  submission_grades?: number;
+  submission_reviews?: number;
+  results?: number;
+  result_artifacts?: number;
+  course_content_deployments?: number;
+  deployment_histories?: number;
+  course_member_comments?: number;
+  messages?: number;
+  example_repositories?: number;
+  examples?: number;
+  example_versions?: number;
+  example_dependencies?: number;
+  student_profiles?: number;
 }
 
-export interface GroupGet {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  /** Group unique identifier */
-  id: string;
-  /** Group title */
-  title: string;
-  /** Group description */
-  description?: string | null;
-  /** Group slug identifier */
-  slug: string;
-  /** Type of group */
-  type: GroupType;
-  /** Additional properties */
-  properties?: any | null;
+/**
+ * Preview of what will be deleted in a cascade operation.
+ */
+export interface CascadeDeletePreview {
+  /** Type of root entity being deleted */
+  entity_type: string;
+  /** ID of root entity being deleted */
+  entity_id: string;
+  /** Name/identifier of root entity */
+  entity_name: string;
+  /** Count of child entities that will be deleted */
+  child_counts?: EntityDeleteCount;
+  /** MinIO storage paths that will be cleaned up */
+  minio_paths?: string[];
 }
 
-export interface GroupList {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  /** Group unique identifier */
-  id: string;
-  /** Group title */
-  title: string;
-  /** Group description */
-  description?: string | null;
-  /** Group slug identifier */
-  slug: string;
-  /** Type of group */
-  type: GroupType;
-}
-
-export interface GroupUpdate {
-  /** Group title */
-  title?: string | null;
-  /** Group slug identifier */
-  slug?: string | null;
-  /** Group description */
-  description?: string | null;
-  /** Type of group */
-  type?: GroupType | null;
-  /** Additional properties */
-  properties?: any | null;
-}
-
-export interface GroupQuery {
-  skip?: number | null;
-  limit?: number | null;
-  /** Filter by group ID */
-  id?: string | null;
-  /** Filter by group title */
-  title?: string | null;
-  /** Filter by group slug */
-  slug?: string | null;
-  /** Filter by group type */
-  type?: GroupType | null;
-}
-
-export interface FilterBase {
-}
-
-export interface EqualsFilter {
-  eq: any;
-}
-
-export interface GreaterFilter {
-  gt: any;
-}
-
-export interface LowerFilter {
-  lt: any;
-}
-
-export interface NotEqualsFilter {
-  ne: any;
-}
-
-export interface InFilter {
-  in_: any[];
-}
-
-export interface NotInFilter {
-  not_in: any[];
-}
-
-export interface LikeFilter {
-  like: string;
-}
-
-export interface ILikeFilter {
-  ilike: string;
-}
-
-export interface BetweenFilter {
-  between: any[];
-}
-
-export interface IsNullFilter {
-  is_null: boolean;
-}
-
-export interface NotNullFilter {
-  not_null: boolean;
-}
-
-export interface StartswithFilter {
-  startswith: string;
-}
-
-export interface EndswithFilter {
-  endswith: string;
-}
-
-export interface ContainsFilter {
-  contains: string;
-}
-
-export interface AndFilter {
-  and_: EqualsFilter | GreaterFilter | LowerFilter | NotEqualsFilter | InFilter | NotInFilter | LikeFilter | ILikeFilter | BetweenFilter | IsNullFilter | NotNullFilter | StartswithFilter | EndswithFilter | ContainsFilter | AndFilter | OrFilter[];
-}
-
-export interface OrFilter {
-  or_: EqualsFilter | GreaterFilter | LowerFilter | NotEqualsFilter | InFilter | NotInFilter | LikeFilter | ILikeFilter | BetweenFilter | IsNullFilter | NotNullFilter | StartswithFilter | EndswithFilter | ContainsFilter | AndFilter | OrFilter[];
+/**
+ * Result of a cascade deletion operation.
+ */
+export interface CascadeDeleteResult {
+  /** Whether this was a preview only */
+  dry_run: boolean;
+  /** Type of root entity deleted */
+  entity_type: string;
+  /** ID of root entity deleted */
+  entity_id: string;
+  /** Count of entities deleted by type */
+  deleted_counts?: EntityDeleteCount;
+  /** Number of MinIO objects deleted */
+  minio_objects_deleted?: number;
+  /** Errors encountered during deletion */
+  errors?: string[];
 }
 
 /**
@@ -642,26 +921,18 @@ export interface ExamplesUploadConfig {
   path: string;
 }
 
-export interface SubmissionGroupProperties {
+export interface SubmissionGroupMemberProperties {
   gitlab?: GitLabConfig | null;
 }
 
-export interface SubmissionGroupCreate {
-  properties?: SubmissionGroupProperties | null;
-  display_name?: string | null;
-  max_group_size?: number;
-  max_submissions?: number | null;
-  course_content_id: string;
-  status?: string | null;
+export interface SubmissionGroupMemberCreate {
+  course_member_id: string;
+  submission_group_id: string;
+  grading?: number | null;
+  properties?: SubmissionGroupMemberProperties | null;
 }
 
-export interface SubmissionGroupGet {
-  properties?: SubmissionGroupProperties | null;
-  display_name?: string | null;
-  max_group_size?: number;
-  max_submissions?: number | null;
-  course_content_id: string;
-  status?: string | null;
+export interface SubmissionGroupMemberGet {
   /** Creation timestamp */
   created_at?: string | null;
   /** Update timestamp */
@@ -670,467 +941,648 @@ export interface SubmissionGroupGet {
   updated_by?: string | null;
   id: string;
   course_id: string;
-  last_submitted_result_id?: string | null;
+  course_member_id: string;
+  submission_group_id: string;
+  grading?: number | null;
+  status?: string | null;
+  properties?: SubmissionGroupMemberProperties | null;
 }
 
-export interface SubmissionGroupList {
+export interface SubmissionGroupMemberList {
   id: string;
-  properties?: SubmissionGroupProperties | null;
-  display_name?: string | null;
-  max_group_size: number;
-  max_submissions?: number | null;
   course_id: string;
-  course_content_id: string;
-  status?: string | null;
-  last_submitted_result_id?: string | null;
-}
-
-export interface SubmissionGroupUpdate {
-  properties?: SubmissionGroupProperties | null;
-  display_name?: string | null;
-  max_group_size?: number | null;
-  max_submissions?: number | null;
+  course_member_id: string;
+  submission_group_id: string;
+  grading?: number | null;
   status?: string | null;
 }
 
-export interface SubmissionGroupQuery {
+export interface SubmissionGroupMemberUpdate {
+  course_id?: string | null;
+  grading?: number | null;
+  status?: string | null;
+  properties?: SubmissionGroupMemberProperties | null;
+}
+
+export interface SubmissionGroupMemberQuery {
   skip?: number | null;
   limit?: number | null;
   id?: string | null;
-  display_name?: string | null;
-  max_group_size?: number | null;
-  max_submissions?: number | null;
   course_id?: string | null;
   course_content_id?: string | null;
-  properties?: SubmissionGroupProperties | null;
+  course_member_id?: string | null;
+  submission_group_id?: string | null;
+  grading?: number | null;
   status?: string | null;
 }
 
 /**
- * Query parameters for student submission groups
+ * Create a new grading for a submission group.
  */
-export interface SubmissionGroupStudentQuery {
-  course_id?: string | null;
-  course_content_id?: string | null;
-  has_repository?: boolean | null;
-  is_graded?: boolean | null;
+export interface SubmissionGroupGradingCreate {
+  submission_group_id: string;
+  graded_by_course_member_id: string;
+  result_id?: string | null;
+  grading: number;
+  status?: GradingStatus;
+  feedback?: string | null;
+  graded_by_course_member?: GradedByCourseMember | null;
 }
 
 /**
- * Submission group with latest grading information.
+ * Full grading information.
  */
-export interface SubmissionGroupWithGrading {
-  properties?: SubmissionGroupProperties | null;
-  display_name?: string | null;
-  max_group_size?: number;
-  max_submissions?: number | null;
-  course_content_id: string;
-  status?: string | null;
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  id: string;
-  course_id: string;
-  last_submitted_result_id?: string | null;
-  latest_grading?: any | null;
-  grading_count?: number;
-  last_submitted_at?: string | null;
-}
-
-/**
- * Detailed submission group information including members and gradings.
- */
-export interface SubmissionGroupDetailed {
-  id: string;
-  course_id: string;
-  course_content_id: string;
-  properties?: SubmissionGroupProperties | null;
-  display_name?: string | null;
-  max_group_size: number;
-  max_submissions?: number | null;
-  max_test_runs?: number | null;
-  members?: any[];
-  gradings?: any[];
-  last_submitted_result?: any | null;
-  current_group_size?: number;
-  submission_count?: number;
-  test_run_count?: number;
-  latest_grade?: number | null;
-  latest_grading_status?: GradingStatus | null;
+export interface SubmissionGroupGradingGet {
   created_at: string;
   updated_at: string;
-}
-
-export interface StudentTemplateSettings {
-  mr_default_target_self?: boolean;
-  merge_method?: MergeMethod;
-  only_allow_merge_if_pipeline_succeeds?: boolean;
-  only_allow_merge_if_all_discussions_are_resolved?: boolean;
-}
-
-/**
- * Represents a test dependency with slug and version constraint.
- */
-export interface TestDependency {
-  /** Hierarchical slug of the dependency example (e.g., 'physics.math.vectors') */
-  slug: string;
-  /** Version constraint (e.g., '>=1.2.0', '^2.1.0', '1.0.0'). If not specified, uses latest version. */
-  version?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  submission_group_id: string;
+  graded_by_course_member_id: string;
+  result_id?: string | null;
+  grading: number;
+  status: GradingStatus;
+  feedback?: string | null;
+  graded_by_course_member?: GradedByCourseMember | null;
 }
 
 /**
- * Base class for all CodeAbility meta models.
+ * List view of grading.
  */
-export interface CodeAbilityBase {
+export interface SubmissionGroupGradingList {
+  id: string;
+  submission_group_id: string;
+  graded_by_course_member_id: string;
+  result_id?: string | null;
+  grading: number;
+  status: GradingStatus;
+  feedback?: string | null;
+  created_at: string;
+  graded_by_course_member?: GradedByCourseMember | null;
 }
 
 /**
- * Link to external resources.
+ * Update grading information.
  */
-export interface CodeAbilityLink {
-  /** Description of the link */
-  description: string;
-  /** URL of the link */
-  url: string;
+export interface SubmissionGroupGradingUpdate {
+  grading?: number | null;
+  status?: GradingStatus | null;
+  feedback?: string | null;
+  result_id?: string | null;
 }
 
 /**
- * Person information for authors/maintainers.
+ * Query parameters for searching gradings.
  */
-export interface CodeAbilityPerson {
-  /** Full name */
-  name?: string | null;
-  /** Email address */
-  email?: string | null;
-  /** Institutional affiliation */
-  affiliation?: string | null;
-}
-
-/**
- * Properties specific to assignment-level meta.
- */
-export interface CodeAbilityMetaProperties {
-  /** Files that students must submit */
-  studentSubmissionFiles?: string[] | null;
-  /** Additional files provided to students */
-  additionalFiles?: string[] | null;
-  /** Test files for automated grading */
-  testFiles?: string[] | null;
-  /** Template files for student projects */
-  studentTemplates?: string[] | null;
-  /** List of example dependencies. Can be simple strings (slugs) or objects with slug and version constraints */
-  testDependencies?: string | TestDependency[] | null;
-  /** Execution backend configuration for this assignment */
-  executionBackend?: CourseExecutionBackendConfig | null;
-}
-
-/**
- * Meta information for assignments/examples.
- */
-export interface CodeAbilityMeta {
-  /** Version of the meta format */
-  version?: string | null;
-  /** Unique identifier for the assignment */
-  slug?: string | null;
-  /** Human-readable title */
-  title?: string | null;
-  /** Detailed description of the content */
-  description?: string | null;
-  /** Primary language of the content (e.g., 'en', 'de', 'fr', etc.) */
-  language?: string | null;
-  /** License information */
-  license?: string | null;
-  /** Content authors */
-  authors?: CodeAbilityPerson[] | null;
-  /** Content maintainers */
-  maintainers?: CodeAbilityPerson[] | null;
-  /** Related links */
-  links?: CodeAbilityLink[] | null;
-  /** Supporting material links */
-  supportingMaterial?: CodeAbilityLink[] | null;
-  /** Keywords for categorization */
-  keywords?: string[] | null;
-  /** Assignment-specific properties */
-  properties?: CodeAbilityMetaProperties | null;
-}
-
-/**
- * Reference material link (new format).
- * 
- * Uses 'name' instead of 'description' (cf. CodeAbilityLink).
- * Used for courseMaterials and supportingMaterials in the new meta format.
- */
-export interface ComputorMaterial {
-  /** Identifier/key for this material (e.g., 'mat2str', 'wiki-ASCII') */
-  name: string;
-  /** URL to the resource */
-  url: string;
-}
-
-/**
- * Typed settings for execution backend configuration.
- * 
- * These settings can be specified in meta.yaml to override defaults.
- * The hierarchy is: test.yaml > meta.yaml > tester default.
- * 
- * Uses extra='allow' to support language-specific settings not listed here.
- */
-export interface ExecutionBackendSettings {
-  /** Execution timeout in seconds */
-  timeout?: number | null;
-  /** Compilation timeout in seconds (for compiled languages) */
-  compileTimeout?: number | null;
-  /** Memory limit in megabytes */
-  memoryLimitMB?: number | null;
-  /** CPU time limit in seconds */
-  cpuLimit?: number | null;
-  /** Maximum number of processes/threads */
-  maxProcesses?: number | null;
-  /** Environment variables (KEY=VALUE format) */
-  env?: string[] | null;
-  /** Compiler to use (gcc, g++, clang, gfortran, etc.) */
-  compiler?: string | null;
-  /** Compiler/interpreter flags */
-  flags?: string[] | null;
-}
-
-/**
- * Execution backend configuration (new format).
- * 
- * Extends CourseExecutionBackendConfig with typed settings and optional version.
- * 
- * Example in meta.yaml:
- * properties:
- * executionBackend:
- * slug: itpcp.exec.c
- * version: "13"
- * settings:
- * timeout: 60
- * memoryLimitMB: 256
- * compiler: gcc
- * flags: ["-Wall", "-Wextra"]
- */
-export interface ExecutionBackend {
-  /** Backend identifier (e.g., 'itpcp.exec.mat', 'itpcp.exec.c') */
-  slug: string;
-  /** Backend/language version requirement */
-  version?: string | null;
-  /** Backend-specific settings (timeout, memory, etc.) */
-  settings?: ExecutionBackendSettings | null;
-}
-
-/**
- * Content categorization for examples (new format).
- * 
- * Provides structured metadata for organizing, searching, and filtering.
- * Replaces the flat 'keywords' field from the old format.
- */
-export interface ContentMetadata {
-  /** Type of example: programming, mathematics, visualization, etc. */
-  types?: string[] | null;
-  /** Curricular classification: mathematics, computer_science, physics, etc. */
-  disciplines?: string[] | null;
-  /** Hierarchical topics in Ltree format (e.g., 'math.linear_equations') */
-  topics?: string[] | null;
-  /** Tools/languages used: matlab, octave, python, latex, etc. */
-  tools?: string[] | null;
-  /** Free-form tags for additional categorization (replaces keywords) */
-  tags?: string[] | null;
-}
-
-/**
- * Properties section of meta.yaml (new format).
- * 
- * Similar to CodeAbilityMetaProperties but uses typed ExecutionBackend
- * and simpler testDependencies (plain strings only).
- */
-export interface ComputorMetaProperties {
-  studentSubmissionFiles?: string[] | null;
-  additionalFiles?: string[] | null;
-  testFiles?: string[] | null;
-  studentTemplates?: string[] | null;
-  /** Execution backend configuration */
-  executionBackend?: ExecutionBackend | null;
-  testDependencies?: string[] | null;
-}
-
-/**
- * Meta.yaml schema for example/assignment metadata (new format).
- * 
- * This is the proposed evolution of CodeAbilityMeta:
- * - 'slug' renamed to 'identifier'
- * - 'links' renamed to 'courseMaterials' (using ComputorMaterial with 'name')
- * - 'supportingMaterial' renamed to 'supportingMaterials' (plural)
- * - 'keywords' replaced by 'content.tags' (structured ContentMetadata)
- * - 'language' removed (now derived from content/index_*.md files)
- * - Typed ExecutionBackendSettings instead of plain dict
- * 
- * The old format (CodeAbilityMeta) remains the primary production format.
- */
-export interface ComputorMeta {
-  /** Unique identifier for this example (e.g., 'itpcp.pgph.mat.hello_world') */
-  identifier?: string | null;
-  /** Version of the meta format */
-  version?: string | null;
-  /** Human-readable title */
-  title?: string | null;
-  /** Detailed description of the content */
-  description?: string | null;
-  /** License information */
-  license?: string | null;
-  /** Content authors */
-  authors?: CodeAbilityPerson[] | null;
-  /** Content maintainers */
-  maintainers?: CodeAbilityPerson[] | null;
-  /** Lecture/course materials (presentations, tutorials, etc.) */
-  courseMaterials?: ComputorMaterial[] | null;
-  /** API references and documentation (function docs, etc.) */
-  supportingMaterials?: ComputorMaterial[] | null;
-  /** Content categorization (types, disciplines, topics, tools, tags) */
-  content?: ContentMetadata | null;
-  /** Assignment-specific properties */
-  properties?: ComputorMetaProperties | null;
-}
-
-/**
- * Test count statistics.
- */
-export interface ComputorReportSummary {
-  total?: number;
-  passed?: number;
-  failed?: number;
-  skipped?: number;
-}
-
-/**
- * Common properties for test report entries.
- */
-export interface ComputorReportProperties {
-  timestamp?: string | null;
-  type?: string | null;
-  version?: string | null;
-  name?: string | null;
-  description?: string | null;
-  status?: StatusEnum | null;
-  result?: ResultEnum | null;
-  summary?: ComputorReportSummary | null;
-  statusMessage?: string | null;
-  resultMessage?: string | null;
-  details?: string | null;
-  setup?: string | null;
-  teardown?: string | null;
-  duration?: number | null;
-  executionDuration?: number | null;
-  environment?: any | null;
-  properties?: any | null;
-  debug?: any | null;
-}
-
-/**
- * Individual test result within a test collection.
- */
-export interface ComputorReportSub {
-  timestamp?: string | null;
-  type?: string | null;
-  version?: string | null;
-  name?: string | null;
-  description?: string | null;
-  status?: StatusEnum | null;
-  result?: ResultEnum | null;
-  summary?: ComputorReportSummary | null;
-  statusMessage?: string | null;
-  resultMessage?: string | null;
-  details?: string | null;
-  setup?: string | null;
-  teardown?: string | null;
-  duration?: number | null;
-  executionDuration?: number | null;
-  environment?: any | null;
-  properties?: any | null;
-  debug?: any | null;
-}
-
-/**
- * Test collection result containing individual test results.
- */
-export interface ComputorReportMain {
-  timestamp?: string | null;
-  type?: string | null;
-  version?: string | null;
-  name?: string | null;
-  description?: string | null;
-  status?: StatusEnum | null;
-  result?: ResultEnum | null;
-  summary?: ComputorReportSummary | null;
-  statusMessage?: string | null;
-  resultMessage?: string | null;
-  details?: string | null;
-  setup?: string | null;
-  teardown?: string | null;
-  duration?: number | null;
-  executionDuration?: number | null;
-  environment?: any | null;
-  properties?: any | null;
-  debug?: any | null;
-  tests?: ComputorReportSub[] | null;
-}
-
-/**
- * Top-level test report containing test collection results.
- */
-export interface ComputorReport {
-  timestamp?: string | null;
-  type?: string | null;
-  version?: string | null;
-  name?: string | null;
-  description?: string | null;
-  status?: StatusEnum | null;
-  result?: ResultEnum | null;
-  summary?: ComputorReportSummary | null;
-  statusMessage?: string | null;
-  resultMessage?: string | null;
-  details?: string | null;
-  setup?: string | null;
-  teardown?: string | null;
-  duration?: number | null;
-  executionDuration?: number | null;
-  environment?: any | null;
-  properties?: any | null;
-  debug?: any | null;
-  tests?: ComputorReportMain[] | null;
-}
-
-export interface Repository {
-  url: string;
-  user?: string | null;
-  token?: string | null;
-  branch?: string | null;
-  path?: string | null;
-  commit?: string | null;
-}
-
-export interface ListQuery {
+export interface SubmissionGroupGradingQuery {
   skip?: number | null;
   limit?: number | null;
+  id?: string | null;
+  submission_group_id?: string | null;
+  graded_by_course_member_id?: string | null;
+  result_id?: string | null;
+  status?: GradingStatus | null;
+  min_grade?: number | null;
+  max_grade?: number | null;
+  has_feedback?: boolean | null;
 }
 
-export interface BaseEntityList {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
+/**
+ * Simplified grading view for students.
+ */
+export interface GradingStudentView {
+  id: string;
+  grading: number;
+  status: GradingStatus;
+  feedback?: string | null;
+  graded_by_name?: string | null;
+  graded_at: string;
 }
 
-export interface BaseEntityGet {
+/**
+ * Summary of gradings for a course content.
+ */
+export interface GradingSummary {
+  course_content_id: string;
+  total_submissions: number;
+  graded_count: number;
+  ungraded_count: number;
+  corrected_count: number;
+  correction_necessary_count: number;
+  improvement_possible_count: number;
+  average_grade?: number | null;
+}
+
+/**
+ * Get deployment details.
+ */
+export interface CourseContentDeploymentGet {
   /** Creation timestamp */
   created_at?: string | null;
   /** Update timestamp */
   updated_at?: string | null;
   created_by?: string | null;
   updated_by?: string | null;
+  id: string;
+  course_content_id: string;
+  example_version_id: string | null;
+  example_identifier?: string | null;
+  version_tag?: string | null;
+  deployment_status: string;
+  deployment_message?: string | null;
+  assigned_at: string;
+  deployed_at?: string | null;
+  last_attempt_at?: string | null;
+  deployment_path?: string | null;
+  version_identifier?: string | null;
+  deployment_metadata?: Record<string, any> | null;
+  workflow_id?: string | null;
+  example_version?: any | null;
+}
+
+/**
+ * List view of deployments.
+ */
+export interface CourseContentDeploymentList {
+  id: string;
+  course_content_id: string;
+  example_version_id: string | null;
+  example_identifier?: string | null;
+  version_tag?: string | null;
+  deployment_status: string;
+  assigned_at: string;
+  deployed_at: string | null;
+  version_identifier: string | null;
+  has_newer_version?: boolean;
+  example_version?: ExampleVersionList | null;
+}
+
+/**
+ * Get deployment history entry.
+ */
+export interface DeploymentHistoryGet {
+  id: string;
+  deployment_id: string;
+  action: string;
+  example_version_id: string | null;
+  previous_example_version_id: string | null;
+  example_identifier?: string | null;
+  version_tag?: string | null;
+  workflow_id: string | null;
+  created_at: string;
+  created_by: string | null;
+  example_version?: any | null;
+  previous_example_version?: any | null;
+}
+
+/**
+ * Deployment with its full history.
+ */
+export interface DeploymentWithHistory {
+  deployment: CourseContentDeploymentGet;
+  history: DeploymentHistoryGet[];
+}
+
+/**
+ * Summary of deployments for a course.
+ */
+export interface DeploymentSummary {
+  course_id: string;
+  /** Total course content items */
+  total_content: number;
+  /** Total submittable content (assignments) */
+  submittable_content: number;
+  /** Total deployments */
+  deployments_total: number;
+  /** Deployments pending */
+  deployments_pending: number;
+  /** Successfully deployed */
+  deployments_deployed: number;
+  /** Failed deployments */
+  deployments_failed: number;
+  /** Most recent deployment */
+  last_deployment_at?: string | null;
+}
+
+export interface ResultCreate {
+  course_member_id: string;
+  course_content_id: string;
+  submission_group_id?: string;
+  submission_artifact_id?: string | null;
+  testing_service_id?: string | null;
+  test_system_id?: string | null;
+  result: number;
+  grade?: number | null;
+  result_json?: any | null;
+  properties?: any | null;
+  version_identifier: string;
+  reference_version_identifier?: string | null;
+  status: TaskStatus;
+}
+
+/**
+ * Artifact information embedded in ResultGet.
+ */
+export interface ResultArtifactInfo {
+  id: string;
+  filename: string;
+  content_type?: string | null;
+  file_size: number;
+  created_at?: string | null;
+}
+
+export interface ResultGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  course_member_id: string;
+  course_content_id: string;
+  course_content_type_id: string;
+  submission_group_id?: string | null;
+  submission_artifact_id?: string | null;
+  testing_service_id?: string | null;
+  test_system_id?: string | null;
+  result: number;
+  grade?: number | null;
+  result_json?: any | null;
+  properties?: any | null;
+  version_identifier: string;
+  reference_version_identifier?: string | null;
+  status: TaskStatus;
+  grading_ids?: string[] | null;
+  has_artifacts?: boolean;
+  artifact_count?: number;
+  result_artifacts?: ResultArtifactInfo[];
+}
+
+export interface ResultList {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  id: string;
+  course_member_id: string;
+  course_content_id: string;
+  course_content_type_id: string;
+  submission_group_id?: string | null;
+  submission_artifact_id?: string | null;
+  testing_service_id?: string | null;
+  test_system_id?: string | null;
+  result: number;
+  grade?: number | null;
+  version_identifier: string;
+  reference_version_identifier?: string | null;
+  status: TaskStatus;
+  has_artifacts?: boolean;
+  artifact_count?: number;
+}
+
+export interface ResultUpdate {
+  result?: number | null;
+  grade?: number | null;
+  result_json?: any | null;
+  status?: TaskStatus | null;
+  test_system_id?: string | null;
+  properties?: any | null;
+}
+
+export interface ResultQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  submitter_id?: string | null;
+  course_member_id?: string | null;
+  course_content_id?: string | null;
+  course_content_type_id?: string | null;
+  submission_group_id?: string | null;
+  submission_artifact_id?: string | null;
+  testing_service_id?: string | null;
+  test_system_id?: string | null;
+  version_identifier?: string | null;
+  status?: TaskStatus | null;
+  latest?: boolean | null;
+  result?: number | null;
+  grade?: number | null;
+}
+
+/**
+ * Result with associated grading information.
+ */
+export interface ResultWithGrading {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  course_member_id: string;
+  course_content_id: string;
+  course_content_type_id: string;
+  submission_group_id?: string | null;
+  submission_artifact_id?: string | null;
+  testing_service_id?: string | null;
+  test_system_id?: string | null;
+  result: number;
+  grade?: number | null;
+  result_json?: any | null;
+  properties?: any | null;
+  version_identifier: string;
+  reference_version_identifier?: string | null;
+  status: TaskStatus;
+  grading_ids?: string[] | null;
+  has_artifacts?: boolean;
+  artifact_count?: number;
+  result_artifacts?: ResultArtifactInfo[];
+  latest_grading?: any | null;
+  grading_count?: number;
+}
+
+export interface RepositoryConfig {
+  settings?: any | null;
+}
+
+export interface GitLabConfigGet {
+  settings?: any | null;
+  url?: string | null;
+  full_path?: string | null;
+  directory?: string | null;
+  registry?: string | null;
+  parent?: number | null;
+  group_id?: number | null;
+  parent_id?: number | null;
+  namespace_id?: number | null;
+  namespace_path?: string | null;
+  web_url?: string | null;
+  visibility?: string | null;
+  last_synced_at?: string | null;
+}
+
+export interface GitLabConfig {
+  settings?: any | null;
+  url?: string | null;
+  full_path?: string | null;
+  directory?: string | null;
+  registry?: string | null;
+  parent?: number | null;
+  group_id?: number | null;
+  parent_id?: number | null;
+  namespace_id?: number | null;
+  namespace_path?: string | null;
+  web_url?: string | null;
+  visibility?: string | null;
+  last_synced_at?: string | null;
+  token?: string | null;
+}
+
+/**
+ * Current maintenance status.
+ */
+export interface MaintenanceStatusGet {
+  active?: boolean;
+  message?: string;
+  activated_at?: string | null;
+  activated_by?: string | null;
+  activated_by_name?: string | null;
+  scheduled_at?: string | null;
+  scheduled_by?: string | null;
+  scheduled_by_name?: string | null;
+}
+
+/**
+ * Activate maintenance mode.
+ */
+export interface MaintenanceActivate {
+  /** Message shown to users */
+  message?: string;
+  /** Broadcast maintenance notification via WebSocket */
+  notify_websocket?: boolean;
+}
+
+/**
+ * Schedule future maintenance.
+ */
+export interface MaintenanceSchedule {
+  /** ISO8601 datetime when maintenance will start */
+  scheduled_at: string;
+  /** Message shown to users */
+  message?: string;
+  /** Broadcast schedule notification via WebSocket */
+  notify_websocket?: boolean;
+}
+
+/**
+ * Base class for all deployment configurations.
+ */
+export interface BaseDeployment {
+}
+
+/**
+ * DTO for creating a grade through the tutor endpoint.
+ * 
+ * This is used when a tutor grades a student's submission for a specific course content.
+ * The endpoint will automatically find the latest artifact for the submission group.
+ */
+export interface TutorGradeCreate {
+  artifact_id?: string | null;
+  /** Grade between 0.0 and 1.0 */
+  grade?: number | null;
+  /** Grading status */
+  status?: GradingStatus | null;
+  /** Feedback/comment for the student */
+  feedback?: string | null;
+}
+
+/**
+ * Information about the artifact that was graded.
+ * 
+ * This provides context about which specific artifact received the grade,
+ * useful for tracking grading history and artifact metadata.
+ */
+export interface GradedArtifactInfo {
+  /** The artifact ID that was graded */
+  id: string;
+  /** When the artifact was created (ISO format) */
+  created_at?: string | null;
+  /** Additional artifact properties (e.g., GitLab info) */
+  properties?: Record<string, any> | null;
+}
+
+/**
+ * Response after creating a grade through the tutor endpoint.
+ * 
+ * Returns the updated course content information with the new grade applied.
+ * We extend CourseContentStudentList to maintain backward compatibility.
+ */
+export interface TutorGradeResponse {
+  id: string;
+  title?: string | null;
+  path: string;
+  course_id: string;
+  course_content_type_id: string;
+  course_content_kind_id: string;
+  position: number;
+  max_group_size?: number | null;
+  submitted?: boolean | null;
+  course_content_type: CourseContentTypeList;
+  result_count: number;
+  submission_count: number;
+  max_test_runs?: number | null;
+  testing_service_id?: string | null;
+  directory?: string | null;
+  color: string;
+  result?: ResultStudentList | null;
+  submission_group?: SubmissionGroupStudentList | null;
+  unread_message_count?: number;
+  deployment?: CourseContentDeploymentList | null;
+  has_deployment?: boolean | null;
+  status?: string | null;
+  unreviewed_count?: number;
+  latest_grade_status?: string | null;
+  graded_artifact_id?: string | null;
+  graded_artifact_info?: GradedArtifactInfo | null;
+}
+
+/**
+ * Credentials for GitLab Personal Access Token authentication.
+ */
+export interface GitLabPATCredentials {
+  /** GitLab Personal Access Token (glpat-...) */
+  access_token: string;
+  /** GitLab instance URL (e.g., https://gitlab.com) */
+  gitlab_url: string;
+}
+
+/**
+ * Request to set password for first time or after reset.
+ * 
+ * Can authenticate either via:
+ * 1. Bearer token (user already authenticated)
+ * 2. Provider credentials (e.g., GitLab PAT for users without password)
+ */
+export interface SetPasswordRequest {
+  /** New password (min 12 chars) */
+  new_password: string;
+  /** Confirm new password */
+  confirm_password: string;
+  /** Alternative authentication via external provider (for users without password) */
+  provider_auth?: ProviderAuthCredentials | null;
+}
+
+/**
+ * Request to change user's own password.
+ */
+export interface ChangePasswordRequest {
+  /** Current password */
+  old_password: string;
+  /** New password (min 12 chars) */
+  new_password: string;
+  /** Confirm new password */
+  confirm_password: string;
+}
+
+/**
+ * Admin request to set another user's password.
+ */
+export interface AdminSetPasswordRequest {
+  /** Target username */
+  username: string;
+  /** New password (min 12 chars) */
+  new_password: string;
+  /** Confirm new password */
+  confirm_password: string;
+  /** Require user to change password on next login */
+  force_reset?: boolean;
+}
+
+/**
+ * Admin request to reset a user's password (marks for reset).
+ */
+export interface AdminResetPasswordRequest {
+  /** Target username */
+  username: string;
+}
+
+/**
+ * Response showing password status for a user.
+ */
+export interface PasswordStatusResponse {
+  user_id: string;
+  username: string;
+  has_password: boolean;
+  password_reset_required: boolean;
+  password_type: string;
+}
+
+/**
+ * Generic response for password operations.
+ */
+export interface PasswordOperationResponse {
+  message: string;
+  user_id: string;
+  username: string;
+}
+
+export interface GroupClaimCreate {
+  /** Group ID this claim belongs to */
+  group_id: string;
+  /** Type of claim (e.g., 'permission', 'attribute') */
+  claim_type: string;
+  /** Value of the claim */
+  claim_value: string;
+  /** Additional claim properties */
+  properties?: any | null;
+}
+
+export interface GroupClaimGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  /** Group ID */
+  group_id: string;
+  /** Type of claim */
+  claim_type: string;
+  /** Value of the claim */
+  claim_value: string;
+  /** Additional properties */
+  properties?: any | null;
+}
+
+export interface GroupClaimList {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  /** Group ID */
+  group_id: string;
+  /** Type of claim */
+  claim_type: string;
+  /** Value of the claim */
+  claim_value: string;
+}
+
+export interface GroupClaimUpdate {
+  /** Additional claim properties */
+  properties?: any | null;
+}
+
+export interface GroupClaimQuery {
+  skip?: number | null;
+  limit?: number | null;
+  /** Filter by group ID */
+  group_id?: string | null;
+  /** Filter by claim type */
+  claim_type?: string | null;
+  /** Filter by claim value */
+  claim_value?: string | null;
 }
 
 /**
@@ -1155,6 +1607,8 @@ export interface ServiceTypeBase {
   color?: string | null;
   /** Whether this service type is enabled */
   enabled?: boolean;
+  /** Whether services of this type need a workspace (e.g. a GitLab repository) provisioned for their course members. When False, the CourseMember post-create hook skips workspace provisioning. */
+  requires_workspace?: boolean;
   /** Additional properties */
   properties?: any | null;
 }
@@ -1181,6 +1635,8 @@ export interface ServiceTypeCreate {
   color?: string | null;
   /** Whether this service type is enabled */
   enabled?: boolean;
+  /** Whether services of this type need a workspace (e.g. a GitLab repository) provisioned for their course members. When False, the CourseMember post-create hook skips workspace provisioning. */
+  requires_workspace?: boolean;
   /** Additional properties */
   properties?: any | null;
 }
@@ -1197,6 +1653,8 @@ export interface ServiceTypeUpdate {
   icon?: string | null;
   color?: string | null;
   enabled?: boolean | null;
+  /** Whether services of this type need a workspace provisioned for their course members. */
+  requires_workspace?: boolean | null;
   properties?: any | null;
 }
 
@@ -1256,6 +1714,8 @@ export interface ServiceTypeGet {
   color?: string | null;
   /** Enabled status */
   enabled: boolean;
+  /** Whether services of this type need a workspace provisioned for their course members. */
+  requires_workspace?: boolean;
   /** Additional properties */
   properties?: any;
   /** Version number */
@@ -1284,277 +1744,258 @@ export interface ServiceTypeQuery {
   plugin_module?: string | null;
 }
 
-/**
- * Base model for test specification models (strict: extra fields forbidden).
- */
-export interface ComputorBase {
-}
-
-/**
- * Common properties for all test types.
- */
-export interface ComputorTestCommon {
-  failureMessage?: string | null;
-  successMessage?: string | null;
-  qualification?: QualificationEnum | null;
-  relativeTolerance?: number | null;
-  absoluteTolerance?: number | null;
-  allowedOccuranceRange?: number[] | null;
-  occuranceType?: string | null;
-  typeCheck?: boolean | null;
-  shapeCheck?: boolean | null;
-  ignoreClass?: boolean | null;
-  verbosity?: number | null;
-}
-
-/**
- * Common properties for test collections.
- */
-export interface ComputorTestCollectionCommon {
-  failureMessage?: string | null;
-  successMessage?: string | null;
-  qualification?: QualificationEnum | null;
-  relativeTolerance?: number | null;
-  absoluteTolerance?: number | null;
-  allowedOccuranceRange?: number[] | null;
-  occuranceType?: string | null;
-  typeCheck?: boolean | null;
-  shapeCheck?: boolean | null;
-  ignoreClass?: boolean | null;
-  verbosity?: number | null;
-  storeGraphicsArtifacts?: boolean | null;
-  competency?: string | null;
-  timeout?: number | null;
-}
-
-/**
- * Individual test case definition.
- */
-export interface ComputorTest {
-  failureMessage?: string | null;
-  successMessage?: string | null;
-  qualification?: QualificationEnum | null;
-  relativeTolerance?: number | null;
-  absoluteTolerance?: number | null;
-  allowedOccuranceRange?: number[] | null;
-  occuranceType?: string | null;
-  typeCheck?: boolean | null;
-  shapeCheck?: boolean | null;
-  ignoreClass?: boolean | null;
-  verbosity?: number | null;
-  name: string;
-  value?: any | null;
-  evalString?: string | null;
-  pattern?: string | null;
-  countRequirement?: number | null;
-  stdin?: (string | string[]) | null;
-  expectedStdout?: (string | string[]) | null;
-  expectedStderr?: (string | string[]) | null;
-  expectedExitCode?: number | null;
-  lineNumber?: (number | number[]) | null;
-  ignoreWhitespace?: boolean | null;
-  ignoreCase?: boolean | null;
-  trimOutput?: boolean | null;
-  normalizeNewlines?: boolean | null;
-  numericTolerance?: number | null;
-  allowEmpty?: boolean | null;
-}
-
-/**
- * Test collection (group of related tests).
- */
-export interface ComputorTestCollection {
-  failureMessage?: string | null;
-  successMessage?: string | null;
-  qualification?: QualificationEnum | null;
-  relativeTolerance?: number | null;
-  absoluteTolerance?: number | null;
-  allowedOccuranceRange?: number[] | null;
-  occuranceType?: string | null;
-  typeCheck?: boolean | null;
-  shapeCheck?: boolean | null;
-  ignoreClass?: boolean | null;
-  verbosity?: number | null;
-  storeGraphicsArtifacts?: boolean | null;
-  competency?: string | null;
-  timeout?: number | null;
-  type?: TypeEnum | null;
-  name: string;
+export interface GroupCreate {
+  /** Group title */
+  title: string;
+  /** Group slug identifier */
+  slug: string;
+  /** Group description */
   description?: string | null;
-  successDependency?: (string | number | any[]) | null;
-  setUpCodeDependency?: string | null;
-  entryPoint?: string | null;
-  inputAnswers?: (string | string[]) | null;
-  setUpCode?: (string | string[]) | null;
-  tearDownCode?: (string | string[]) | null;
+  /** Type of group (fixed or dynamic) */
+  type: GroupType;
+  /** Additional group properties */
+  properties?: any | null;
+}
+
+export interface GroupGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  /** Group unique identifier */
+  id: string;
+  /** Group title */
+  title: string;
+  /** Group description */
+  description?: string | null;
+  /** Group slug identifier */
+  slug: string;
+  /** Type of group */
+  type: GroupType;
+  /** Additional properties */
+  properties?: any | null;
+}
+
+export interface GroupList {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  /** Group unique identifier */
+  id: string;
+  /** Group title */
+  title: string;
+  /** Group description */
+  description?: string | null;
+  /** Group slug identifier */
+  slug: string;
+  /** Type of group */
+  type: GroupType;
+}
+
+export interface GroupUpdate {
+  /** Group title */
+  title?: string | null;
+  /** Group slug identifier */
+  slug?: string | null;
+  /** Group description */
+  description?: string | null;
+  /** Type of group */
+  type?: GroupType | null;
+  /** Additional properties */
+  properties?: any | null;
+}
+
+export interface GroupQuery {
+  skip?: number | null;
+  limit?: number | null;
+  /** Filter by group ID */
   id?: string | null;
-  file?: string | null;
-  tests: ComputorTest[];
-  compiler?: string | null;
-  compilerFlags?: string[] | null;
-  linkerFlags?: string[] | null;
-  sourceFiles?: string[] | null;
-  executableName?: string | null;
-  workingDirectory?: string | null;
-  environment?: any | null;
-  memoryLimit?: number | null;
-  args?: string[] | null;
+  /** Filter by group title */
+  title?: string | null;
+  /** Filter by group slug */
+  slug?: string | null;
+  /** Filter by group type */
+  type?: GroupType | null;
 }
 
 /**
- * Test suite properties with defaults.
+ * Metadata extracted from a VSIX manifest.
  */
-export interface ComputorTestProperty {
-  failureMessage?: string | null;
-  successMessage?: string | null;
-  qualification?: QualificationEnum | null;
-  relativeTolerance?: number | null;
-  absoluteTolerance?: number | null;
-  allowedOccuranceRange?: number[] | null;
-  occuranceType?: string | null;
-  typeCheck?: boolean | null;
-  shapeCheck?: boolean | null;
-  ignoreClass?: boolean | null;
-  verbosity?: number | null;
-  storeGraphicsArtifacts?: boolean | null;
-  competency?: string | null;
-  timeout?: number | null;
-  resultMessage?: string | null;
-  tests?: ComputorTestCollection[];
-}
-
-/**
- * Main test suite definition (test.yaml root).
- */
-export interface ComputorTestSuite {
-  type?: string | null;
-  name?: string | null;
+export interface VsixMetadata {
+  /** Publisher identifier from manifest */
+  publisher: string;
+  /** Extension name/ID from manifest */
+  name: string;
+  /** Semantic version from manifest */
+  version: string;
+  /** Display name from manifest */
+  display_name?: string | null;
+  /** Description from manifest */
   description?: string | null;
+  /** VS Code engine compatibility range */
+  engine_range?: string | null;
+}
+
+/**
+ * Form metadata submitted when publishing a new extension version.
+ */
+export interface ExtensionPublishRequest {
+  /** Semantic version override (defaults to manifest value) */
   version?: string | null;
-  properties?: ComputorTestProperty;
+  /** VS Code engine compatibility override */
+  engine_range?: string | null;
+  /** Friendly display name for the extension */
+  display_name?: string | null;
+  /** Optional extension description */
+  description?: string | null;
 }
 
 /**
- * Specification for test execution directories.
+ * Common fields describing an extension version.
  */
-export interface ComputorSpecification {
-  executionDirectory?: string | null;
-  studentDirectory?: string | null;
-  referenceDirectory?: string | null;
-  testDirectory?: string | null;
-  outputDirectory?: string | null;
-  artifactDirectory?: string | null;
-  testVersion?: string | null;
-  storeGraphicsArtifacts?: boolean | null;
-  outputName?: string | null;
-  isLocalUsage?: boolean | null;
-  studentTestCounter?: number | null;
-}
-
-/**
- * Semantic version following semver.org spec (subset).
- * 
- * Supports format: <major>.<minor>.<patch>[-<prerelease>]
- * 
- * Examples:
- * - 1.0.0
- * - 2.1.3
- * - 1.0.0-alpha
- * - 3.2.1-beta.2
- */
-export interface SemanticVersion {
-  /** Major version number */
-  major: number;
-  /** Minor version number */
-  minor: number;
-  /** Patch version number */
-  patch: number;
-  /** Optional prerelease identifier */
-  prerelease?: any;
-}
-
-/**
- * Request to sync GitLab permissions for a course member.
- */
-export interface GitLabSyncRequest {
-  /** GitLab access token to check existing permissions before syncing (reduces API calls with organization token) */
-  access_token?: string | null;
-}
-
-/**
- * Result of GitLab permission sync operation.
- */
-export interface GitLabSyncResult {
-  course_member_id: string;
-  sync_status: string;
-  message?: string | null;
-}
-
-/**
- * Optional configuration for tutor test (passed as JSON in form data).
- */
-export interface TutorTestConfig {
-  store_graphics_artifacts?: boolean;
-  timeout_seconds?: number | null;
-}
-
-/**
- * Response when creating a tutor test - just the essentials.
- */
-export interface TutorTestCreateResponse {
-  test_id: string;
-  status?: "pending" | "running" | "completed" | "failed" | "timeout";
-  created_at?: string | null;
-}
-
-/**
- * Quick status check for a tutor test run (for polling).
- */
-export interface TutorTestStatus {
-  test_id: string;
-  status: "pending" | "running" | "completed" | "failed" | "timeout";
-  created_at?: string | null;
-  started_at?: string | null;
-  finished_at?: string | null;
-  has_artifacts?: boolean;
-  artifact_count?: number;
-}
-
-/**
- * Full tutor test details including result_dict from MinIO.
- */
-export interface TutorTestGet {
-  test_id: string;
-  status: "pending" | "running" | "completed" | "failed" | "timeout";
-  created_at?: string | null;
-  started_at?: string | null;
-  finished_at?: string | null;
-  result_dict?: any | null;
-  passed?: number | null;
-  failed?: number | null;
-  total?: number | null;
-  result_value?: number | null;
-  error?: string | null;
-  has_artifacts?: boolean;
-  artifact_count?: number;
-}
-
-/**
- * Information about a single artifact.
- */
-export interface TutorTestArtifactInfo {
-  filename: string;
+export interface ExtensionVersionBase {
+  /** Semantic version identifier */
+  version: string;
+  /** Sequential version number for ordering */
+  version_number: number;
+  /** VS Code engine compatibility constraint */
+  engine_range?: string | null;
+  /** Whether the version is yanked */
+  yanked?: boolean;
+  /** Package size in bytes */
   size: number;
-  last_modified?: string | null;
+  /** SHA256 checksum of the VSIX contents */
+  sha256: string;
+  /** Stored content type of the VSIX */
+  content_type: string;
+  /** Creation timestamp */
+  created_at: string;
+  /** Publish timestamp */
+  published_at: string;
 }
 
 /**
- * List of artifacts from a tutor test.
+ * List view of extension versions.
  */
-export interface TutorTestArtifactList {
-  test_id: string;
-  artifacts?: TutorTestArtifactInfo[];
-  total_count?: number;
+export interface ExtensionVersionListItem {
+  /** Semantic version identifier */
+  version: string;
+  /** Sequential version number for ordering */
+  version_number: number;
+  /** VS Code engine compatibility constraint */
+  engine_range?: string | null;
+  /** Whether the version is yanked */
+  yanked?: boolean;
+  /** Package size in bytes */
+  size: number;
+  /** SHA256 checksum of the VSIX contents */
+  sha256: string;
+  /** Stored content type of the VSIX */
+  content_type: string;
+  /** Creation timestamp */
+  created_at: string;
+  /** Publish timestamp */
+  published_at: string;
+}
+
+/**
+ * Detailed view of an extension version.
+ */
+export interface ExtensionVersionDetail {
+  /** Semantic version identifier */
+  version: string;
+  /** Sequential version number for ordering */
+  version_number: number;
+  /** VS Code engine compatibility constraint */
+  engine_range?: string | null;
+  /** Whether the version is yanked */
+  yanked?: boolean;
+  /** Package size in bytes */
+  size: number;
+  /** SHA256 checksum of the VSIX contents */
+  sha256: string;
+  /** Stored content type of the VSIX */
+  content_type: string;
+  /** Creation timestamp */
+  created_at: string;
+  /** Publish timestamp */
+  published_at: string;
+  /** Object storage key for the VSIX */
+  object_key: string;
+}
+
+/**
+ * Response payload for version listing.
+ */
+export interface ExtensionVersionListResponse {
+  items?: ExtensionVersionListItem[];
+  /** Pagination cursor for the next page, if available */
+  next_cursor?: string | null;
+}
+
+/**
+ * Extension-level metadata including latest version information.
+ */
+export interface ExtensionMetadata {
+  /** Publisher identifier */
+  publisher: string;
+  /** Extension name */
+  name: string;
+  /** Friendly display name for the extension */
+  display_name?: string | null;
+  /** Extension description */
+  description?: string | null;
+  /** Database identifier for the extension */
+  id: string;
+  /** Creation timestamp */
+  created_at: string;
+  /** Last update timestamp */
+  updated_at: string;
+  /** Number of stored versions */
+  version_count: number;
+  /** Metadata for the latest available version */
+  latest_version?: ExtensionVersionListItem | null;
+}
+
+/**
+ * Request payload to (un)yank a specific version.
+ */
+export interface ExtensionVersionYankRequest {
+  /** Target yank state for the version */
+  yanked: boolean;
+}
+
+/**
+ * Response payload returned after publishing a version.
+ */
+export interface ExtensionPublishResponse {
+  /** Semantic version identifier */
+  version: string;
+  /** Sequential version number for ordering */
+  version_number: number;
+  /** VS Code engine compatibility constraint */
+  engine_range?: string | null;
+  /** Whether the version is yanked */
+  yanked?: boolean;
+  /** Package size in bytes */
+  size: number;
+  /** SHA256 checksum of the VSIX contents */
+  sha256: string;
+  /** Stored content type of the VSIX */
+  content_type: string;
+  /** Creation timestamp */
+  created_at: string;
+  /** Publish timestamp */
+  published_at: string;
+  /** Object storage key for the VSIX */
+  object_key: string;
+  /** Publisher identifier */
+  publisher: string;
+  /** Extension name */
+  name: string;
 }
 
 /**
@@ -1625,6 +2066,183 @@ export interface TutorSubmissionGroupQuery {
   has_ungraded_submissions?: boolean | null;
   limit?: number;
   offset?: number;
+}
+
+/**
+ * Request to assign an example to a course content (assignment).
+ */
+export interface AssignExampleRequest {
+  /** ID of the example to assign (UUID) */
+  example_id?: string | null;
+  /** Identifier path of the example (e.g., 'itpcp.pgph.mat.function_time_formatter') */
+  example_identifier?: string | null;
+  /** Specific version tag using semantic versioning (e.g., '1.0.0', '2.1.3-beta') */
+  version_tag: string;
+}
+
+/**
+ * Response after assigning an example.
+ */
+export interface AssignExampleResponse {
+  /** ID of the deployment record */
+  deployment_id: string;
+  course_content_id: string;
+  example_id: string;
+  example_version_id: string;
+  version_tag: string;
+  /** Status: 'pending' */
+  deployment_status: string;
+  assigned_at: string;
+  /** Success message */
+  message: string;
+}
+
+/**
+ * Detailed deployment information for a course content.
+ */
+export interface DeploymentGet {
+  id: string;
+  course_content_id: string;
+  example_id?: string | null;
+  example_version_id?: string | null;
+  example_identifier?: string | null;
+  version_tag?: string | null;
+  deployment_status: string;
+  deployment_message?: string | null;
+  assigned_at: string;
+  deployed_at?: string | null;
+  deployment_path?: string | null;
+  /** Whether a newer version of the assigned example exists */
+  has_newer_version?: boolean;
+  example_title?: string | null;
+  example_directory?: string | null;
+  example_description?: string | null;
+  course_content_title?: string | null;
+  course_content_path?: string | null;
+}
+
+/**
+ * Minimal deployment info for list views.
+ */
+export interface DeploymentList {
+  id: string;
+  course_content_id: string;
+  deployment_status: string;
+  version_tag?: string | null;
+  assigned_at: string;
+  deployed_at?: string | null;
+}
+
+/**
+ * Response after unassigning an example.
+ */
+export interface UnassignExampleResponse {
+  course_content_id: string;
+  /** Success message */
+  message: string;
+  previous_example_id?: string | null;
+  previous_version_tag?: string | null;
+}
+
+/**
+ * Single validation error for release validation.
+ */
+export interface ValidationError {
+  course_content_id: string;
+  title: string;
+  path: string;
+  issue: string;
+}
+
+/**
+ * Error response when release validation fails.
+ */
+export interface ReleaseValidationError {
+  /** Main error message */
+  error: string;
+  /** List of specific issues */
+  validation_errors: ValidationError[];
+  /** Count of validation errors */
+  total_issues: number;
+}
+
+/**
+ * Single deployment in batch listing — includes version freshness.
+ */
+export interface CourseDeploymentList {
+  course_content_id: string;
+  example_id?: string | null;
+  example_identifier?: string | null;
+  version_tag?: string | null;
+  deployment_status: string;
+  deployed_at?: string | null;
+  /** Whether a newer version of the assigned example exists */
+  has_newer_version?: boolean;
+  /** Version tag of the latest available version */
+  latest_version_tag?: string | null;
+  course_content_title?: string | null;
+  course_content_path?: string | null;
+}
+
+/**
+ * Response: all deployments for a course with version freshness.
+ */
+export interface CourseDeploymentGet {
+  course_id: string;
+  /** Total number of deployments returned */
+  total: number;
+  deployments: CourseDeploymentList[];
+}
+
+/**
+ * Request to batch-upgrade course contents to latest example versions.
+ */
+export interface VersionUpgradeCreate {
+  /** List of course content IDs to upgrade */
+  course_content_ids: string[];
+}
+
+/**
+ * Per-item upgrade result.
+ */
+export interface VersionUpgradeResult {
+  course_content_id: string;
+  success: boolean;
+  from_tag?: string | null;
+  to_tag?: string | null;
+  error?: string | null;
+}
+
+/**
+ * Response: batch upgrade results.
+ */
+export interface VersionUpgradeGet {
+  /** Number of items requested */
+  total_requested: number;
+  /** Number of items successfully upgraded */
+  total_upgraded: number;
+  /** Number of items already at latest version */
+  total_skipped: number;
+  /** Number of items that failed to upgrade */
+  total_failed: number;
+  results: VersionUpgradeResult[];
+}
+
+export interface CourseMemberGitLabConfig {
+  settings?: any | null;
+  url?: string | null;
+  full_path?: string | null;
+  directory?: string | null;
+  registry?: string | null;
+  parent?: number | null;
+  group_id?: number | null;
+  parent_id?: number | null;
+  namespace_id?: number | null;
+  namespace_path?: string | null;
+  web_url?: string | null;
+  visibility?: string | null;
+  last_synced_at?: string | null;
+  full_path_submission?: string | null;
 }
 
 /**
@@ -1807,570 +2425,226 @@ export interface StorageUsageStats {
   last_updated: string;
 }
 
-/**
- * DTO for creating a new service account.
- */
-export interface ServiceCreate {
-  /** URL-safe slug identifier (lowercase, alphanumeric, dots, hyphens) */
-  slug: string;
-  /** Human-readable service name */
-  name: string;
-  /** Service description */
-  description?: string | null;
-  /** Service type (e.g., 'temporal_worker', 'grading', 'notification') */
-  service_type: string;
-  /** Username for service user (defaults to slug) */
-  username?: string | null;
-  /** Email for service user */
-  email?: string | null;
-  /** Given name for service user (defaults to first word of name) */
-  given_name?: string | null;
-  /** Family name for service user (defaults to rest of name) */
-  family_name?: string | null;
-  /** Password for service user (optional - use API tokens instead) */
-  password?: string | null;
-  /** Service-specific configuration */
-  config?: Record<string, any> | null;
-  /** Whether the service is enabled */
-  enabled?: boolean | null;
+export interface StudentTemplateSettings {
+  mr_default_target_self?: boolean;
+  merge_method?: MergeMethod;
+  only_allow_merge_if_pipeline_succeeds?: boolean;
+  only_allow_merge_if_all_discussions_are_resolved?: boolean;
 }
 
 /**
- * DTO for updating a service account.
+ * Request to sync GitLab permissions for a course member.
  */
-export interface ServiceUpdate {
-  name?: string | null;
-  description?: string | null;
-  config?: Record<string, any> | null;
-  enabled?: boolean | null;
-  /** Last heartbeat timestamp */
-  last_seen_at?: string | null;
-  properties?: Record<string, any> | null;
+export interface GitLabSyncRequest {
+  /** GitLab access token to check existing permissions before syncing (reduces API calls with organization token) */
+  access_token?: string | null;
 }
 
 /**
- * DTO for retrieving a service account.
+ * Result of GitLab permission sync operation.
  */
-export interface ServiceGet {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  /** Service UUID */
-  id: string;
-  slug: string;
-  name: string;
-  description?: string | null;
-  /** ServiceType UUID */
-  service_type_id?: string | null;
-  /** ServiceType path (e.g., 'testing.python') */
-  service_type_path?: string | null;
-  user_id: string;
-  config?: Record<string, any>;
-  enabled: boolean;
-  last_seen_at?: string | null;
-  /** Additional properties */
-  properties?: Record<string, any> | null;
-}
-
-/**
- * DTO for listing services.
- */
-export interface ServiceList {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  items: ServiceGet[];
-}
-
-/**
- * DTO for querying services.
- */
-export interface ServiceQuery {
-  skip?: number | null;
-  limit?: number | null;
-  /** Filter by service UUID */
-  id?: string | null;
-  /** Filter by service slug */
-  slug?: string | null;
-  /** Filter by service type UUID */
-  service_type_id?: string | null;
-  /** Filter by enabled status */
-  enabled?: boolean | null;
-  /** Filter by user ID */
-  user_id?: string | null;
-}
-
-/**
- * Count of deleted entities by type.
- */
-export interface EntityDeleteCount {
-  courses?: number;
-  course_families?: number;
-  course_members?: number;
-  course_groups?: number;
-  course_content_types?: number;
-  course_contents?: number;
-  submission_groups?: number;
-  submission_group_members?: number;
-  submission_artifacts?: number;
-  submission_grades?: number;
-  submission_reviews?: number;
-  results?: number;
-  result_artifacts?: number;
-  course_content_deployments?: number;
-  deployment_histories?: number;
-  course_member_comments?: number;
-  messages?: number;
-  example_repositories?: number;
-  examples?: number;
-  example_versions?: number;
-  example_dependencies?: number;
-  student_profiles?: number;
-}
-
-/**
- * Preview of what will be deleted in a cascade operation.
- */
-export interface CascadeDeletePreview {
-  /** Type of root entity being deleted */
-  entity_type: string;
-  /** ID of root entity being deleted */
-  entity_id: string;
-  /** Name/identifier of root entity */
-  entity_name: string;
-  /** Count of child entities that will be deleted */
-  child_counts?: EntityDeleteCount;
-  /** MinIO storage paths that will be cleaned up */
-  minio_paths?: string[];
-}
-
-/**
- * Result of a cascade deletion operation.
- */
-export interface CascadeDeleteResult {
-  /** Whether this was a preview only */
-  dry_run: boolean;
-  /** Type of root entity deleted */
-  entity_type: string;
-  /** ID of root entity deleted */
-  entity_id: string;
-  /** Count of entities deleted by type */
-  deleted_counts?: EntityDeleteCount;
-  /** Number of MinIO objects deleted */
-  minio_objects_deleted?: number;
-  /** Errors encountered during deletion */
-  errors?: string[];
-}
-
-export interface TestCreate {
-  artifact_id?: string | null;
-  submission_group_id?: string | null;
-  version_identifier?: string | null;
-  course_member_id?: string | null;
-  course_content_id?: string | null;
-  course_content_path?: string | null;
-  directory?: string | null;
-  project?: string | null;
-  provider_url?: string | null;
-  submit?: boolean | null;
-}
-
-/**
- * Payload describing a manual submission request.
- */
-export interface SubmissionCreate {
-  submission_group_id: string;
-  version_identifier?: string | null;
-  submit?: boolean;
-}
-
-/**
- * Metadata about a file extracted from a submission archive.
- */
-export interface SubmissionUploadedFile {
-  object_key: string;
-  size: number;
-  content_type: string;
-  relative_path: string;
-}
-
-/**
- * Response returned after processing a manual submission.
- */
-export interface SubmissionUploadResponseModel {
-  artifacts: string[];
-  submission_group_id: string;
-  uploaded_by_course_member_id: string;
-  total_size: number;
-  files_count: number;
-  uploaded_at: string;
-  version_identifier: string;
-}
-
-/**
- * List item representation for manual submissions stored as results.
- */
-export interface SubmissionListItem {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  id: string;
-  submit: boolean;
+export interface GitLabSyncResult {
   course_member_id: string;
+  sync_status: string;
+  message?: string | null;
+}
+
+export interface Repository {
+  url: string;
+  user?: string | null;
+  token?: string | null;
+  branch?: string | null;
+  path?: string | null;
+  commit?: string | null;
+}
+
+export interface SubmissionGroupProperties {
+  gitlab?: GitLabConfig | null;
+}
+
+export interface SubmissionGroupCreate {
+  properties?: SubmissionGroupProperties | null;
+  display_name?: string | null;
+  max_group_size?: number;
+  max_submissions?: number | null;
   course_content_id: string;
-  submission_group_id?: string | null;
-  testing_service_id?: string | null;
-  test_system_id?: string | null;
-  version_identifier: string;
-  reference_version_identifier?: string | null;
-  status: TaskStatus;
-  result: number;
-  result_json?: Record<string, any> | null;
-  properties?: Record<string, any> | null;
+  status?: string | null;
 }
 
-/**
- * Query parameters for listing manual submissions.
- */
-export interface SubmissionQuery {
-  skip?: number | null;
-  limit?: number | null;
-  id?: string | null;
-  submit?: boolean | null;
-  course_member_id?: string | null;
-  submission_group_id?: string | null;
-  course_content_id?: string | null;
-  testing_service_id?: string | null;
-  test_system_id?: string | null;
-  version_identifier?: string | null;
-  reference_version_identifier?: string | null;
-  status?: TaskStatus | null;
-}
-
-export interface SessionCreate {
-  /** Associated user ID */
-  user_id: string;
-  /** Hashed session token */
-  session_id: string;
-  /** Hashed refresh token (binary) */
-  refresh_token_hash?: any | null;
-  /** IP address at session creation */
-  created_ip: string;
-  /** Last seen IP address */
-  last_ip?: string | null;
-  /** User agent string */
-  user_agent?: string | null;
-  /** Human-readable device description */
-  device_label?: string | null;
-  /** Session expiration time */
-  expires_at?: string | null;
-  /** Refresh token expiration */
-  refresh_expires_at?: string | null;
-  /** Additional session properties */
-  properties?: any | null;
-}
-
-export interface SessionGet {
-  /** Session creation time */
-  created_at: string;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  /** Session unique identifier */
-  id: string;
-  /** Unique session ID per device */
-  sid: string;
-  /** Associated user ID */
-  user_id: string;
-  /** Hashed session token */
-  session_id: string;
-  /** Last activity time */
-  last_seen_at?: string | null;
-  /** Expiration time */
-  expires_at?: string | null;
-  /** Revocation timestamp */
-  revoked_at?: string | null;
-  /** Reason for revocation */
-  revocation_reason?: string | null;
-  /** End timestamp (logout) */
-  ended_at?: string | null;
-  /** Number of token refreshes */
-  refresh_counter?: number;
-  /** IP at creation */
-  created_ip: string;
-  /** Last seen IP */
-  last_ip?: string | null;
-  /** Device description */
-  device_label?: string | null;
-  /** Additional properties */
-  properties?: any | null;
-  /** Deprecated: use ended_at */
-  logout_time?: string | null;
-  /** Deprecated: use created_ip */
-  ip_address?: string | null;
-}
-
-export interface SessionList {
-  /** Session creation time */
-  created_at: string;
-  /** Update timestamp */
-  updated_at?: string | null;
-  /** Session unique identifier */
-  id: string;
-  /** Unique session ID per device */
-  sid: string;
-  /** Associated user ID */
-  user_id: string;
-  /** Hashed session token */
-  session_id: string;
-  /** Last activity time */
-  last_seen_at?: string | null;
-  /** Expiration time */
-  expires_at?: string | null;
-  /** Revocation timestamp */
-  revoked_at?: string | null;
-  /** End timestamp */
-  ended_at?: string | null;
-  /** IP at creation */
-  created_ip: string;
-  /** Last seen IP */
-  last_ip?: string | null;
-  /** Device description */
-  device_label?: string | null;
-  /** Refresh count */
-  refresh_counter?: number;
-  /** Deprecated */
-  logout_time?: string | null;
-  /** Deprecated */
-  ip_address?: string | null;
-}
-
-export interface SessionUpdate {
-  /** Logout timestamp */
-  logout_time?: string | null;
-  /** Additional properties */
-  properties?: any | null;
-}
-
-export interface SessionQuery {
-  skip?: number | null;
-  limit?: number | null;
-  /** Filter by session ID */
-  id?: string | null;
-  /** Filter by user ID */
-  user_id?: string | null;
-  /** Filter by session identifier */
-  session_id?: string | null;
-  /** Filter for active sessions only */
-  active_only?: boolean | null;
-  /** Filter by IP address */
-  ip_address?: string | null;
-}
-
-export interface GroupClaimCreate {
-  /** Group ID this claim belongs to */
-  group_id: string;
-  /** Type of claim (e.g., 'permission', 'attribute') */
-  claim_type: string;
-  /** Value of the claim */
-  claim_value: string;
-  /** Additional claim properties */
-  properties?: any | null;
-}
-
-export interface GroupClaimGet {
+export interface SubmissionGroupGet {
+  properties?: SubmissionGroupProperties | null;
+  display_name?: string | null;
+  max_group_size?: number;
+  max_submissions?: number | null;
+  course_content_id: string;
+  status?: string | null;
   /** Creation timestamp */
   created_at?: string | null;
   /** Update timestamp */
   updated_at?: string | null;
   created_by?: string | null;
   updated_by?: string | null;
-  /** Group ID */
-  group_id: string;
-  /** Type of claim */
-  claim_type: string;
-  /** Value of the claim */
-  claim_value: string;
-  /** Additional properties */
-  properties?: any | null;
-}
-
-export interface GroupClaimList {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  /** Group ID */
-  group_id: string;
-  /** Type of claim */
-  claim_type: string;
-  /** Value of the claim */
-  claim_value: string;
-}
-
-export interface GroupClaimUpdate {
-  /** Additional claim properties */
-  properties?: any | null;
-}
-
-export interface GroupClaimQuery {
-  skip?: number | null;
-  limit?: number | null;
-  /** Filter by group ID */
-  group_id?: string | null;
-  /** Filter by claim type */
-  claim_type?: string | null;
-  /** Filter by claim value */
-  claim_value?: string | null;
-}
-
-/**
- * Information about a team member (for display in team lists).
- */
-export interface TeamMemberInfo {
-  course_member_id: string;
-  user_id: string;
-  given_name?: string | null;
-  family_name?: string | null;
-  email?: string | null;
-}
-
-/**
- * Team formation rules resolved from Course and CourseContent.
- */
-export interface TeamFormationRules {
-  mode?: string;
-  max_group_size: number;
-  min_group_size?: number;
-  formation_deadline?: string | null;
-  allow_student_group_creation?: boolean;
-  allow_student_join_groups?: boolean;
-  allow_student_leave_groups?: boolean;
-  auto_assign_unmatched?: boolean;
-  lock_teams_at_deadline?: boolean;
-  require_approval?: boolean;
-}
-
-/**
- * Request to create a new team.
- */
-export interface TeamCreate {
-  /** Optional team name (default: generated from members) */
-  team_name?: string | null;
-}
-
-/**
- * Response when team is created or retrieved.
- */
-export interface TeamResponse {
   id: string;
-  course_content_id: string;
   course_id: string;
+  last_submitted_result_id?: string | null;
+}
+
+export interface SubmissionGroupList {
+  id: string;
+  properties?: SubmissionGroupProperties | null;
+  display_name?: string | null;
   max_group_size: number;
-  status?: string;
-  created_by?: string;
-  join_code?: string | null;
-  members: TeamMemberInfo[];
-  member_count: number;
-  can_join: boolean;
-  locked_at?: string | null;
+  max_submissions?: number | null;
+  course_id: string;
+  course_content_id: string;
+  status?: string | null;
+  last_submitted_result_id?: string | null;
+}
+
+export interface SubmissionGroupUpdate {
+  properties?: SubmissionGroupProperties | null;
+  display_name?: string | null;
+  max_group_size?: number | null;
+  max_submissions?: number | null;
+  status?: string | null;
+}
+
+export interface SubmissionGroupQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  display_name?: string | null;
+  max_group_size?: number | null;
+  max_submissions?: number | null;
+  course_id?: string | null;
+  course_content_id?: string | null;
+  properties?: SubmissionGroupProperties | null;
+  status?: string | null;
 }
 
 /**
- * Team available for joining (limited info for privacy).
+ * Query parameters for student submission groups
  */
-export interface AvailableTeam {
+export interface SubmissionGroupStudentQuery {
+  course_id?: string | null;
+  course_content_id?: string | null;
+  has_repository?: boolean | null;
+  is_graded?: boolean | null;
+}
+
+/**
+ * Submission group with latest grading information.
+ */
+export interface SubmissionGroupWithGrading {
+  properties?: SubmissionGroupProperties | null;
+  display_name?: string | null;
+  max_group_size?: number;
+  max_submissions?: number | null;
+  course_content_id: string;
+  status?: string | null;
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
   id: string;
-  member_count: number;
+  course_id: string;
+  last_submitted_result_id?: string | null;
+  latest_grading?: any | null;
+  grading_count?: number;
+  last_submitted_at?: string | null;
+}
+
+/**
+ * Detailed submission group information including members and gradings.
+ */
+export interface SubmissionGroupDetailed {
+  id: string;
+  course_id: string;
+  course_content_id: string;
+  properties?: SubmissionGroupProperties | null;
+  display_name?: string | null;
   max_group_size: number;
-  join_code?: string | null;
-  requires_approval: boolean;
-  status: string;
-  members: TeamMemberInfo[];
+  max_submissions?: number | null;
+  max_test_runs?: number | null;
+  members?: any[];
+  gradings?: any[];
+  last_submitted_result?: any | null;
+  current_group_size?: number;
+  submission_count?: number;
+  test_run_count?: number;
+  latest_grade?: number | null;
+  latest_grading_status?: GradingStatus | null;
+  created_at: string;
+  updated_at: string;
 }
 
-/**
- * Request to join a team.
- */
-export interface JoinTeamRequest {
-  /** Optional join code for direct access */
-  join_code?: string | null;
+export interface FilterBase {
 }
 
-/**
- * Response when joining a team.
- */
-export interface JoinTeamResponse {
-  id: string;
-  status: string;
-  message: string;
+export interface EqualsFilter {
+  eq: any;
 }
 
-/**
- * Response when leaving a team.
- */
-export interface LeaveTeamResponse {
-  success: boolean;
-  message: string;
+export interface GreaterFilter {
+  gt: any;
 }
 
-/**
- * Request to lock a team (instructor only).
- */
-export interface TeamLockRequest {
-  /** Optional reason for locking */
-  reason?: string | null;
+export interface LowerFilter {
+  lt: any;
 }
 
-/**
- * Response when team is locked.
- */
-export interface TeamLockResponse {
-  id: string;
-  locked_at: string;
-  message: string;
+export interface NotEqualsFilter {
+  ne: any;
 }
 
-/**
- * Current maintenance status.
- */
-export interface MaintenanceStatusGet {
-  active?: boolean;
-  message?: string;
-  activated_at?: string | null;
-  activated_by?: string | null;
-  activated_by_name?: string | null;
-  scheduled_at?: string | null;
-  scheduled_by?: string | null;
-  scheduled_by_name?: string | null;
+export interface InFilter {
+  in_: any[];
 }
 
-/**
- * Activate maintenance mode.
- */
-export interface MaintenanceActivate {
-  /** Message shown to users */
-  message?: string;
-  /** Broadcast maintenance notification via WebSocket */
-  notify_websocket?: boolean;
+export interface NotInFilter {
+  not_in: any[];
 }
 
-/**
- * Schedule future maintenance.
- */
-export interface MaintenanceSchedule {
-  /** ISO8601 datetime when maintenance will start */
-  scheduled_at: string;
-  /** Message shown to users */
-  message?: string;
-  /** Broadcast schedule notification via WebSocket */
-  notify_websocket?: boolean;
+export interface LikeFilter {
+  like: string;
+}
+
+export interface ILikeFilter {
+  ilike: string;
+}
+
+export interface BetweenFilter {
+  between: any[];
+}
+
+export interface IsNullFilter {
+  is_null: boolean;
+}
+
+export interface NotNullFilter {
+  not_null: boolean;
+}
+
+export interface StartswithFilter {
+  startswith: string;
+}
+
+export interface EndswithFilter {
+  endswith: string;
+}
+
+export interface ContainsFilter {
+  contains: string;
+}
+
+export interface AndFilter {
+  and_: EqualsFilter | GreaterFilter | LowerFilter | NotEqualsFilter | InFilter | NotInFilter | LikeFilter | ILikeFilter | BetweenFilter | IsNullFilter | NotNullFilter | StartswithFilter | EndswithFilter | ContainsFilter | AndFilter | OrFilter[];
+}
+
+export interface OrFilter {
+  or_: EqualsFilter | GreaterFilter | LowerFilter | NotEqualsFilter | InFilter | NotInFilter | LikeFilter | ILikeFilter | BetweenFilter | IsNullFilter | NotNullFilter | StartswithFilter | EndswithFilter | ContainsFilter | AndFilter | OrFilter[];
 }
 
 /**
@@ -2645,235 +2919,6 @@ export interface ResultArtifactUploadResponse {
   artifacts: ArtifactInfo[];
 }
 
-export interface CourseMemberGitLabConfig {
-  settings?: any | null;
-  url?: string | null;
-  full_path?: string | null;
-  directory?: string | null;
-  registry?: string | null;
-  parent?: number | null;
-  group_id?: number | null;
-  parent_id?: number | null;
-  namespace_id?: number | null;
-  namespace_path?: string | null;
-  web_url?: string | null;
-  visibility?: string | null;
-  last_synced_at?: string | null;
-  full_path_submission?: string | null;
-}
-
-export interface LanguageCreate {
-  /** ISO 639-1 language code (2 lowercase letters) */
-  code: string;
-  /** Language name in English */
-  name: string;
-  /** Language name in native script */
-  native_name?: string | null;
-}
-
-export interface LanguageGet {
-  /** ISO 639-1 language code */
-  code: string;
-  /** Language name in English */
-  name: string;
-  /** Language name in native script */
-  native_name?: string | null;
-}
-
-export interface LanguageList {
-  /** ISO 639-1 language code */
-  code: string;
-  /** Language name in English */
-  name: string;
-  /** Language name in native script */
-  native_name?: string | null;
-}
-
-export interface LanguageUpdate {
-  /** Language name in English */
-  name?: string | null;
-  /** Language name in native script */
-  native_name?: string | null;
-}
-
-export interface LanguageQuery {
-  skip?: number | null;
-  limit?: number | null;
-  /** Filter by language code */
-  code?: string | null;
-  /** Filter by language name */
-  name?: string | null;
-  /** Filter by native language name */
-  native_name?: string | null;
-}
-
-/**
- * Get deployment details.
- */
-export interface CourseContentDeploymentGet {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  id: string;
-  course_content_id: string;
-  example_version_id: string | null;
-  example_identifier?: string | null;
-  version_tag?: string | null;
-  deployment_status: string;
-  deployment_message?: string | null;
-  assigned_at: string;
-  deployed_at?: string | null;
-  last_attempt_at?: string | null;
-  deployment_path?: string | null;
-  version_identifier?: string | null;
-  deployment_metadata?: Record<string, any> | null;
-  workflow_id?: string | null;
-  example_version?: any | null;
-}
-
-/**
- * List view of deployments.
- */
-export interface CourseContentDeploymentList {
-  id: string;
-  course_content_id: string;
-  example_version_id: string | null;
-  example_identifier?: string | null;
-  version_tag?: string | null;
-  deployment_status: string;
-  assigned_at: string;
-  deployed_at: string | null;
-  version_identifier: string | null;
-  has_newer_version?: boolean;
-  example_version?: ExampleVersionList | null;
-}
-
-/**
- * Get deployment history entry.
- */
-export interface DeploymentHistoryGet {
-  id: string;
-  deployment_id: string;
-  action: string;
-  example_version_id: string | null;
-  previous_example_version_id: string | null;
-  example_identifier?: string | null;
-  version_tag?: string | null;
-  workflow_id: string | null;
-  created_at: string;
-  created_by: string | null;
-  example_version?: any | null;
-  previous_example_version?: any | null;
-}
-
-/**
- * Deployment with its full history.
- */
-export interface DeploymentWithHistory {
-  deployment: CourseContentDeploymentGet;
-  history: DeploymentHistoryGet[];
-}
-
-/**
- * Summary of deployments for a course.
- */
-export interface DeploymentSummary {
-  course_id: string;
-  /** Total course content items */
-  total_content: number;
-  /** Total submittable content (assignments) */
-  submittable_content: number;
-  /** Total deployments */
-  deployments_total: number;
-  /** Deployments pending */
-  deployments_pending: number;
-  /** Successfully deployed */
-  deployments_deployed: number;
-  /** Failed deployments */
-  deployments_failed: number;
-  /** Most recent deployment */
-  last_deployment_at?: string | null;
-}
-
-/**
- * GitLab connection credentials.
- */
-export interface GitLabCredentials {
-  gitlab_url: string;
-  gitlab_token: string;
-}
-
-/**
- * Per-item override for release commit selection.
- */
-export interface ReleaseOverride {
-  course_content_id: string;
-  /** Commit SHA to use for this content */
-  version_identifier: string;
-}
-
-/**
- * Selection of contents and commits for a release.
- */
-export interface ReleaseSelection {
-  /** Explicit list of course content IDs to release */
-  course_content_ids?: string[] | null;
-  /** Parent content ID; combined with include_descendants */
-  parent_id?: string | null;
-  /** Whether to include descendants of parent_id */
-  include_descendants?: boolean;
-  /** Select all contents in the course */
-  all?: boolean;
-  /** Commit SHA to apply to all selected contents (overridden by per-item overrides) */
-  global_commit?: string | null;
-  /** Per-content commit overrides */
-  overrides?: ReleaseOverride[] | null;
-}
-
-/**
- * Request to generate student template.
- */
-export interface GenerateTemplateRequest {
-  /** Custom commit message (optional) */
-  commit_message?: string | null;
-  /** Force redeployment of already deployed content */
-  force_redeploy?: boolean;
-  /** Selection of contents and commits to release */
-  release?: ReleaseSelection | null;
-}
-
-/**
- * Response for template generation request.
- */
-export interface GenerateTemplateResponse {
-  workflow_id: string;
-  status?: string;
-  contents_to_process: number;
-}
-
-/**
- * Request to generate the assignments repository from Example Library.
- */
-export interface GenerateAssignmentsRequest {
-  assignments_url?: string | null;
-  course_content_ids?: string[] | null;
-  parent_id?: string | null;
-  include_descendants?: boolean;
-  all?: boolean;
-  /** skip_if_exists|force_update */
-  overwrite_strategy?: string;
-  commit_message?: string | null;
-}
-
-export interface GenerateAssignmentsResponse {
-  workflow_id: string;
-  status?: string;
-  contents_to_process: number;
-}
-
 /**
  * Complete error definition from registry.
  */
@@ -2968,34 +3013,198 @@ export interface ErrorMetadata {
   override_details?: any | null;
 }
 
-export interface ResultCreate {
-  course_member_id: string;
-  course_content_id: string;
-  submission_group_id?: string;
-  submission_artifact_id?: string | null;
-  testing_service_id?: string | null;
-  test_system_id?: string | null;
-  result: number;
-  grade?: number | null;
-  result_json?: any | null;
-  properties?: any | null;
-  version_identifier: string;
-  reference_version_identifier?: string | null;
-  status: TaskStatus;
+export interface TestCreate {
+  artifact_id?: string | null;
+  submission_group_id?: string | null;
+  version_identifier?: string | null;
+  course_member_id?: string | null;
+  course_content_id?: string | null;
+  course_content_path?: string | null;
+  directory?: string | null;
+  project?: string | null;
+  provider_url?: string | null;
+  submit?: boolean | null;
 }
 
 /**
- * Artifact information embedded in ResultGet.
+ * Base model for test specification models (strict: extra fields forbidden).
  */
-export interface ResultArtifactInfo {
-  id: string;
-  filename: string;
-  content_type?: string | null;
-  file_size: number;
-  created_at?: string | null;
+export interface ComputorBase {
 }
 
-export interface ResultGet {
+/**
+ * Common properties for all test types.
+ */
+export interface ComputorTestCommon {
+  failureMessage?: string | null;
+  successMessage?: string | null;
+  qualification?: QualificationEnum | null;
+  relativeTolerance?: number | null;
+  absoluteTolerance?: number | null;
+  allowedOccuranceRange?: number[] | null;
+  occuranceType?: string | null;
+  typeCheck?: boolean | null;
+  shapeCheck?: boolean | null;
+  ignoreClass?: boolean | null;
+  verbosity?: number | null;
+}
+
+/**
+ * Common properties for test collections.
+ */
+export interface ComputorTestCollectionCommon {
+  failureMessage?: string | null;
+  successMessage?: string | null;
+  qualification?: QualificationEnum | null;
+  relativeTolerance?: number | null;
+  absoluteTolerance?: number | null;
+  allowedOccuranceRange?: number[] | null;
+  occuranceType?: string | null;
+  typeCheck?: boolean | null;
+  shapeCheck?: boolean | null;
+  ignoreClass?: boolean | null;
+  verbosity?: number | null;
+  storeGraphicsArtifacts?: boolean | null;
+  competency?: string | null;
+  timeout?: number | null;
+}
+
+/**
+ * Individual test case definition.
+ */
+export interface ComputorTest {
+  failureMessage?: string | null;
+  successMessage?: string | null;
+  qualification?: QualificationEnum | null;
+  relativeTolerance?: number | null;
+  absoluteTolerance?: number | null;
+  allowedOccuranceRange?: number[] | null;
+  occuranceType?: string | null;
+  typeCheck?: boolean | null;
+  shapeCheck?: boolean | null;
+  ignoreClass?: boolean | null;
+  verbosity?: number | null;
+  name: string;
+  value?: any | null;
+  evalString?: string | null;
+  pattern?: string | null;
+  countRequirement?: number | null;
+  stdin?: (string | string[]) | null;
+  expectedStdout?: (string | string[]) | null;
+  expectedStderr?: (string | string[]) | null;
+  expectedExitCode?: number | null;
+  lineNumber?: (number | number[]) | null;
+  ignoreWhitespace?: boolean | null;
+  ignoreCase?: boolean | null;
+  trimOutput?: boolean | null;
+  normalizeNewlines?: boolean | null;
+  numericTolerance?: number | null;
+  allowEmpty?: boolean | null;
+}
+
+/**
+ * Test collection (group of related tests).
+ */
+export interface ComputorTestCollection {
+  failureMessage?: string | null;
+  successMessage?: string | null;
+  qualification?: QualificationEnum | null;
+  relativeTolerance?: number | null;
+  absoluteTolerance?: number | null;
+  allowedOccuranceRange?: number[] | null;
+  occuranceType?: string | null;
+  typeCheck?: boolean | null;
+  shapeCheck?: boolean | null;
+  ignoreClass?: boolean | null;
+  verbosity?: number | null;
+  storeGraphicsArtifacts?: boolean | null;
+  competency?: string | null;
+  timeout?: number | null;
+  type?: TypeEnum | null;
+  name: string;
+  description?: string | null;
+  successDependency?: (string | number | any[]) | null;
+  setUpCodeDependency?: string | null;
+  entryPoint?: string | null;
+  inputAnswers?: (string | string[]) | null;
+  setUpCode?: (string | string[]) | null;
+  tearDownCode?: (string | string[]) | null;
+  id?: string | null;
+  file?: string | null;
+  tests: ComputorTest[];
+  compiler?: string | null;
+  compilerFlags?: string[] | null;
+  linkerFlags?: string[] | null;
+  sourceFiles?: string[] | null;
+  executableName?: string | null;
+  workingDirectory?: string | null;
+  environment?: any | null;
+  memoryLimit?: number | null;
+  args?: string[] | null;
+}
+
+/**
+ * Test suite properties with defaults.
+ */
+export interface ComputorTestProperty {
+  failureMessage?: string | null;
+  successMessage?: string | null;
+  qualification?: QualificationEnum | null;
+  relativeTolerance?: number | null;
+  absoluteTolerance?: number | null;
+  allowedOccuranceRange?: number[] | null;
+  occuranceType?: string | null;
+  typeCheck?: boolean | null;
+  shapeCheck?: boolean | null;
+  ignoreClass?: boolean | null;
+  verbosity?: number | null;
+  storeGraphicsArtifacts?: boolean | null;
+  competency?: string | null;
+  timeout?: number | null;
+  resultMessage?: string | null;
+  tests?: ComputorTestCollection[];
+}
+
+/**
+ * Main test suite definition (test.yaml root).
+ */
+export interface ComputorTestSuite {
+  type?: string | null;
+  name?: string | null;
+  description?: string | null;
+  version?: string | null;
+  properties?: ComputorTestProperty;
+}
+
+/**
+ * Specification for test execution directories.
+ */
+export interface ComputorSpecification {
+  executionDirectory?: string | null;
+  studentDirectory?: string | null;
+  referenceDirectory?: string | null;
+  testDirectory?: string | null;
+  outputDirectory?: string | null;
+  artifactDirectory?: string | null;
+  testVersion?: string | null;
+  storeGraphicsArtifacts?: boolean | null;
+  outputName?: string | null;
+  isLocalUsage?: boolean | null;
+  studentTestCounter?: number | null;
+}
+
+export interface StudentProfileCreate {
+  student_id?: string | null;
+  student_email?: string | null;
+  user_id?: string | null;
+  organization_id: string;
+}
+
+export interface StudentProfileGet {
+  student_id?: string | null;
+  student_email?: string | null;
+  user_id: string;
+  organization_id: string;
   /** Creation timestamp */
   created_at?: string | null;
   /** Update timestamp */
@@ -3003,298 +3212,150 @@ export interface ResultGet {
   created_by?: string | null;
   updated_by?: string | null;
   id: string;
-  course_member_id: string;
-  course_content_id: string;
-  course_content_type_id: string;
-  submission_group_id?: string | null;
-  submission_artifact_id?: string | null;
-  testing_service_id?: string | null;
-  test_system_id?: string | null;
-  result: number;
-  grade?: number | null;
-  result_json?: any | null;
-  properties?: any | null;
-  version_identifier: string;
-  reference_version_identifier?: string | null;
-  status: TaskStatus;
-  grading_ids?: string[] | null;
-  has_artifacts?: boolean;
-  artifact_count?: number;
-  result_artifacts?: ResultArtifactInfo[];
+  organization?: OrganizationGet | null;
 }
 
-export interface ResultList {
+export interface StudentProfileList {
+  id: string;
+  student_id?: string | null;
+  student_email?: string | null;
+  user_id: string;
+  organization_id: string;
+}
+
+export interface StudentProfileUpdate {
+  student_id?: string | null;
+  student_email?: string | null;
+  properties?: any | null;
+  organization_id?: string | null;
+}
+
+export interface StudentProfileQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  student_id?: string | null;
+  student_email?: string | null;
+  user_id?: string | null;
+  organization_id?: string | null;
+}
+
+/**
+ * Payload describing a manual submission request.
+ */
+export interface SubmissionCreate {
+  submission_group_id: string;
+  version_identifier?: string | null;
+  submit?: boolean;
+}
+
+/**
+ * Metadata about a file extracted from a submission archive.
+ */
+export interface SubmissionUploadedFile {
+  object_key: string;
+  size: number;
+  content_type: string;
+  relative_path: string;
+}
+
+/**
+ * Response returned after processing a manual submission.
+ */
+export interface SubmissionUploadResponseModel {
+  artifacts: string[];
+  submission_group_id: string;
+  uploaded_by_course_member_id: string;
+  total_size: number;
+  files_count: number;
+  uploaded_at: string;
+  version_identifier: string;
+}
+
+/**
+ * List item representation for manual submissions stored as results.
+ */
+export interface SubmissionListItem {
   /** Creation timestamp */
   created_at?: string | null;
   /** Update timestamp */
   updated_at?: string | null;
   id: string;
+  submit: boolean;
   course_member_id: string;
   course_content_id: string;
-  course_content_type_id: string;
   submission_group_id?: string | null;
-  submission_artifact_id?: string | null;
   testing_service_id?: string | null;
   test_system_id?: string | null;
-  result: number;
-  grade?: number | null;
   version_identifier: string;
   reference_version_identifier?: string | null;
   status: TaskStatus;
-  has_artifacts?: boolean;
-  artifact_count?: number;
+  result: number;
+  result_json?: Record<string, any> | null;
+  properties?: Record<string, any> | null;
 }
 
-export interface ResultUpdate {
-  result?: number | null;
-  grade?: number | null;
-  result_json?: any | null;
-  status?: TaskStatus | null;
-  test_system_id?: string | null;
-  properties?: any | null;
-}
-
-export interface ResultQuery {
+/**
+ * Query parameters for listing manual submissions.
+ */
+export interface SubmissionQuery {
   skip?: number | null;
   limit?: number | null;
   id?: string | null;
-  submitter_id?: string | null;
+  submit?: boolean | null;
   course_member_id?: string | null;
-  course_content_id?: string | null;
-  course_content_type_id?: string | null;
   submission_group_id?: string | null;
-  submission_artifact_id?: string | null;
+  course_content_id?: string | null;
   testing_service_id?: string | null;
   test_system_id?: string | null;
   version_identifier?: string | null;
-  status?: TaskStatus | null;
-  latest?: boolean | null;
-  result?: number | null;
-  grade?: number | null;
-}
-
-/**
- * Result with associated grading information.
- */
-export interface ResultWithGrading {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  id: string;
-  course_member_id: string;
-  course_content_id: string;
-  course_content_type_id: string;
-  submission_group_id?: string | null;
-  submission_artifact_id?: string | null;
-  testing_service_id?: string | null;
-  test_system_id?: string | null;
-  result: number;
-  grade?: number | null;
-  result_json?: any | null;
-  properties?: any | null;
-  version_identifier: string;
   reference_version_identifier?: string | null;
-  status: TaskStatus;
-  grading_ids?: string[] | null;
-  has_artifacts?: boolean;
-  artifact_count?: number;
-  result_artifacts?: ResultArtifactInfo[];
-  latest_grading?: any | null;
-  grading_count?: number;
+  status?: TaskStatus | null;
 }
 
-/**
- * Create a new grading for a submission group.
- */
-export interface SubmissionGroupGradingCreate {
-  submission_group_id: string;
-  graded_by_course_member_id: string;
-  result_id?: string | null;
-  grading: number;
-  status?: GradingStatus;
-  feedback?: string | null;
-  graded_by_course_member?: GradedByCourseMember | null;
+export interface LanguageCreate {
+  /** ISO 639-1 language code (2 lowercase letters) */
+  code: string;
+  /** Language name in English */
+  name: string;
+  /** Language name in native script */
+  native_name?: string | null;
 }
 
-/**
- * Full grading information.
- */
-export interface SubmissionGroupGradingGet {
-  created_at: string;
-  updated_at: string;
-  created_by?: string | null;
-  updated_by?: string | null;
-  id: string;
-  submission_group_id: string;
-  graded_by_course_member_id: string;
-  result_id?: string | null;
-  grading: number;
-  status: GradingStatus;
-  feedback?: string | null;
-  graded_by_course_member?: GradedByCourseMember | null;
+export interface LanguageGet {
+  /** ISO 639-1 language code */
+  code: string;
+  /** Language name in English */
+  name: string;
+  /** Language name in native script */
+  native_name?: string | null;
 }
 
-/**
- * List view of grading.
- */
-export interface SubmissionGroupGradingList {
-  id: string;
-  submission_group_id: string;
-  graded_by_course_member_id: string;
-  result_id?: string | null;
-  grading: number;
-  status: GradingStatus;
-  feedback?: string | null;
-  created_at: string;
-  graded_by_course_member?: GradedByCourseMember | null;
+export interface LanguageList {
+  /** ISO 639-1 language code */
+  code: string;
+  /** Language name in English */
+  name: string;
+  /** Language name in native script */
+  native_name?: string | null;
 }
 
-/**
- * Update grading information.
- */
-export interface SubmissionGroupGradingUpdate {
-  grading?: number | null;
-  status?: GradingStatus | null;
-  feedback?: string | null;
-  result_id?: string | null;
+export interface LanguageUpdate {
+  /** Language name in English */
+  name?: string | null;
+  /** Language name in native script */
+  native_name?: string | null;
 }
 
-/**
- * Query parameters for searching gradings.
- */
-export interface SubmissionGroupGradingQuery {
+export interface LanguageQuery {
   skip?: number | null;
   limit?: number | null;
-  id?: string | null;
-  submission_group_id?: string | null;
-  graded_by_course_member_id?: string | null;
-  result_id?: string | null;
-  status?: GradingStatus | null;
-  min_grade?: number | null;
-  max_grade?: number | null;
-  has_feedback?: boolean | null;
-}
-
-/**
- * Simplified grading view for students.
- */
-export interface GradingStudentView {
-  id: string;
-  grading: number;
-  status: GradingStatus;
-  feedback?: string | null;
-  graded_by_name?: string | null;
-  graded_at: string;
-}
-
-/**
- * Summary of gradings for a course content.
- */
-export interface GradingSummary {
-  course_content_id: string;
-  total_submissions: number;
-  graded_count: number;
-  ungraded_count: number;
-  corrected_count: number;
-  correction_necessary_count: number;
-  improvement_possible_count: number;
-  average_grade?: number | null;
-}
-
-export interface GitCommit {
-  hash: string;
-  date: string;
-  message: string;
-  author: string;
-}
-
-/**
- * Credentials for GitLab Personal Access Token authentication.
- */
-export interface GitLabPATCredentials {
-  /** GitLab Personal Access Token (glpat-...) */
-  access_token: string;
-  /** GitLab instance URL (e.g., https://gitlab.com) */
-  gitlab_url: string;
-}
-
-/**
- * Request to set password for first time or after reset.
- * 
- * Can authenticate either via:
- * 1. Bearer token (user already authenticated)
- * 2. Provider credentials (e.g., GitLab PAT for users without password)
- */
-export interface SetPasswordRequest {
-  /** New password (min 12 chars) */
-  new_password: string;
-  /** Confirm new password */
-  confirm_password: string;
-  /** Alternative authentication via external provider (for users without password) */
-  provider_auth?: ProviderAuthCredentials | null;
-}
-
-/**
- * Request to change user's own password.
- */
-export interface ChangePasswordRequest {
-  /** Current password */
-  old_password: string;
-  /** New password (min 12 chars) */
-  new_password: string;
-  /** Confirm new password */
-  confirm_password: string;
-}
-
-/**
- * Admin request to set another user's password.
- */
-export interface AdminSetPasswordRequest {
-  /** Target username */
-  username: string;
-  /** New password (min 12 chars) */
-  new_password: string;
-  /** Confirm new password */
-  confirm_password: string;
-  /** Require user to change password on next login */
-  force_reset?: boolean;
-}
-
-/**
- * Admin request to reset a user's password (marks for reset).
- */
-export interface AdminResetPasswordRequest {
-  /** Target username */
-  username: string;
-}
-
-/**
- * Response showing password status for a user.
- */
-export interface PasswordStatusResponse {
-  user_id: string;
-  username: string;
-  has_password: boolean;
-  password_reset_required: boolean;
-  password_type: string;
-}
-
-/**
- * Generic response for password operations.
- */
-export interface PasswordOperationResponse {
-  message: string;
-  user_id: string;
-  username: string;
-}
-
-/**
- * Base class for all deployment configurations.
- */
-export interface BaseDeployment {
+  /** Filter by language code */
+  code?: string | null;
+  /** Filter by language name */
+  name?: string | null;
+  /** Filter by native language name */
+  native_name?: string | null;
 }
 
 export interface ProfileCreate {
@@ -3392,70 +3453,25 @@ export interface ProfileQuery {
   language_code?: string | null;
 }
 
-/**
- * DTO for creating a grade through the tutor endpoint.
- * 
- * This is used when a tutor grades a student's submission for a specific course content.
- * The endpoint will automatically find the latest artifact for the submission group.
- */
-export interface TutorGradeCreate {
-  artifact_id?: string | null;
-  /** Grade between 0.0 and 1.0 */
-  grade?: number | null;
-  /** Grading status */
-  status?: GradingStatus | null;
-  /** Feedback/comment for the student */
-  feedback?: string | null;
+export interface ListQuery {
+  skip?: number | null;
+  limit?: number | null;
 }
 
-/**
- * Information about the artifact that was graded.
- * 
- * This provides context about which specific artifact received the grade,
- * useful for tracking grading history and artifact metadata.
- */
-export interface GradedArtifactInfo {
-  /** The artifact ID that was graded */
-  id: string;
-  /** When the artifact was created (ISO format) */
+export interface BaseEntityList {
+  /** Creation timestamp */
   created_at?: string | null;
-  /** Additional artifact properties (e.g., GitLab info) */
-  properties?: Record<string, any> | null;
+  /** Update timestamp */
+  updated_at?: string | null;
 }
 
-/**
- * Response after creating a grade through the tutor endpoint.
- * 
- * Returns the updated course content information with the new grade applied.
- * We extend CourseContentStudentList to maintain backward compatibility.
- */
-export interface TutorGradeResponse {
-  id: string;
-  title?: string | null;
-  path: string;
-  course_id: string;
-  course_content_type_id: string;
-  course_content_kind_id: string;
-  position: number;
-  max_group_size?: number | null;
-  submitted?: boolean | null;
-  course_content_type: CourseContentTypeList;
-  result_count: number;
-  submission_count: number;
-  max_test_runs?: number | null;
-  testing_service_id?: string | null;
-  directory?: string | null;
-  color: string;
-  result?: ResultStudentList | null;
-  submission_group?: SubmissionGroupStudentList | null;
-  unread_message_count?: number;
-  deployment?: CourseContentDeploymentList | null;
-  has_deployment?: boolean | null;
-  status?: string | null;
-  unreviewed_count?: number;
-  latest_grade_status?: string | null;
-  graded_artifact_id?: string | null;
-  graded_artifact_info?: GradedArtifactInfo | null;
+export interface BaseEntityGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
 }
 
 /**
@@ -3519,440 +3535,440 @@ export interface ContentValidationGet {
   validation_results: ContentValidationResult[];
 }
 
-export interface RepositoryConfig {
-  settings?: any | null;
-}
-
-export interface GitLabConfigGet {
-  settings?: any | null;
-  url?: string | null;
-  full_path?: string | null;
-  directory?: string | null;
-  registry?: string | null;
-  parent?: number | null;
-  group_id?: number | null;
-  parent_id?: number | null;
-  namespace_id?: number | null;
-  namespace_path?: string | null;
-  web_url?: string | null;
-  visibility?: string | null;
-  last_synced_at?: string | null;
-}
-
-export interface GitLabConfig {
-  settings?: any | null;
-  url?: string | null;
-  full_path?: string | null;
-  directory?: string | null;
-  registry?: string | null;
-  parent?: number | null;
-  group_id?: number | null;
-  parent_id?: number | null;
-  namespace_id?: number | null;
-  namespace_path?: string | null;
-  web_url?: string | null;
-  visibility?: string | null;
-  last_synced_at?: string | null;
-  token?: string | null;
-}
-
 /**
- * Metadata extracted from a VSIX manifest.
+ * Represents a test dependency with slug and version constraint.
  */
-export interface VsixMetadata {
-  /** Publisher identifier from manifest */
-  publisher: string;
-  /** Extension name/ID from manifest */
-  name: string;
-  /** Semantic version from manifest */
-  version: string;
-  /** Display name from manifest */
-  display_name?: string | null;
-  /** Description from manifest */
-  description?: string | null;
-  /** VS Code engine compatibility range */
-  engine_range?: string | null;
-}
-
-/**
- * Form metadata submitted when publishing a new extension version.
- */
-export interface ExtensionPublishRequest {
-  /** Semantic version override (defaults to manifest value) */
+export interface TestDependency {
+  /** Hierarchical slug of the dependency example (e.g., 'physics.math.vectors') */
+  slug: string;
+  /** Version constraint (e.g., '>=1.2.0', '^2.1.0', '1.0.0'). If not specified, uses latest version. */
   version?: string | null;
-  /** VS Code engine compatibility override */
-  engine_range?: string | null;
-  /** Friendly display name for the extension */
-  display_name?: string | null;
-  /** Optional extension description */
+}
+
+/**
+ * Base class for all CodeAbility meta models.
+ */
+export interface CodeAbilityBase {
+}
+
+/**
+ * Link to external resources.
+ */
+export interface CodeAbilityLink {
+  /** Description of the link */
+  description: string;
+  /** URL of the link */
+  url: string;
+}
+
+/**
+ * Person information for authors/maintainers.
+ */
+export interface CodeAbilityPerson {
+  /** Full name */
+  name?: string | null;
+  /** Email address */
+  email?: string | null;
+  /** Institutional affiliation */
+  affiliation?: string | null;
+}
+
+/**
+ * Properties specific to assignment-level meta.
+ */
+export interface CodeAbilityMetaProperties {
+  /** Files that students must submit */
+  studentSubmissionFiles?: string[] | null;
+  /** Additional files provided to students */
+  additionalFiles?: string[] | null;
+  /** Test files for automated grading */
+  testFiles?: string[] | null;
+  /** Template files for student projects */
+  studentTemplates?: string[] | null;
+  /** List of example dependencies. Can be simple strings (slugs) or objects with slug and version constraints */
+  testDependencies?: string | TestDependency[] | null;
+  /** Execution backend configuration for this assignment */
+  executionBackend?: CourseExecutionBackendConfig | null;
+}
+
+/**
+ * Meta information for assignments/examples.
+ */
+export interface CodeAbilityMeta {
+  /** Version of the meta format */
+  version?: string | null;
+  /** Unique identifier for the assignment */
+  slug?: string | null;
+  /** Human-readable title */
+  title?: string | null;
+  /** Detailed description of the content */
   description?: string | null;
+  /** Primary language of the content (e.g., 'en', 'de', 'fr', etc.) */
+  language?: string | null;
+  /** License information */
+  license?: string | null;
+  /** Content authors */
+  authors?: CodeAbilityPerson[] | null;
+  /** Content maintainers */
+  maintainers?: CodeAbilityPerson[] | null;
+  /** Related links */
+  links?: CodeAbilityLink[] | null;
+  /** Supporting material links */
+  supportingMaterial?: CodeAbilityLink[] | null;
+  /** Keywords for categorization */
+  keywords?: string[] | null;
+  /** Assignment-specific properties */
+  properties?: CodeAbilityMetaProperties | null;
 }
 
 /**
- * Common fields describing an extension version.
+ * Reference material link (new format).
+ * 
+ * Uses 'name' instead of 'description' (cf. CodeAbilityLink).
+ * Used for courseMaterials and supportingMaterials in the new meta format.
  */
-export interface ExtensionVersionBase {
-  /** Semantic version identifier */
-  version: string;
-  /** Sequential version number for ordering */
-  version_number: number;
-  /** VS Code engine compatibility constraint */
-  engine_range?: string | null;
-  /** Whether the version is yanked */
-  yanked?: boolean;
-  /** Package size in bytes */
-  size: number;
-  /** SHA256 checksum of the VSIX contents */
-  sha256: string;
-  /** Stored content type of the VSIX */
-  content_type: string;
-  /** Creation timestamp */
-  created_at: string;
-  /** Publish timestamp */
-  published_at: string;
-}
-
-/**
- * List view of extension versions.
- */
-export interface ExtensionVersionListItem {
-  /** Semantic version identifier */
-  version: string;
-  /** Sequential version number for ordering */
-  version_number: number;
-  /** VS Code engine compatibility constraint */
-  engine_range?: string | null;
-  /** Whether the version is yanked */
-  yanked?: boolean;
-  /** Package size in bytes */
-  size: number;
-  /** SHA256 checksum of the VSIX contents */
-  sha256: string;
-  /** Stored content type of the VSIX */
-  content_type: string;
-  /** Creation timestamp */
-  created_at: string;
-  /** Publish timestamp */
-  published_at: string;
-}
-
-/**
- * Detailed view of an extension version.
- */
-export interface ExtensionVersionDetail {
-  /** Semantic version identifier */
-  version: string;
-  /** Sequential version number for ordering */
-  version_number: number;
-  /** VS Code engine compatibility constraint */
-  engine_range?: string | null;
-  /** Whether the version is yanked */
-  yanked?: boolean;
-  /** Package size in bytes */
-  size: number;
-  /** SHA256 checksum of the VSIX contents */
-  sha256: string;
-  /** Stored content type of the VSIX */
-  content_type: string;
-  /** Creation timestamp */
-  created_at: string;
-  /** Publish timestamp */
-  published_at: string;
-  /** Object storage key for the VSIX */
-  object_key: string;
-}
-
-/**
- * Response payload for version listing.
- */
-export interface ExtensionVersionListResponse {
-  items?: ExtensionVersionListItem[];
-  /** Pagination cursor for the next page, if available */
-  next_cursor?: string | null;
-}
-
-/**
- * Extension-level metadata including latest version information.
- */
-export interface ExtensionMetadata {
-  /** Publisher identifier */
-  publisher: string;
-  /** Extension name */
+export interface ComputorMaterial {
+  /** Identifier/key for this material (e.g., 'mat2str', 'wiki-ASCII') */
   name: string;
-  /** Friendly display name for the extension */
-  display_name?: string | null;
-  /** Extension description */
+  /** URL to the resource */
+  url: string;
+}
+
+/**
+ * Typed settings for execution backend configuration.
+ * 
+ * These settings can be specified in meta.yaml to override defaults.
+ * The hierarchy is: test.yaml > meta.yaml > tester default.
+ * 
+ * Uses extra='allow' to support language-specific settings not listed here.
+ */
+export interface ExecutionBackendSettings {
+  /** Execution timeout in seconds */
+  timeout?: number | null;
+  /** Compilation timeout in seconds (for compiled languages) */
+  compileTimeout?: number | null;
+  /** Memory limit in megabytes */
+  memoryLimitMB?: number | null;
+  /** CPU time limit in seconds */
+  cpuLimit?: number | null;
+  /** Maximum number of processes/threads */
+  maxProcesses?: number | null;
+  /** Environment variables (KEY=VALUE format) */
+  env?: string[] | null;
+  /** Compiler to use (gcc, g++, clang, gfortran, etc.) */
+  compiler?: string | null;
+  /** Compiler/interpreter flags */
+  flags?: string[] | null;
+}
+
+/**
+ * Execution backend configuration (new format).
+ * 
+ * Extends CourseExecutionBackendConfig with typed settings and optional version.
+ * 
+ * Example in meta.yaml:
+ * properties:
+ * executionBackend:
+ * slug: itpcp.exec.c
+ * version: "13"
+ * settings:
+ * timeout: 60
+ * memoryLimitMB: 256
+ * compiler: gcc
+ * flags: ["-Wall", "-Wextra"]
+ */
+export interface ExecutionBackend {
+  /** Backend identifier (e.g., 'itpcp.exec.mat', 'itpcp.exec.c') */
+  slug: string;
+  /** Backend/language version requirement */
+  version?: string | null;
+  /** Backend-specific settings (timeout, memory, etc.) */
+  settings?: ExecutionBackendSettings | null;
+}
+
+/**
+ * Content categorization for examples (new format).
+ * 
+ * Provides structured metadata for organizing, searching, and filtering.
+ * Replaces the flat 'keywords' field from the old format.
+ */
+export interface ContentMetadata {
+  /** Type of example: programming, mathematics, visualization, etc. */
+  types?: string[] | null;
+  /** Curricular classification: mathematics, computer_science, physics, etc. */
+  disciplines?: string[] | null;
+  /** Hierarchical topics in Ltree format (e.g., 'math.linear_equations') */
+  topics?: string[] | null;
+  /** Tools/languages used: matlab, octave, python, latex, etc. */
+  tools?: string[] | null;
+  /** Free-form tags for additional categorization (replaces keywords) */
+  tags?: string[] | null;
+}
+
+/**
+ * Properties section of meta.yaml (new format).
+ * 
+ * Similar to CodeAbilityMetaProperties but uses typed ExecutionBackend
+ * and simpler testDependencies (plain strings only).
+ */
+export interface ComputorMetaProperties {
+  studentSubmissionFiles?: string[] | null;
+  additionalFiles?: string[] | null;
+  testFiles?: string[] | null;
+  studentTemplates?: string[] | null;
+  /** Execution backend configuration */
+  executionBackend?: ExecutionBackend | null;
+  testDependencies?: string[] | null;
+}
+
+/**
+ * Meta.yaml schema for example/assignment metadata (new format).
+ * 
+ * This is the proposed evolution of CodeAbilityMeta:
+ * - 'slug' renamed to 'identifier'
+ * - 'links' renamed to 'courseMaterials' (using ComputorMaterial with 'name')
+ * - 'supportingMaterial' renamed to 'supportingMaterials' (plural)
+ * - 'keywords' replaced by 'content.tags' (structured ContentMetadata)
+ * - 'language' removed (now derived from content/index_*.md files)
+ * - Typed ExecutionBackendSettings instead of plain dict
+ * 
+ * The old format (CodeAbilityMeta) remains the primary production format.
+ */
+export interface ComputorMeta {
+  /** Unique identifier for this example (e.g., 'itpcp.pgph.mat.hello_world') */
+  identifier?: string | null;
+  /** Version of the meta format */
+  version?: string | null;
+  /** Human-readable title */
+  title?: string | null;
+  /** Detailed description of the content */
   description?: string | null;
-  /** Database identifier for the extension */
-  id: string;
-  /** Creation timestamp */
-  created_at: string;
-  /** Last update timestamp */
-  updated_at: string;
-  /** Number of stored versions */
-  version_count: number;
-  /** Metadata for the latest available version */
-  latest_version?: ExtensionVersionListItem | null;
+  /** License information */
+  license?: string | null;
+  /** Content authors */
+  authors?: CodeAbilityPerson[] | null;
+  /** Content maintainers */
+  maintainers?: CodeAbilityPerson[] | null;
+  /** Lecture/course materials (presentations, tutorials, etc.) */
+  courseMaterials?: ComputorMaterial[] | null;
+  /** API references and documentation (function docs, etc.) */
+  supportingMaterials?: ComputorMaterial[] | null;
+  /** Content categorization (types, disciplines, topics, tools, tags) */
+  content?: ContentMetadata | null;
+  /** Assignment-specific properties */
+  properties?: ComputorMetaProperties | null;
 }
 
 /**
- * Request payload to (un)yank a specific version.
+ * Optional configuration for tutor test (passed as JSON in form data).
  */
-export interface ExtensionVersionYankRequest {
-  /** Target yank state for the version */
-  yanked: boolean;
+export interface TutorTestConfig {
+  store_graphics_artifacts?: boolean;
+  timeout_seconds?: number | null;
 }
 
 /**
- * Response payload returned after publishing a version.
+ * Response when creating a tutor test - just the essentials.
  */
-export interface ExtensionPublishResponse {
-  /** Semantic version identifier */
-  version: string;
-  /** Sequential version number for ordering */
-  version_number: number;
-  /** VS Code engine compatibility constraint */
-  engine_range?: string | null;
-  /** Whether the version is yanked */
-  yanked?: boolean;
-  /** Package size in bytes */
-  size: number;
-  /** SHA256 checksum of the VSIX contents */
-  sha256: string;
-  /** Stored content type of the VSIX */
-  content_type: string;
-  /** Creation timestamp */
-  created_at: string;
-  /** Publish timestamp */
-  published_at: string;
-  /** Object storage key for the VSIX */
-  object_key: string;
-  /** Publisher identifier */
-  publisher: string;
-  /** Extension name */
-  name: string;
-}
-
-/**
- * Request to assign an example to a course content (assignment).
- */
-export interface AssignExampleRequest {
-  /** ID of the example to assign (UUID) */
-  example_id?: string | null;
-  /** Identifier path of the example (e.g., 'itpcp.pgph.mat.function_time_formatter') */
-  example_identifier?: string | null;
-  /** Specific version tag using semantic versioning (e.g., '1.0.0', '2.1.3-beta') */
-  version_tag: string;
-}
-
-/**
- * Response after assigning an example.
- */
-export interface AssignExampleResponse {
-  /** ID of the deployment record */
-  deployment_id: string;
-  course_content_id: string;
-  example_id: string;
-  example_version_id: string;
-  version_tag: string;
-  /** Status: 'pending' */
-  deployment_status: string;
-  assigned_at: string;
-  /** Success message */
-  message: string;
-}
-
-/**
- * Detailed deployment information for a course content.
- */
-export interface DeploymentGet {
-  id: string;
-  course_content_id: string;
-  example_id?: string | null;
-  example_version_id?: string | null;
-  example_identifier?: string | null;
-  version_tag?: string | null;
-  deployment_status: string;
-  deployment_message?: string | null;
-  assigned_at: string;
-  deployed_at?: string | null;
-  deployment_path?: string | null;
-  /** Whether a newer version of the assigned example exists */
-  has_newer_version?: boolean;
-  example_title?: string | null;
-  example_directory?: string | null;
-  example_description?: string | null;
-  course_content_title?: string | null;
-  course_content_path?: string | null;
-}
-
-/**
- * Minimal deployment info for list views.
- */
-export interface DeploymentList {
-  id: string;
-  course_content_id: string;
-  deployment_status: string;
-  version_tag?: string | null;
-  assigned_at: string;
-  deployed_at?: string | null;
-}
-
-/**
- * Response after unassigning an example.
- */
-export interface UnassignExampleResponse {
-  course_content_id: string;
-  /** Success message */
-  message: string;
-  previous_example_id?: string | null;
-  previous_version_tag?: string | null;
-}
-
-/**
- * Single validation error for release validation.
- */
-export interface ValidationError {
-  course_content_id: string;
-  title: string;
-  path: string;
-  issue: string;
-}
-
-/**
- * Error response when release validation fails.
- */
-export interface ReleaseValidationError {
-  /** Main error message */
-  error: string;
-  /** List of specific issues */
-  validation_errors: ValidationError[];
-  /** Count of validation errors */
-  total_issues: number;
-}
-
-/**
- * Single deployment in batch listing — includes version freshness.
- */
-export interface CourseDeploymentList {
-  course_content_id: string;
-  example_id?: string | null;
-  example_identifier?: string | null;
-  version_tag?: string | null;
-  deployment_status: string;
-  deployed_at?: string | null;
-  /** Whether a newer version of the assigned example exists */
-  has_newer_version?: boolean;
-  /** Version tag of the latest available version */
-  latest_version_tag?: string | null;
-  course_content_title?: string | null;
-  course_content_path?: string | null;
-}
-
-/**
- * Response: all deployments for a course with version freshness.
- */
-export interface CourseDeploymentGet {
-  course_id: string;
-  /** Total number of deployments returned */
-  total: number;
-  deployments: CourseDeploymentList[];
-}
-
-/**
- * Request to batch-upgrade course contents to latest example versions.
- */
-export interface VersionUpgradeCreate {
-  /** List of course content IDs to upgrade */
-  course_content_ids: string[];
-}
-
-/**
- * Per-item upgrade result.
- */
-export interface VersionUpgradeResult {
-  course_content_id: string;
-  success: boolean;
-  from_tag?: string | null;
-  to_tag?: string | null;
-  error?: string | null;
-}
-
-/**
- * Response: batch upgrade results.
- */
-export interface VersionUpgradeGet {
-  /** Number of items requested */
-  total_requested: number;
-  /** Number of items successfully upgraded */
-  total_upgraded: number;
-  /** Number of items already at latest version */
-  total_skipped: number;
-  /** Number of items that failed to upgrade */
-  total_failed: number;
-  results: VersionUpgradeResult[];
-}
-
-export interface SubmissionGroupMemberProperties {
-  gitlab?: GitLabConfig | null;
-}
-
-export interface SubmissionGroupMemberCreate {
-  course_member_id: string;
-  submission_group_id: string;
-  grading?: number | null;
-  properties?: SubmissionGroupMemberProperties | null;
-}
-
-export interface SubmissionGroupMemberGet {
-  /** Creation timestamp */
+export interface TutorTestCreateResponse {
+  test_id: string;
+  status?: "pending" | "running" | "completed" | "failed" | "timeout";
   created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  id: string;
-  course_id: string;
-  course_member_id: string;
-  submission_group_id: string;
-  grading?: number | null;
-  status?: string | null;
-  properties?: SubmissionGroupMemberProperties | null;
 }
 
-export interface SubmissionGroupMemberList {
-  id: string;
-  course_id: string;
-  course_member_id: string;
-  submission_group_id: string;
-  grading?: number | null;
-  status?: string | null;
+/**
+ * Quick status check for a tutor test run (for polling).
+ */
+export interface TutorTestStatus {
+  test_id: string;
+  status: "pending" | "running" | "completed" | "failed" | "timeout";
+  created_at?: string | null;
+  started_at?: string | null;
+  finished_at?: string | null;
+  has_artifacts?: boolean;
+  artifact_count?: number;
 }
 
-export interface SubmissionGroupMemberUpdate {
-  course_id?: string | null;
-  grading?: number | null;
-  status?: string | null;
-  properties?: SubmissionGroupMemberProperties | null;
+/**
+ * Full tutor test details including result_dict from MinIO.
+ */
+export interface TutorTestGet {
+  test_id: string;
+  status: "pending" | "running" | "completed" | "failed" | "timeout";
+  created_at?: string | null;
+  started_at?: string | null;
+  finished_at?: string | null;
+  result_dict?: any | null;
+  passed?: number | null;
+  failed?: number | null;
+  total?: number | null;
+  result_value?: number | null;
+  error?: string | null;
+  has_artifacts?: boolean;
+  artifact_count?: number;
 }
 
-export interface SubmissionGroupMemberQuery {
-  skip?: number | null;
-  limit?: number | null;
-  id?: string | null;
-  course_id?: string | null;
-  course_content_id?: string | null;
-  course_member_id?: string | null;
-  submission_group_id?: string | null;
-  grading?: number | null;
-  status?: string | null;
+/**
+ * Information about a single artifact.
+ */
+export interface TutorTestArtifactInfo {
+  filename: string;
+  size: number;
+  last_modified?: string | null;
+}
+
+/**
+ * List of artifacts from a tutor test.
+ */
+export interface TutorTestArtifactList {
+  test_id: string;
+  artifacts?: TutorTestArtifactInfo[];
+  total_count?: number;
+}
+
+/**
+ * Test count statistics.
+ */
+export interface ComputorReportSummary {
+  total?: number;
+  passed?: number;
+  failed?: number;
+  skipped?: number;
+}
+
+/**
+ * Common properties for test report entries.
+ */
+export interface ComputorReportProperties {
+  timestamp?: string | null;
+  type?: string | null;
+  version?: string | null;
+  name?: string | null;
+  description?: string | null;
+  status?: StatusEnum | null;
+  result?: ResultEnum | null;
+  summary?: ComputorReportSummary | null;
+  statusMessage?: string | null;
+  resultMessage?: string | null;
+  details?: string | null;
+  setup?: string | null;
+  teardown?: string | null;
+  duration?: number | null;
+  executionDuration?: number | null;
+  environment?: any | null;
+  properties?: any | null;
+  debug?: any | null;
+}
+
+/**
+ * Individual test result within a test collection.
+ */
+export interface ComputorReportSub {
+  timestamp?: string | null;
+  type?: string | null;
+  version?: string | null;
+  name?: string | null;
+  description?: string | null;
+  status?: StatusEnum | null;
+  result?: ResultEnum | null;
+  summary?: ComputorReportSummary | null;
+  statusMessage?: string | null;
+  resultMessage?: string | null;
+  details?: string | null;
+  setup?: string | null;
+  teardown?: string | null;
+  duration?: number | null;
+  executionDuration?: number | null;
+  environment?: any | null;
+  properties?: any | null;
+  debug?: any | null;
+}
+
+/**
+ * Test collection result containing individual test results.
+ */
+export interface ComputorReportMain {
+  timestamp?: string | null;
+  type?: string | null;
+  version?: string | null;
+  name?: string | null;
+  description?: string | null;
+  status?: StatusEnum | null;
+  result?: ResultEnum | null;
+  summary?: ComputorReportSummary | null;
+  statusMessage?: string | null;
+  resultMessage?: string | null;
+  details?: string | null;
+  setup?: string | null;
+  teardown?: string | null;
+  duration?: number | null;
+  executionDuration?: number | null;
+  environment?: any | null;
+  properties?: any | null;
+  debug?: any | null;
+  tests?: ComputorReportSub[] | null;
+}
+
+/**
+ * Top-level test report containing test collection results.
+ */
+export interface ComputorReport {
+  timestamp?: string | null;
+  type?: string | null;
+  version?: string | null;
+  name?: string | null;
+  description?: string | null;
+  status?: StatusEnum | null;
+  result?: ResultEnum | null;
+  summary?: ComputorReportSummary | null;
+  statusMessage?: string | null;
+  resultMessage?: string | null;
+  details?: string | null;
+  setup?: string | null;
+  teardown?: string | null;
+  duration?: number | null;
+  executionDuration?: number | null;
+  environment?: any | null;
+  properties?: any | null;
+  debug?: any | null;
+  tests?: ComputorReportMain[] | null;
+}
+
+/**
+ * Semantic version following semver.org spec (subset).
+ * 
+ * Supports format: <major>.<minor>.<patch>[-<prerelease>]
+ * 
+ * Examples:
+ * - 1.0.0
+ * - 2.1.3
+ * - 1.0.0-alpha
+ * - 3.2.1-beta.2
+ */
+export interface SemanticVersion {
+  /** Major version number */
+  major: number;
+  /** Minor version number */
+  minor: number;
+  /** Patch version number */
+  patch: number;
+  /** Optional prerelease identifier */
+  prerelease?: any;
 }
 
 
+
+export type ForceLevel = "none" | "old" | "all";
+
+export type GradingStatus = 0 | 1 | 2 | 3;
 
 export type GroupType = "fixed" | "dynamic";
 
 export type MergeMethod = "rebase_merge" | "merge" | "ff";
+
+export type ErrorSeverity = "info" | "warning" | "error" | "critical";
+
+export type ErrorCategory = "authentication" | "authorization" | "validation" | "not_found" | "conflict" | "rate_limit" | "external_service" | "database" | "internal" | "not_implemented";
 
 export type QualificationEnum = "verifyEqual" | "matches" | "contains" | "startsWith" | "endsWith" | "count" | "regexp" | "matchesLine" | "containsLine" | "lineCount" | "regexpMultiline" | "numericOutput" | "exitCode";
 
@@ -3961,13 +3977,5 @@ export type TypeEnum = "variable" | "graphics" | "structural" | "linting" | "exi
 export type StatusEnum = "SCHEDULED" | "COMPLETED" | "TIMEDOUT" | "CRASHED" | "CANCELLED" | "SKIPPED" | "FAILED";
 
 export type ResultEnum = "PASSED" | "FAILED" | "SKIPPED";
-
-export type ForceLevel = "none" | "old" | "all";
-
-export type ErrorSeverity = "info" | "warning" | "error" | "critical";
-
-export type ErrorCategory = "authentication" | "authorization" | "validation" | "not_found" | "conflict" | "rate_limit" | "external_service" | "database" | "internal" | "not_implemented";
-
-export type GradingStatus = 0 | 1 | 2 | 3;
 
 export type ErrorCode = "AUTH_001" | "AUTH_002" | "AUTH_003" | "AUTH_004" | "AUTHZ_001" | "AUTHZ_002" | "AUTHZ_003" | "AUTHZ_004" | "AUTHZ_005" | "VAL_001" | "VAL_002" | "VAL_003" | "VAL_004" | "NF_001" | "NF_002" | "NF_003" | "NF_004" | "CONFLICT_001" | "CONFLICT_002" | "RATE_001" | "RATE_002" | "RATE_003" | "CONTENT_001" | "CONTENT_002" | "CONTENT_003" | "CONTENT_004" | "CONTENT_005" | "CONTENT_006" | "CONTENT_007" | "VERSION_001" | "DEPLOY_001" | "DEPLOY_002" | "DEPLOY_003" | "DEPLOY_004" | "DEPLOY_005" | "SUBMIT_001" | "SUBMIT_002" | "SUBMIT_003" | "SUBMIT_004" | "SUBMIT_005" | "SUBMIT_006" | "SUBMIT_007" | "SUBMIT_008" | "TASK_001" | "TASK_002" | "TASK_003" | "TASK_004" | "GITLAB_001" | "GITLAB_002" | "GITLAB_003" | "GITLAB_004" | "GITLAB_005" | "GITLAB_006" | "GITLAB_007" | "GITLAB_008" | "EXT_001" | "EXT_002" | "EXT_003" | "EXT_004" | "EXT_005" | "DB_001" | "DB_002" | "DB_003" | "INT_001" | "INT_002" | "NIMPL_001";

--- a/src/types/generated/courses.ts
+++ b/src/types/generated/courses.ts
@@ -29,406 +29,6 @@ export interface CourseContentMoveRequest {
 }
 
 /**
- * Repository information for course content in lecturer view.
- */
-export interface CourseContentRepositoryLecturerGet {
-  url?: string | null;
-  full_path?: string | null;
-}
-
-/**
- * DTO for lecturer GET of course content with course repository info.
- */
-export interface CourseContentLecturerGet {
-  id: string;
-  archived_at?: string | null;
-  title?: string | null;
-  description?: string | null;
-  path: string;
-  course_id: string;
-  course_content_type_id: string;
-  course_content_kind_id: string;
-  position: number;
-  max_group_size?: number | null;
-  max_test_runs?: number | null;
-  max_submissions?: number | null;
-  testing_service_id?: string | null;
-  is_submittable?: boolean;
-  has_deployment?: boolean | null;
-  deployment_status?: string | null;
-  course_content_type?: CourseContentTypeGet | null;
-  repository: CourseContentRepositoryLecturerGet;
-  /** Deployment information if requested via include=deployment */
-  deployment?: CourseContentDeploymentGet | null;
-}
-
-/**
- * DTO for lecturer list of course content with course repository info.
- */
-export interface CourseContentLecturerList {
-  id: string;
-  title?: string | null;
-  path: string;
-  course_id: string;
-  course_content_type_id: string;
-  course_content_kind_id: string;
-  position: number;
-  max_group_size?: number | null;
-  max_test_runs?: number | null;
-  max_submissions?: number | null;
-  testing_service_id?: string | null;
-  is_submittable?: boolean;
-  archived_at?: string | null;
-  has_deployment?: boolean | null;
-  deployment_status?: string | null;
-  course_content_type?: CourseContentTypeList | null;
-  repository: CourseContentRepositoryLecturerGet;
-  /** Deployment information if requested via include=deployment */
-  deployment?: CourseContentDeploymentList | null;
-}
-
-/**
- * Query parameters for lecturer course content.
- */
-export interface CourseContentLecturerQuery {
-  skip?: number | null;
-  limit?: number | null;
-  id?: string | null;
-  title?: string | null;
-  path?: string | null;
-  course_id?: string | null;
-  course_content_type_id?: string | null;
-  archived?: boolean | null;
-  position?: number | null;
-  max_group_size?: number | null;
-  max_test_runs?: number | null;
-  max_submissions?: number | null;
-  testing_service_id?: string | null;
-  /** Filter by whether content has a deployment */
-  has_deployment?: boolean | null;
-  directory?: string | null;
-  project?: string | null;
-  provider_url?: string | null;
-  nlevel?: number | null;
-  descendants?: string | null;
-  ascendants?: string | null;
-}
-
-/**
- * Configuration for course execution backend.
- */
-export interface CourseExecutionBackendConfig {
-  /** Unique identifier for the execution backend */
-  slug: string;
-  /** Version of the execution backend (e.g., 'r2024b', 'v1.0') */
-  version: string;
-  /** Backend-specific settings */
-  settings?: any | null;
-}
-
-/**
- * Request for importing a course member.
- */
-export interface CourseMemberImportRequest {
-  /** Email address (required) */
-  email: string;
-  /** First name */
-  given_name?: string | null;
-  /** Last name */
-  family_name?: string | null;
-  /** Course group name */
-  course_group_title?: string | null;
-  /** Course role ID (e.g., _student) */
-  course_role_id?: string;
-  /** Auto-create missing course group */
-  create_missing_group?: boolean;
-}
-
-/**
- * Response from course member import.
- */
-export interface CourseMemberImportResponse {
-  /** Whether the import was successful */
-  success: boolean;
-  /** Success or error message */
-  message?: string | null;
-  /** Created/updated course member */
-  course_member?: any | null;
-  /** Created course group if new */
-  created_group?: any | null;
-  /** Workflow ID for repository creation task (use GET /tasks/{workflow_id}/status to check progress) */
-  workflow_id?: string | null;
-}
-
-export interface CourseContentKindCreate {
-  title?: string | null;
-  description?: string | null;
-  has_ascendants: boolean;
-  has_descendants: boolean;
-  submittable: boolean;
-}
-
-export interface CourseContentKindGet {
-  title?: string | null;
-  description?: string | null;
-  has_ascendants: boolean;
-  has_descendants: boolean;
-  submittable: boolean;
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  id: string;
-}
-
-export interface CourseContentKindList {
-  id: string;
-  title?: string | null;
-  has_ascendants: boolean;
-  has_descendants: boolean;
-  submittable: boolean;
-}
-
-export interface CourseContentKindUpdate {
-  title?: string | null;
-  description?: string | null;
-}
-
-export interface CourseContentKindQuery {
-  skip?: number | null;
-  limit?: number | null;
-  id?: string | null;
-  title?: string | null;
-  description?: string | null;
-  has_ascendants?: boolean | null;
-  has_descendants?: boolean | null;
-  submittable?: boolean | null;
-}
-
-export interface CourseMemberCommentCreate {
-  id?: string | null;
-  transmitter_id?: string;
-  course_member_id: string;
-  message: string;
-}
-
-export interface CourseMemberCommentGet {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  id: string;
-  transmitter_id?: string;
-  transmitter: CourseMemberGet;
-  course_member_id: string;
-  message: string;
-}
-
-export interface CourseMemberCommentList {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  id: string;
-  transmitter_id?: string;
-  transmitter: CourseMemberList;
-  course_member_id: string;
-  message: string;
-}
-
-export interface CourseMemberCommentUpdate {
-  message?: string | null;
-}
-
-export interface CourseMemberCommentQuery {
-  skip?: number | null;
-  limit?: number | null;
-  id?: string | null;
-  transmitter_id?: string | null;
-  course_member_id?: string | null;
-}
-
-export interface CommentCreate {
-  course_member_id: any;
-  message: string;
-}
-
-export interface CommentUpdate {
-  message: string;
-}
-
-/**
- * Properties for course content (stored in JSONB).
- */
-export interface CourseContentProperties {
-  gitlab?: GitLabConfig | null;
-}
-
-/**
- * Properties for course content GET responses.
- */
-export interface CourseContentPropertiesGet {
-  gitlab?: GitLabConfigGet | null;
-}
-
-/**
- * DTO for creating course content.
- */
-export interface CourseContentCreate {
-  title?: string | null;
-  description?: string | null;
-  path: string;
-  course_id: string;
-  course_content_type_id: string;
-  properties?: CourseContentProperties | null;
-  position?: number;
-  max_group_size?: number | null;
-  max_test_runs?: number | null;
-  max_submissions?: number | null;
-  testing_service_id?: string | null;
-}
-
-/**
- * DTO for course content GET responses.
- */
-export interface CourseContentGet {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  id: string;
-  archived_at?: string | null;
-  title?: string | null;
-  description?: string | null;
-  path: string;
-  course_id: string;
-  course_content_type_id: string;
-  course_content_kind_id: string;
-  properties?: CourseContentPropertiesGet | null;
-  position: number;
-  max_group_size?: number | null;
-  max_test_runs?: number | null;
-  max_submissions?: number | null;
-  testing_service_id?: string | null;
-  is_submittable?: boolean;
-  has_deployment?: boolean | null;
-  deployment_status?: string | null;
-  /** DEPRECATED: Use deployment API */
-  example_version_id?: string | null;
-  course_content_type?: CourseContentTypeGet | null;
-  /** Deployment information if requested via include=deployment */
-  deployment?: CourseContentDeploymentGet | null;
-}
-
-/**
- * DTO for course content list responses.
- */
-export interface CourseContentList {
-  id: string;
-  title?: string | null;
-  path: string;
-  course_id: string;
-  course_content_type_id: string;
-  course_content_kind_id: string;
-  position: number;
-  max_group_size?: number | null;
-  max_test_runs?: number | null;
-  max_submissions?: number | null;
-  testing_service_id?: string | null;
-  is_submittable?: boolean;
-  course_content_type?: CourseContentTypeList | null;
-  /** Whether this content has an example deployment */
-  has_deployment?: boolean | null;
-  /** Current deployment status if has_deployment=true */
-  deployment_status?: string | null;
-  /** Deployment information if requested via include=deployment */
-  deployment?: CourseContentDeploymentList | null;
-}
-
-/**
- * DTO for updating course content.
- */
-export interface CourseContentUpdate {
-  path?: string | null;
-  title?: string | null;
-  description?: string | null;
-  course_content_type_id?: string | null;
-  properties?: CourseContentProperties | null;
-  position?: number | null;
-  max_group_size?: number | null;
-  max_test_runs?: number | null;
-  max_submissions?: number | null;
-  testing_service_id?: string | null;
-}
-
-/**
- * Query parameters for course content.
- */
-export interface CourseContentQuery {
-  skip?: number | null;
-  limit?: number | null;
-  id?: string | null;
-  title?: string | null;
-  description?: string | null;
-  path?: string | null;
-  course_id?: string | null;
-  course_content_type_id?: string | null;
-  archived?: boolean | null;
-  position?: number | null;
-  max_group_size?: number | null;
-  max_test_runs?: number | null;
-  max_submissions?: number | null;
-  testing_service_id?: string | null;
-  /** DEPRECATED: Filter by example version ID */
-  example_version_id?: string | null;
-  /** Filter by whether content has a deployment */
-  has_deployment?: boolean | null;
-}
-
-export interface CourseTutorRepository {
-  provider_url?: string | null;
-  full_path_assignments?: string | null;
-  full_path_student_template?: string | null;
-}
-
-export interface CourseTutorGet {
-  id: string;
-  title?: string | null;
-  course_family_id?: string | null;
-  organization_id?: string | null;
-  path: string;
-  repository: CourseTutorRepository;
-}
-
-export interface CourseTutorList {
-  id: string;
-  title?: string | null;
-  course_family_id?: string | null;
-  organization_id?: string | null;
-  path: string;
-  repository: CourseTutorRepository;
-}
-
-export interface CourseTutorQuery {
-  skip?: number | null;
-  limit?: number | null;
-  id?: string | null;
-  title?: string | null;
-  description?: string | null;
-  path?: string | null;
-  course_family_id?: string | null;
-  organization_id?: string | null;
-}
-
-/**
  * Readiness state for a course member to start working on provider-backed tasks.
  */
 export interface CourseMemberReadinessStatus {
@@ -451,26 +51,6 @@ export interface CourseMemberReadinessStatus {
 export interface CourseMemberValidationRequest {
   /** Access token or credential used to validate provider ownership */
   provider_access_token?: string | null;
-}
-
-export interface CourseRoleGet {
-  id: string;
-  title?: string | null;
-  description?: string | null;
-}
-
-export interface CourseRoleList {
-  id: string;
-  title?: string | null;
-  description?: string | null;
-}
-
-export interface CourseRoleQuery {
-  skip?: number | null;
-  limit?: number | null;
-  id?: string | null;
-  title?: string | null;
-  description?: string | null;
 }
 
 /**
@@ -646,6 +226,207 @@ export interface CourseContentStudentQuery {
   ascendants?: string | null;
 }
 
+export interface CourseContentKindCreate {
+  title?: string | null;
+  description?: string | null;
+  has_ascendants: boolean;
+  has_descendants: boolean;
+  submittable: boolean;
+}
+
+export interface CourseContentKindGet {
+  title?: string | null;
+  description?: string | null;
+  has_ascendants: boolean;
+  has_descendants: boolean;
+  submittable: boolean;
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+}
+
+export interface CourseContentKindList {
+  id: string;
+  title?: string | null;
+  has_ascendants: boolean;
+  has_descendants: boolean;
+  submittable: boolean;
+}
+
+export interface CourseContentKindUpdate {
+  title?: string | null;
+  description?: string | null;
+}
+
+export interface CourseContentKindQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  has_ascendants?: boolean | null;
+  has_descendants?: boolean | null;
+  submittable?: boolean | null;
+}
+
+/**
+ * Request to create a course family via Temporal workflow.
+ */
+export interface CourseFamilyTaskRequest {
+  course_family: Record<string, any>;
+  organization_id: string;
+  gitlab?: GitLabCredentials | null;
+}
+
+/**
+ * Request to create a course via Temporal workflow.
+ */
+export interface CourseTaskRequest {
+  course: Record<string, any>;
+  course_family_id: string;
+  gitlab?: GitLabCredentials | null;
+}
+
+export interface GradedByCourseMember {
+  course_role_id?: string | null;
+  user_id: string;
+  user?: GradingAuthor | null;
+}
+
+/**
+ * Properties for course content (stored in JSONB).
+ */
+export interface CourseContentProperties {
+  gitlab?: GitLabConfig | null;
+}
+
+/**
+ * Properties for course content GET responses.
+ */
+export interface CourseContentPropertiesGet {
+  gitlab?: GitLabConfigGet | null;
+}
+
+/**
+ * DTO for creating course content.
+ */
+export interface CourseContentCreate {
+  title?: string | null;
+  description?: string | null;
+  path: string;
+  course_id: string;
+  course_content_type_id: string;
+  properties?: CourseContentProperties | null;
+  position?: number;
+  max_group_size?: number | null;
+  max_test_runs?: number | null;
+  max_submissions?: number | null;
+  testing_service_id?: string | null;
+}
+
+/**
+ * DTO for course content GET responses.
+ */
+export interface CourseContentGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  archived_at?: string | null;
+  title?: string | null;
+  description?: string | null;
+  path: string;
+  course_id: string;
+  course_content_type_id: string;
+  course_content_kind_id: string;
+  properties?: CourseContentPropertiesGet | null;
+  position: number;
+  max_group_size?: number | null;
+  max_test_runs?: number | null;
+  max_submissions?: number | null;
+  testing_service_id?: string | null;
+  is_submittable?: boolean;
+  has_deployment?: boolean | null;
+  deployment_status?: string | null;
+  /** DEPRECATED: Use deployment API */
+  example_version_id?: string | null;
+  course_content_type?: CourseContentTypeGet | null;
+  /** Deployment information if requested via include=deployment */
+  deployment?: CourseContentDeploymentGet | null;
+}
+
+/**
+ * DTO for course content list responses.
+ */
+export interface CourseContentList {
+  id: string;
+  title?: string | null;
+  path: string;
+  course_id: string;
+  course_content_type_id: string;
+  course_content_kind_id: string;
+  position: number;
+  max_group_size?: number | null;
+  max_test_runs?: number | null;
+  max_submissions?: number | null;
+  testing_service_id?: string | null;
+  is_submittable?: boolean;
+  course_content_type?: CourseContentTypeList | null;
+  /** Whether this content has an example deployment */
+  has_deployment?: boolean | null;
+  /** Current deployment status if has_deployment=true */
+  deployment_status?: string | null;
+  /** Deployment information if requested via include=deployment */
+  deployment?: CourseContentDeploymentList | null;
+}
+
+/**
+ * DTO for updating course content.
+ */
+export interface CourseContentUpdate {
+  path?: string | null;
+  title?: string | null;
+  description?: string | null;
+  course_content_type_id?: string | null;
+  properties?: CourseContentProperties | null;
+  position?: number | null;
+  max_group_size?: number | null;
+  max_test_runs?: number | null;
+  max_submissions?: number | null;
+  testing_service_id?: string | null;
+}
+
+/**
+ * Query parameters for course content.
+ */
+export interface CourseContentQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  path?: string | null;
+  course_id?: string | null;
+  course_content_type_id?: string | null;
+  archived?: boolean | null;
+  position?: number | null;
+  max_group_size?: number | null;
+  max_test_runs?: number | null;
+  max_submissions?: number | null;
+  testing_service_id?: string | null;
+  /** DEPRECATED: Filter by example version ID */
+  example_version_id?: string | null;
+  /** Filter by whether content has a deployment */
+  has_deployment?: boolean | null;
+}
+
 /**
  * Grading statistics for a specific course_content_type.
  */
@@ -795,6 +576,44 @@ export interface CourseMemberGradingsQuery {
   course_id?: string | null;
 }
 
+export interface CourseStudentRepository {
+  provider_url?: string | null;
+  full_path?: string | null;
+}
+
+export interface CourseStudentGet {
+  id: string;
+  title?: string | null;
+  course_family_id?: string | null;
+  organization_id?: string | null;
+  course_content_types: CourseContentTypeGet[];
+  path: string;
+  repository: CourseStudentRepository;
+}
+
+export interface CourseStudentList {
+  id: string;
+  title?: string | null;
+  course_family_id?: string | null;
+  organization_id?: string | null;
+  path: string;
+  repository: CourseStudentRepository;
+}
+
+export interface CourseStudentQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  path?: string | null;
+  course_family_id?: string | null;
+  organization_id?: string | null;
+  provider_url?: string | null;
+  full_path?: string | null;
+  full_path_student?: string | null;
+}
+
 export interface CourseFamilyProperties {
   gitlab?: GitLabConfig | null;
 }
@@ -852,42 +671,69 @@ export interface CourseFamilyQuery {
   organization_id?: string | null;
 }
 
-export interface CourseStudentRepository {
-  provider_url?: string | null;
-  full_path?: string | null;
-}
-
-export interface CourseStudentGet {
+export interface CourseRoleGet {
   id: string;
   title?: string | null;
-  course_family_id?: string | null;
-  organization_id?: string | null;
-  course_content_types: CourseContentTypeGet[];
-  path: string;
-  repository: CourseStudentRepository;
+  description?: string | null;
 }
 
-export interface CourseStudentList {
+export interface CourseRoleList {
   id: string;
   title?: string | null;
-  course_family_id?: string | null;
-  organization_id?: string | null;
-  path: string;
-  repository: CourseStudentRepository;
+  description?: string | null;
 }
 
-export interface CourseStudentQuery {
+export interface CourseRoleQuery {
   skip?: number | null;
   limit?: number | null;
   id?: string | null;
   title?: string | null;
   description?: string | null;
-  path?: string | null;
+}
+
+export interface CourseFamilyMemberCreate {
+  id?: string | null;
+  properties?: any | null;
+  user_id: string;
+  course_family_id: string;
+  course_family_role_id: string;
+}
+
+export interface CourseFamilyMemberGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  properties?: any | null;
+  user_id: string;
+  course_family_id: string;
+  course_family_role_id: string;
+  user?: UserList | null;
+}
+
+export interface CourseFamilyMemberList {
+  id: string;
+  user_id: string;
+  course_family_id: string;
+  course_family_role_id: string;
+  user?: UserList | null;
+}
+
+export interface CourseFamilyMemberUpdate {
+  properties?: any | null;
+  course_family_role_id?: string | null;
+}
+
+export interface CourseFamilyMemberQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  user_id?: string | null;
   course_family_id?: string | null;
-  organization_id?: string | null;
-  provider_url?: string | null;
-  full_path?: string | null;
-  full_path_student?: string | null;
+  course_family_role_id?: string | null;
 }
 
 export interface CourseMemberProperties {
@@ -944,6 +790,150 @@ export interface CourseMemberQuery {
   course_role_id?: string | null;
   given_name?: string | null;
   family_name?: string | null;
+}
+
+export interface CourseTutorRepository {
+  provider_url?: string | null;
+  full_path_assignments?: string | null;
+  full_path_student_template?: string | null;
+}
+
+export interface CourseTutorGet {
+  id: string;
+  title?: string | null;
+  course_family_id?: string | null;
+  organization_id?: string | null;
+  path: string;
+  repository: CourseTutorRepository;
+}
+
+export interface CourseTutorList {
+  id: string;
+  title?: string | null;
+  course_family_id?: string | null;
+  organization_id?: string | null;
+  path: string;
+  repository: CourseTutorRepository;
+}
+
+export interface CourseTutorQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  path?: string | null;
+  course_family_id?: string | null;
+  organization_id?: string | null;
+}
+
+export interface CourseContentTypeCreate {
+  slug: string;
+  title?: string | null;
+  description?: string | null;
+  color?: string | null;
+  properties?: any | null;
+  course_id: string;
+  course_content_kind_id: string;
+}
+
+export interface CourseContentTypeGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  slug: string;
+  title?: string | null;
+  description?: string | null;
+  color: string;
+  properties?: any | null;
+  course_id: string;
+  course_content_kind_id: string;
+  course_content_kind?: CourseContentKindGet | null;
+}
+
+export interface CourseContentTypeList {
+  id: string;
+  slug: string;
+  title?: string | null;
+  color: string;
+  course_id: string;
+  course_content_kind_id: string;
+  course_content_kind?: CourseContentKindList | null;
+}
+
+export interface CourseContentTypeUpdate {
+  slug?: string | null;
+  title?: string | null;
+  color?: string | null;
+  description?: string | null;
+  properties?: any | null;
+}
+
+export interface CourseContentTypeQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  slug?: string | null;
+  title?: string | null;
+  color?: string | null;
+  description?: string | null;
+  course_id?: string | null;
+  course_content_kind_id?: string | null;
+}
+
+export interface TutorCourseMemberCourseContent {
+  id: string;
+  path: string;
+}
+
+export interface TutorCourseMemberGet {
+  id: string;
+  properties?: CourseMemberProperties | null;
+  user_id: string;
+  course_id: string;
+  course_group_id?: string | null;
+  course_role_id: string;
+  unreviewed_course_contents?: TutorCourseMemberCourseContent[];
+  user: UserList;
+}
+
+export interface TutorCourseMemberList {
+  id: string;
+  user_id: string;
+  course_id: string;
+  course_group_id?: string | null;
+  course_role_id: string;
+  unreviewed?: boolean | null;
+  ungraded_submissions_count?: number | null;
+  unread_message_count?: number | null;
+  user: UserList;
+}
+
+export interface CourseFamilyRoleGet {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean;
+}
+
+export interface CourseFamilyRoleList {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean;
+}
+
+export interface CourseFamilyRoleQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean | null;
 }
 
 export interface CourseProperties {
@@ -1038,28 +1028,94 @@ export interface CourseQuery {
   full_path?: string | null;
 }
 
-/**
- * Request to create a course family via Temporal workflow.
- */
-export interface CourseFamilyTaskRequest {
-  course_family: Record<string, any>;
-  organization_id: string;
-  gitlab?: GitLabCredentials | null;
+export interface CourseMemberCommentCreate {
+  id?: string | null;
+  transmitter_id?: string;
+  course_member_id: string;
+  message: string;
+}
+
+export interface CourseMemberCommentGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  transmitter_id?: string;
+  transmitter: CourseMemberGet;
+  course_member_id: string;
+  message: string;
+}
+
+export interface CourseMemberCommentList {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  transmitter_id?: string;
+  transmitter: CourseMemberList;
+  course_member_id: string;
+  message: string;
+}
+
+export interface CourseMemberCommentUpdate {
+  message?: string | null;
+}
+
+export interface CourseMemberCommentQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  transmitter_id?: string | null;
+  course_member_id?: string | null;
+}
+
+export interface CommentCreate {
+  course_member_id: any;
+  message: string;
+}
+
+export interface CommentUpdate {
+  message: string;
 }
 
 /**
- * Request to create a course via Temporal workflow.
+ * Request for importing a course member.
  */
-export interface CourseTaskRequest {
-  course: Record<string, any>;
-  course_family_id: string;
-  gitlab?: GitLabCredentials | null;
+export interface CourseMemberImportRequest {
+  /** Email address (required) */
+  email: string;
+  /** First name */
+  given_name?: string | null;
+  /** Last name */
+  family_name?: string | null;
+  /** Course group name */
+  course_group_title?: string | null;
+  /** Course role ID (e.g., _student) */
+  course_role_id?: string;
+  /** Auto-create missing course group */
+  create_missing_group?: boolean;
 }
 
-export interface GradedByCourseMember {
-  course_role_id?: string | null;
-  user_id: string;
-  user?: GradingAuthor | null;
+/**
+ * Response from course member import.
+ */
+export interface CourseMemberImportResponse {
+  /** Whether the import was successful */
+  success: boolean;
+  /** Success or error message */
+  message?: string | null;
+  /** Created/updated course member */
+  course_member?: any | null;
+  /** Created course group if new */
+  created_group?: any | null;
+  /** Workflow ID for repository creation task (use GET /tasks/{workflow_id}/status to check progress) */
+  workflow_id?: string | null;
 }
 
 export interface CourseGroupCreate {
@@ -1104,88 +1160,100 @@ export interface CourseGroupQuery {
   course_id?: string | null;
 }
 
-export interface CourseContentTypeCreate {
-  slug: string;
-  title?: string | null;
-  description?: string | null;
-  color?: string | null;
-  properties?: any | null;
-  course_id: string;
-  course_content_kind_id: string;
+/**
+ * Repository information for course content in lecturer view.
+ */
+export interface CourseContentRepositoryLecturerGet {
+  url?: string | null;
+  full_path?: string | null;
 }
 
-export interface CourseContentTypeGet {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
+/**
+ * DTO for lecturer GET of course content with course repository info.
+ */
+export interface CourseContentLecturerGet {
   id: string;
-  slug: string;
+  archived_at?: string | null;
   title?: string | null;
   description?: string | null;
-  color: string;
-  properties?: any | null;
+  path: string;
   course_id: string;
+  course_content_type_id: string;
   course_content_kind_id: string;
-  course_content_kind?: CourseContentKindGet | null;
+  position: number;
+  max_group_size?: number | null;
+  max_test_runs?: number | null;
+  max_submissions?: number | null;
+  testing_service_id?: string | null;
+  is_submittable?: boolean;
+  has_deployment?: boolean | null;
+  deployment_status?: string | null;
+  course_content_type?: CourseContentTypeGet | null;
+  repository: CourseContentRepositoryLecturerGet;
+  /** Deployment information if requested via include=deployment */
+  deployment?: CourseContentDeploymentGet | null;
 }
 
-export interface CourseContentTypeList {
+/**
+ * DTO for lecturer list of course content with course repository info.
+ */
+export interface CourseContentLecturerList {
   id: string;
-  slug: string;
   title?: string | null;
-  color: string;
+  path: string;
   course_id: string;
+  course_content_type_id: string;
   course_content_kind_id: string;
-  course_content_kind?: CourseContentKindList | null;
+  position: number;
+  max_group_size?: number | null;
+  max_test_runs?: number | null;
+  max_submissions?: number | null;
+  testing_service_id?: string | null;
+  is_submittable?: boolean;
+  archived_at?: string | null;
+  has_deployment?: boolean | null;
+  deployment_status?: string | null;
+  course_content_type?: CourseContentTypeList | null;
+  repository: CourseContentRepositoryLecturerGet;
+  /** Deployment information if requested via include=deployment */
+  deployment?: CourseContentDeploymentList | null;
 }
 
-export interface CourseContentTypeUpdate {
-  slug?: string | null;
-  title?: string | null;
-  color?: string | null;
-  description?: string | null;
-  properties?: any | null;
-}
-
-export interface CourseContentTypeQuery {
+/**
+ * Query parameters for lecturer course content.
+ */
+export interface CourseContentLecturerQuery {
   skip?: number | null;
   limit?: number | null;
   id?: string | null;
-  slug?: string | null;
   title?: string | null;
-  color?: string | null;
-  description?: string | null;
+  path?: string | null;
   course_id?: string | null;
-  course_content_kind_id?: string | null;
+  course_content_type_id?: string | null;
+  archived?: boolean | null;
+  position?: number | null;
+  max_group_size?: number | null;
+  max_test_runs?: number | null;
+  max_submissions?: number | null;
+  testing_service_id?: string | null;
+  /** Filter by whether content has a deployment */
+  has_deployment?: boolean | null;
+  directory?: string | null;
+  project?: string | null;
+  provider_url?: string | null;
+  nlevel?: number | null;
+  descendants?: string | null;
+  ascendants?: string | null;
 }
 
-export interface TutorCourseMemberCourseContent {
-  id: string;
-  path: string;
-}
-
-export interface TutorCourseMemberGet {
-  id: string;
-  properties?: CourseMemberProperties | null;
-  user_id: string;
-  course_id: string;
-  course_group_id?: string | null;
-  course_role_id: string;
-  unreviewed_course_contents?: TutorCourseMemberCourseContent[];
-  user: UserList;
-}
-
-export interface TutorCourseMemberList {
-  id: string;
-  user_id: string;
-  course_id: string;
-  course_group_id?: string | null;
-  course_role_id: string;
-  unreviewed?: boolean | null;
-  ungraded_submissions_count?: number | null;
-  unread_message_count?: number | null;
-  user: UserList;
+/**
+ * Configuration for course execution backend.
+ */
+export interface CourseExecutionBackendConfig {
+  /** Unique identifier for the execution backend */
+  slug: string;
+  /** Version of the execution backend (e.g., 'r2024b', 'v1.0') */
+  version: string;
+  /** Backend-specific settings */
+  settings?: any | null;
 }

--- a/src/types/generated/error-codes.ts
+++ b/src/types/generated/error-codes.ts
@@ -2,7 +2,7 @@
  * Auto-generated error code definitions
  *
  * DO NOT EDIT MANUALLY
- * Generated at: 2026-03-12T09:41:25.568207
+ * Generated at: 2026-04-28T11:59:24.319270
  *
  * To regenerate: bash generate_error_codes.sh
  */

--- a/src/types/generated/examples.ts
+++ b/src/types/generated/examples.ts
@@ -13,6 +13,64 @@ import type { ForceLevel } from './common';
 
 
 /**
+ * Preview of a single example that would be deleted.
+ */
+export interface ExampleDeletePreview {
+  example_id: string;
+  identifier: string;
+  title: string;
+  directory: string;
+  repository_id: string;
+  repository_name: string;
+  /** Number of versions to delete */
+  version_count: number;
+  /** MinIO storage paths for versions */
+  storage_paths?: string[];
+  /** Count of CourseContentDeployments referencing this example */
+  deployment_references?: number;
+}
+
+/**
+ * Request to delete examples by identifier prefix pattern.
+ */
+export interface ExampleBulkDeleteRequest {
+  /** Ltree pattern to match (e.g., 'itpcp.progphys.py.*'). Uses * for single-level wildcard. */
+  identifier_pattern: string;
+  /** Optional: scope deletion to specific repository */
+  repository_id?: string | null;
+  /** If true, only returns preview without deleting */
+  dry_run?: boolean;
+  /** Force level: 'none' blocks if active deployments, 'old' allows archived/failed, 'all' deletes active (requires confirmation) */
+  force_level?: ForceLevel;
+}
+
+/**
+ * Result of bulk example deletion operation.
+ */
+export interface ExampleBulkDeleteResult {
+  /** Whether this was a preview only */
+  dry_run: boolean;
+  /** Pattern that was used for matching */
+  pattern_matched: string;
+  /** Repository scope if specified */
+  repository_id?: string | null;
+  /** Number of examples deleted */
+  examples_affected?: number;
+  /** Total versions deleted */
+  versions_deleted?: number;
+  /** Example dependencies deleted */
+  dependencies_deleted?: number;
+  /** MinIO objects deleted */
+  storage_objects_deleted?: number;
+  /** Deployments with example_version_id set to NULL */
+  deployment_references_orphaned?: number;
+  /** Details of examples affected */
+  examples?: ExampleDeletePreview[];
+  /** Errors encountered during deletion */
+  errors?: string[];
+}
+
+/**
  * Create a new example repository.
  */
 export interface ExampleRepositoryCreate {
@@ -309,64 +367,6 @@ export interface ExampleDownloadResponse {
   test_yaml?: string | null;
   /** Dependency examples when with_dependencies=True */
   dependencies?: ExampleFileSet[] | null;
-}
-
-/**
- * Preview of a single example that would be deleted.
- */
-export interface ExampleDeletePreview {
-  example_id: string;
-  identifier: string;
-  title: string;
-  directory: string;
-  repository_id: string;
-  repository_name: string;
-  /** Number of versions to delete */
-  version_count: number;
-  /** MinIO storage paths for versions */
-  storage_paths?: string[];
-  /** Count of CourseContentDeployments referencing this example */
-  deployment_references?: number;
-}
-
-/**
- * Request to delete examples by identifier prefix pattern.
- */
-export interface ExampleBulkDeleteRequest {
-  /** Ltree pattern to match (e.g., 'itpcp.progphys.py.*'). Uses * for single-level wildcard. */
-  identifier_pattern: string;
-  /** Optional: scope deletion to specific repository */
-  repository_id?: string | null;
-  /** If true, only returns preview without deleting */
-  dry_run?: boolean;
-  /** Force level: 'none' blocks if active deployments, 'old' allows archived/failed, 'all' deletes active (requires confirmation) */
-  force_level?: ForceLevel;
-}
-
-/**
- * Result of bulk example deletion operation.
- */
-export interface ExampleBulkDeleteResult {
-  /** Whether this was a preview only */
-  dry_run: boolean;
-  /** Pattern that was used for matching */
-  pattern_matched: string;
-  /** Repository scope if specified */
-  repository_id?: string | null;
-  /** Number of examples deleted */
-  examples_affected?: number;
-  /** Total versions deleted */
-  versions_deleted?: number;
-  /** Example dependencies deleted */
-  dependencies_deleted?: number;
-  /** MinIO objects deleted */
-  storage_objects_deleted?: number;
-  /** Deployments with example_version_id set to NULL */
-  deployment_references_orphaned?: number;
-  /** Details of examples affected */
-  examples?: ExampleDeletePreview[];
-  /** Errors encountered during deletion */
-  errors?: string[];
 }
 
 /**

--- a/src/types/generated/messages.ts
+++ b/src/types/generated/messages.ts
@@ -15,7 +15,8 @@ import type { MessageAuthor, MessageAuthorCourseMember } from './auth';
 export interface MessageCreate {
   parent_id?: string | null;
   level?: number;
-  title: string;
+  /** Message title (optional, used for tags like #ai) */
+  title?: string | null;
   content: string;
   /** Organization-level message */
   organization_id?: string | null;
@@ -48,7 +49,7 @@ export interface MessageGet {
   created_by?: string | null;
   updated_by?: string | null;
   id: string;
-  title: string;
+  title?: string | null;
   content: string;
   level: number;
   parent_id?: string | null;
@@ -82,7 +83,7 @@ export interface MessageList {
   /** Update timestamp */
   updated_at?: string | null;
   id: string;
-  title: string;
+  title?: string | null;
   content: string;
   level: number;
   parent_id?: string | null;
@@ -132,12 +133,27 @@ export interface MessageQuery {
   created_before?: string | null;
   /** Filter by read status: True = unread only, False = read only, None = all */
   unread?: boolean | null;
-  /** Filter by tags in title (e.g., ['ai::request', 'priority::high']) */
+  /** Filter by tags in title (e.g., ['ai', 'ai-help', 'review']). Without # prefix. */
   tags?: string[] | null;
   /** True = must match ALL tags (AND), False = match ANY tag (OR) */
   tags_match_all?: boolean | null;
-  /** Filter by tag scope prefix (e.g., 'ai' matches any #ai::* tag) */
+  /** Filter by tag prefix (e.g., 'ai' matches #ai, #ai-help, #ai-response, etc.) */
   tag_scope?: string | null;
+}
+
+/**
+ * Full conversation thread for a message.
+ * 
+ * Returns all messages sharing the same root, ordered by created_at.
+ * Used by agents to get full conversation context for follow-up detection.
+ */
+export interface MessageThread {
+  /** ID of the root message in the thread */
+  root_message_id: string;
+  /** All messages in the thread, ordered by created_at ascending */
+  messages?: MessageList[];
+  /** Total number of messages in the thread */
+  total?: number;
 }
 
 /**

--- a/src/types/generated/organizations.ts
+++ b/src/types/generated/organizations.ts
@@ -10,7 +10,63 @@
 
 import type { GitLabConfig, GitLabConfigGet, GitLabCredentials } from './common';
 
+import type { UserList } from './users';
 
+
+
+export interface OrganizationMemberCreate {
+  id?: string | null;
+  properties?: any | null;
+  user_id: string;
+  organization_id: string;
+  organization_role_id: string;
+}
+
+export interface OrganizationMemberGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  id: string;
+  properties?: any | null;
+  user_id: string;
+  organization_id: string;
+  organization_role_id: string;
+  user?: UserList | null;
+}
+
+export interface OrganizationMemberList {
+  id: string;
+  user_id: string;
+  organization_id: string;
+  organization_role_id: string;
+  user?: UserList | null;
+}
+
+export interface OrganizationMemberUpdate {
+  properties?: any | null;
+  organization_role_id?: string | null;
+}
+
+export interface OrganizationMemberQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  user_id?: string | null;
+  organization_id?: string | null;
+  organization_role_id?: string | null;
+}
+
+/**
+ * Request to create an organization via Temporal workflow.
+ */
+export interface OrganizationTaskRequest {
+  organization: Record<string, any>;
+  gitlab: GitLabCredentials;
+  parent_group_id: number;
+}
 
 export interface OrganizationProperties {
   gitlab?: GitLabConfig | null;
@@ -157,13 +213,27 @@ export interface OrganizationQuery {
   country?: string | null;
 }
 
-/**
- * Request to create an organization via Temporal workflow.
- */
-export interface OrganizationTaskRequest {
-  organization: Record<string, any>;
-  gitlab: GitLabCredentials;
-  parent_group_id: number;
+export interface OrganizationRoleGet {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean;
+}
+
+export interface OrganizationRoleList {
+  id: string;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean;
+}
+
+export interface OrganizationRoleQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  builtin?: boolean | null;
 }
 
 

--- a/src/types/generated/tasks.ts
+++ b/src/types/generated/tasks.ts
@@ -13,6 +13,15 @@ import type { Repository } from './common';
 
 
 /**
+ * Response with task ID for async operation.
+ */
+export interface TaskResponse {
+  task_id: string;
+  status: string;
+  message: string;
+}
+
+/**
  * Task execution result container.
  */
 export interface TaskResult {
@@ -94,15 +103,6 @@ export interface TestJob {
   testing_service_type_path: string;
   module: Repository;
   reference?: Repository | null;
-}
-
-/**
- * Response with task ID for async operation.
- */
-export interface TaskResponse {
-  task_id: string;
-  status: string;
-  message: string;
 }
 
 

--- a/src/types/generated/users.ts
+++ b/src/types/generated/users.ts
@@ -22,153 +22,6 @@ export interface CourseMemberProviderAccountUpdate {
   provider_access_token?: string | null;
 }
 
-export interface AccountCreate {
-  /** Authentication provider name */
-  provider: string;
-  /** Type of authentication account */
-  type: string;
-  /** Account ID from the provider */
-  provider_account_id: string;
-  /** Associated user ID */
-  user_id: string;
-  /** Provider-specific properties */
-  properties?: any | null;
-}
-
-export interface AccountGet {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  /** Account unique identifier */
-  id: string;
-  /** Authentication provider name */
-  provider: string;
-  /** Type of authentication account */
-  type: string;
-  /** Account ID from the provider */
-  provider_account_id: string;
-  /** Associated user ID */
-  user_id: string;
-  /** Provider-specific properties */
-  properties?: any | null;
-}
-
-export interface AccountList {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  /** Account unique identifier */
-  id: string;
-  /** Authentication provider name */
-  provider: string;
-  /** Type of authentication account */
-  type: string;
-  /** Account ID from the provider */
-  provider_account_id: string;
-  /** Associated user ID */
-  user_id: string;
-}
-
-export interface AccountUpdate {
-  /** Authentication provider name */
-  provider?: string | null;
-  /** Type of authentication account */
-  type?: string | null;
-  /** Account ID from the provider */
-  provider_account_id?: string | null;
-  /** Provider-specific properties */
-  properties?: any | null;
-}
-
-export interface AccountQuery {
-  skip?: number | null;
-  limit?: number | null;
-  id?: string | null;
-  provider?: string | null;
-  type?: string | null;
-  provider_account_id?: string | null;
-  user_id?: string | null;
-}
-
-/**
- * A user with their workspace roles.
- */
-export interface WorkspaceRoleUser {
-  user_id: string;
-  email: any;
-  username: any;
-  given_name: any;
-  family_name: any;
-  roles?: string[];
-}
-
-/**
- * User manager request to reset a user's password (sets to NULL).
- */
-export interface UserManagerResetPasswordRequest {
-  /** Target user ID to reset */
-  user_id: string;
-  /** User manager's own password for verification */
-  manager_password: string;
-}
-
-export interface UserGroupCreate {
-  /** User ID */
-  user_id: string;
-  /** Group ID */
-  group_id: string;
-  /** Whether this is a transient membership */
-  transient?: boolean | null;
-}
-
-export interface UserGroupGet {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  created_by?: string | null;
-  updated_by?: string | null;
-  /** User ID */
-  user_id: string;
-  /** Group ID */
-  group_id: string;
-  /** Whether this is transient membership */
-  transient?: boolean | null;
-}
-
-export interface UserGroupList {
-  /** Creation timestamp */
-  created_at?: string | null;
-  /** Update timestamp */
-  updated_at?: string | null;
-  /** User ID */
-  user_id: string;
-  /** Group ID */
-  group_id: string;
-  /** Whether this is transient membership */
-  transient?: boolean | null;
-}
-
-export interface UserGroupUpdate {
-  /** Whether this is transient membership */
-  transient?: boolean | null;
-}
-
-export interface UserGroupQuery {
-  skip?: number | null;
-  limit?: number | null;
-  /** Filter by user ID */
-  user_id?: string | null;
-  /** Filter by group ID */
-  group_id?: string | null;
-  /** Filter by transient status */
-  transient?: boolean | null;
-}
-
 export interface UserCreate {
   /** User ID (UUID will be generated if not provided) */
   id?: string | null;
@@ -273,6 +126,112 @@ export interface UserPassword {
   password_old?: string | null;
 }
 
+/**
+ * Per-scope role memberships for the current authenticated user.
+ * 
+ * Mirrors the scope-namespace slice of ``Principal.claims.dependent``
+ * so a client can pre-gate UI against the same data the backend uses
+ * for authorization. Each map is keyed by ``scope_id`` and lists every
+ * role label the user holds on that scope (a user can hold more than
+ * one role on the same scope).
+ * 
+ * Admins do not have explicit per-scope claims — instead ``is_admin``
+ * is true and the server bypasses scope checks entirely. Treat that as
+ * "every role on every scope".
+ */
+export interface UserScopes {
+  /** Whether the user is a system admin (bypasses all scope checks). */
+  is_admin: boolean;
+  /** organization_id -> [role labels held by the user on that organization]. */
+  organization?: Record<string, string[]>;
+  /** course_family_id -> [role labels held by the user on that course family]. */
+  course_family?: Record<string, string[]>;
+  /** course_id -> [role labels held by the user on that course]. */
+  course?: Record<string, string[]>;
+}
+
+export interface AccountCreate {
+  /** Authentication provider name */
+  provider: string;
+  /** Type of authentication account */
+  type: string;
+  /** Account ID from the provider */
+  provider_account_id: string;
+  /** Associated user ID */
+  user_id: string;
+  /** Provider-specific properties */
+  properties?: any | null;
+}
+
+export interface AccountGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  /** Account unique identifier */
+  id: string;
+  /** Authentication provider name */
+  provider: string;
+  /** Type of authentication account */
+  type: string;
+  /** Account ID from the provider */
+  provider_account_id: string;
+  /** Associated user ID */
+  user_id: string;
+  /** Provider-specific properties */
+  properties?: any | null;
+}
+
+export interface AccountList {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  /** Account unique identifier */
+  id: string;
+  /** Authentication provider name */
+  provider: string;
+  /** Type of authentication account */
+  type: string;
+  /** Account ID from the provider */
+  provider_account_id: string;
+  /** Associated user ID */
+  user_id: string;
+}
+
+export interface AccountUpdate {
+  /** Authentication provider name */
+  provider?: string | null;
+  /** Type of authentication account */
+  type?: string | null;
+  /** Account ID from the provider */
+  provider_account_id?: string | null;
+  /** Provider-specific properties */
+  properties?: any | null;
+}
+
+export interface AccountQuery {
+  skip?: number | null;
+  limit?: number | null;
+  id?: string | null;
+  provider?: string | null;
+  type?: string | null;
+  provider_account_id?: string | null;
+  user_id?: string | null;
+}
+
+/**
+ * User manager request to reset a user's password (sets to NULL).
+ */
+export interface UserManagerResetPasswordRequest {
+  /** Target user ID to reset */
+  user_id: string;
+  /** User manager's own password for verification */
+  manager_password: string;
+}
+
 export interface UserRoleCreate {
   user_id: string;
   role_id: string;
@@ -303,4 +262,69 @@ export interface UserRoleQuery {
   limit?: number | null;
   user_id?: string | null;
   role_id?: string | null;
+}
+
+export interface UserGroupCreate {
+  /** User ID */
+  user_id: string;
+  /** Group ID */
+  group_id: string;
+  /** Whether this is a transient membership */
+  transient?: boolean | null;
+}
+
+export interface UserGroupGet {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  /** User ID */
+  user_id: string;
+  /** Group ID */
+  group_id: string;
+  /** Whether this is transient membership */
+  transient?: boolean | null;
+}
+
+export interface UserGroupList {
+  /** Creation timestamp */
+  created_at?: string | null;
+  /** Update timestamp */
+  updated_at?: string | null;
+  /** User ID */
+  user_id: string;
+  /** Group ID */
+  group_id: string;
+  /** Whether this is transient membership */
+  transient?: boolean | null;
+}
+
+export interface UserGroupUpdate {
+  /** Whether this is transient membership */
+  transient?: boolean | null;
+}
+
+export interface UserGroupQuery {
+  skip?: number | null;
+  limit?: number | null;
+  /** Filter by user ID */
+  user_id?: string | null;
+  /** Filter by group ID */
+  group_id?: string | null;
+  /** Filter by transient status */
+  transient?: boolean | null;
+}
+
+/**
+ * A user with their workspace roles.
+ */
+export interface WorkspaceRoleUser {
+  user_id: string;
+  email: any;
+  username: any;
+  given_name: any;
+  family_name: any;
+  roles?: string[];
 }

--- a/src/ui/panels/MessagesInputPanel.ts
+++ b/src/ui/panels/MessagesInputPanel.ts
@@ -249,16 +249,16 @@ export class MessagesInputPanelProvider implements vscode.WebviewViewProvider {
       vscode.window.showWarningMessage('Unable to post message: target context missing.');
       return;
     }
+    if (target.readOnly) {
+      vscode.window.showWarningMessage(target.readOnlyReason || 'You do not have permission to post messages here.');
+      return;
+    }
 
     const level = this.resolveMessageLevel(data.parent_id);
-    const targetFields = ['user_id', 'course_member_id', 'submission_group_id', 'course_group_id', 'course_content_id', 'course_id'] as const;
-    const filteredPayload: Partial<MessageCreate> = {};
-    for (const field of targetFields) {
-      const value = target.createPayload[field];
-      if (typeof value === 'string') {
-        filteredPayload[field] = value;
-      }
-    }
+    // Backend enforces a single-target invariant — only the most-specific
+    // target is persisted, all other target columns are forced NULL. Send
+    // exactly one to keep the wire payload honest.
+    const filteredPayload = pickMostSpecificTarget(target.createPayload);
 
     const payload: MessageCreate = {
       title: data.title,
@@ -356,4 +356,29 @@ export class MessagesInputPanelProvider implements vscode.WebviewViewProvider {
 </body>
 </html>`;
   }
+}
+
+// Most-specific first; the first match is the only target sent on the wire.
+// user_id / course_member_id sit at the top: backend currently rejects writes
+// to those scopes (NotImplementedException), but we forward them so the user
+// sees the real error rather than a misleading global-post 403.
+const TARGET_FIELDS_BY_SPECIFICITY = [
+  'user_id',
+  'course_member_id',
+  'submission_group_id',
+  'course_content_id',
+  'course_group_id',
+  'course_id',
+  'course_family_id',
+  'organization_id'
+] as const;
+
+function pickMostSpecificTarget(createPayload: Record<string, unknown>): Partial<MessageCreate> {
+  for (const field of TARGET_FIELDS_BY_SPECIFICITY) {
+    const value = createPayload[field];
+    if (typeof value === 'string' && value.length > 0) {
+      return { [field]: value } as Partial<MessageCreate>;
+    }
+  }
+  return {};
 }

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -59,6 +59,8 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   private wsService?: WebSocketService;
   private wsSubscribedForUserId?: string;
   private readonly wsHandlerId = `chat-inbox-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  private wsReloadTimer?: ReturnType<typeof setTimeout>;
+  private static readonly WS_RELOAD_DEBOUNCE_MS = 250;
 
   // Persisted UI state
   private expandedScopes: Set<MessageScope> = new Set();
@@ -594,12 +596,12 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
   private handleInboxEvent(channel: string): void {
     if (!this.isInboxChannel(channel)) { return; }
-    void this.requestReload();
+    this.scheduleWsReload();
   }
 
   private handleInboxNewMessage(channel: string, data: Record<string, unknown>): void {
     if (!this.isInboxChannel(channel)) { return; }
-    void this.requestReload();
+    this.scheduleWsReload();
     // WS payload nests the MessageGet under `data` for message:new (see
     // MessagesWebviewProvider.handleWsMessageNew for the same unwrap).
     const inner = (data && typeof data === 'object' && 'data' in data ? (data as any).data : data) as Record<string, unknown> | undefined;
@@ -609,6 +611,20 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       return;
     }
     void this.showNewMessageToast(inner);
+  }
+
+  private scheduleWsReload(): void {
+    // Bursts of WS events (e.g., N read:update events when opening a thread
+    // with N unread messages) would otherwise produce N back-to-back reloads
+    // and visible flicker as state converges. Debounce so the burst becomes
+    // a single reload once events stop arriving.
+    if (this.wsReloadTimer) {
+      clearTimeout(this.wsReloadTimer);
+    }
+    this.wsReloadTimer = setTimeout(() => {
+      this.wsReloadTimer = undefined;
+      void this.requestReload();
+    }, ChatInboxTreeProvider.WS_RELOAD_DEBOUNCE_MS);
   }
 
   private async showNewMessageToast(message: Record<string, unknown>): Promise<void> {

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -51,6 +51,8 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   private currentUserId?: string;
   private userScopes?: import('../../../types/generated').UserScopes;
   private userScopesPromise?: Promise<void>;
+  private reloadInFlight?: Promise<void>;
+  private reloadQueued = false;
 
   // Persisted UI state
   private expandedScopes: Set<MessageScope> = new Set();
@@ -78,9 +80,23 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   // ----- Public API -----
 
   refresh(): void {
-    this.scopeItems = [];
-    this.loadError = undefined;
-    void this.reload();
+    void this.requestReload();
+  }
+
+  private requestReload(): Promise<void> {
+    if (this.reloadInFlight) {
+      // Coalesce — at most one extra reload queued after the current one.
+      this.reloadQueued = true;
+      return this.reloadInFlight;
+    }
+    this.reloadInFlight = this.reload().finally(() => {
+      this.reloadInFlight = undefined;
+      if (this.reloadQueued) {
+        this.reloadQueued = false;
+        void this.requestReload();
+      }
+    });
+    return this.reloadInFlight;
   }
 
   getTotalUnread(): number {
@@ -177,9 +193,15 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   // ----- Internals -----
 
   private async reload(): Promise<void> {
+    // Only show the loading spinner on initial load. On subsequent reloads,
+    // keep the current scope items visible so the tree doesn't flicker to
+    // "Loading…" between the user's click and the new data arriving.
+    const showSpinner = this.scopeItems.length === 0 && !this.loadError;
     this.loading = true;
     this.loadError = undefined;
-    this._onDidChangeTreeData.fire(undefined);
+    if (showSpinner) {
+      this._onDidChangeTreeData.fire(undefined);
+    }
 
     try {
       const [identity, messages, scopes] = await Promise.all([

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -1,8 +1,11 @@
 import * as vscode from 'vscode';
 import { ComputorApiService } from '../../../services/ComputorApiService';
 import { canPostGlobal, canPostToCourseFamily, canPostToOrganization } from '../../../services/MessagePermissions';
+import { WebSocketService } from '../../../services/WebSocketService';
 import { MessagesWebviewProvider, MessageTargetContext } from '../../webviews/MessagesWebviewProvider';
 import type { MessageList } from '../../../types/generated';
+
+const GLOBAL_CHANNEL = 'global';
 import {
   ChatScopeItem,
   ChatThreadItem,
@@ -53,6 +56,9 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   private userScopesPromise?: Promise<void>;
   private reloadInFlight?: Promise<void>;
   private reloadQueued = false;
+  private wsService?: WebSocketService;
+  private wsSubscribedForUserId?: string;
+  private readonly wsHandlerId = `chat-inbox-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
   // Persisted UI state
   private expandedScopes: Set<MessageScope> = new Set();
@@ -78,6 +84,14 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   }
 
   // ----- Public API -----
+
+  setWebSocketService(wsService: WebSocketService): void {
+    this.wsService = wsService;
+    // If we already know who we are, subscribe immediately. Otherwise the
+    // subscription happens at the end of the next reload, when currentUserId
+    // is set.
+    this.maybeSubscribeUserChannels();
+  }
 
   refresh(): void {
     void this.requestReload();
@@ -211,6 +225,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       ]);
       this.currentUserId = identity?.id;
       this.userScopes = scopes;
+      this.maybeSubscribeUserChannels();
 
       const grouped = this.groupMessages(messages || []);
       await this.resolveLabels(grouped);
@@ -549,6 +564,37 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       readOnly,
       readOnlyReason
     };
+  }
+
+  // ----- WebSocket -----
+
+  private maybeSubscribeUserChannels(): void {
+    if (!this.wsService || !this.currentUserId) {
+      return;
+    }
+    if (this.wsSubscribedForUserId === this.currentUserId) {
+      return;
+    }
+    const userChannel = `user:${this.currentUserId}`;
+    // Backend auto-subscribes both `user:<own_id>` and `global` on WS connect,
+    // but we still register a local handler so events get dispatched here.
+    this.wsService.subscribe([userChannel, GLOBAL_CHANNEL], this.wsHandlerId, {
+      onMessageNew: (channel) => this.handleInboxEvent(channel),
+      onMessageUpdate: (channel) => this.handleInboxEvent(channel),
+      onMessageDelete: (channel) => this.handleInboxEvent(channel),
+      onReadUpdate: (channel) => this.handleInboxEvent(channel)
+    });
+    this.wsSubscribedForUserId = this.currentUserId;
+  }
+
+  private handleInboxEvent(channel: string): void {
+    if (!this.currentUserId) {
+      return;
+    }
+    if (channel !== `user:${this.currentUserId}` && channel !== GLOBAL_CHANNEL) {
+      return;
+    }
+    void this.requestReload();
   }
 
   // ----- Persistence -----

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ComputorApiService } from '../../../services/ComputorApiService';
+import { canPostGlobal, canPostToCourseFamily, canPostToOrganization } from '../../../services/MessagePermissions';
 import { MessagesWebviewProvider, MessageTargetContext } from '../../webviews/MessagesWebviewProvider';
 import type { MessageList } from '../../../types/generated';
 import {
@@ -46,6 +47,8 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   private loadError: string | undefined;
   private scopeItems: ChatScopeItem[] = [];
   private currentUserId?: string;
+  private userScopes?: import('../../../types/generated').UserScopes;
+  private userScopesPromise?: Promise<void>;
 
   // Persisted UI state
   private expandedScopes: Set<MessageScope> = new Set();
@@ -108,15 +111,37 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     await this.messagesProvider.showMessages(ctx);
   }
 
+  private async ensureUserScopes(): Promise<void> {
+    if (this.userScopes !== undefined || this.userScopesPromise) {
+      if (this.userScopesPromise) {
+        await this.userScopesPromise;
+      }
+      return;
+    }
+    this.userScopesPromise = this.api.getUserScopes()
+      .then(value => {
+        this.userScopes = value;
+      })
+      .catch(() => {
+        this.userScopes = undefined;
+      })
+      .finally(() => {
+        this.userScopesPromise = undefined;
+      });
+    await this.userScopesPromise;
+  }
+
   async markThreadRead(threadItem: ChatThreadItem): Promise<void> {
-    const unread = threadItem.thread.messages.filter(m => !m.is_read);
+    const unread = threadItem.thread.messages.filter(m => !m.is_read && m.author_id !== this.currentUserId);
     if (unread.length === 0) { return; }
     await Promise.all(unread.map(m => this.api.markMessageRead(m.id).catch(() => undefined)));
     this.refresh();
   }
 
   async markScopeRead(scopeItem: ChatScopeItem): Promise<void> {
-    const ids = scopeItem.threads.flatMap(t => t.messages.filter(m => !m.is_read).map(m => m.id));
+    const ids = scopeItem.threads.flatMap(t =>
+      t.messages.filter(m => !m.is_read && m.author_id !== this.currentUserId).map(m => m.id)
+    );
     if (ids.length === 0) { return; }
     await Promise.all(ids.map(id => this.api.markMessageRead(id).catch(() => undefined)));
     this.refresh();
@@ -151,11 +176,13 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     this._onDidChangeTreeData.fire(undefined);
 
     try {
-      const [identity, messages] = await Promise.all([
+      const [identity, messages, scopes] = await Promise.all([
         this.api.getCurrentUser().catch(() => undefined),
-        this.api.listMessages(this.unreadOnly ? { unread: true } : {})
+        this.api.listMessages(this.unreadOnly ? { unread: true } : {}),
+        this.api.getUserScopes().catch(() => undefined)
       ]);
       this.currentUserId = identity?.id;
+      this.userScopes = scopes;
 
       const grouped = this.groupMessages(messages || []);
       await this.resolveLabels(grouped);
@@ -307,7 +334,10 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       for (const [targetId, msgs] of byTarget) {
         const sortedMessages = msgs.slice().sort((a, b) => compareCreated(a, b));
         const lastMessage = sortedMessages[sortedMessages.length - 1];
-        const unreadCount = msgs.filter(m => !m.is_read).length;
+        // Exclude the user's own messages — backend doesn't auto-stamp authors
+        // as readers of their own posts, so without this they'd show as
+        // permanently unread to themselves.
+        const unreadCount = msgs.filter(m => !m.is_read && m.author_id !== this.currentUserId).length;
         if (this.unreadOnly && unreadCount === 0) { continue; }
 
         const { title, subtitle } = this.threadLabels(scope, targetId === '__none__' ? null : targetId, msgs);
@@ -406,21 +436,36 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     const baseQuery: Record<string, string> = {};
     const basePayload: Record<string, unknown> = {};
     let wsChannel: string | undefined;
+    let readOnly = false;
+    let readOnlyReason: string | undefined;
+
+    await this.ensureUserScopes();
 
     switch (scope) {
       case 'global':
-        return undefined;
+        // Global threads carry no target IDs, so /messages without a scope
+        // filter returns the user's full inbox — not just globals. Pin the
+        // scope explicitly so the panel only shows global announcements.
+        baseQuery.scope = 'global';
+        readOnly = !canPostGlobal(this.userScopes);
+        readOnlyReason = readOnly ? 'Only administrators can post global announcements.' : undefined;
+        // wsChannel intentionally undefined — no per-target channel for global.
+        break;
       case 'organization':
         if (!targetId) { return undefined; }
         baseQuery.organization_id = targetId;
         basePayload.organization_id = targetId;
         wsChannel = `organization:${targetId}`;
+        readOnly = !canPostToOrganization(this.userScopes, targetId);
+        readOnlyReason = readOnly ? 'Posting to this organization requires manager or owner role.' : undefined;
         break;
       case 'course_family':
         if (!targetId) { return undefined; }
         baseQuery.course_family_id = targetId;
         basePayload.course_family_id = targetId;
         wsChannel = `course_family:${targetId}`;
+        readOnly = !canPostToCourseFamily(this.userScopes, targetId);
+        readOnlyReason = readOnly ? 'Posting to this course family requires manager or owner role.' : undefined;
         break;
       case 'course':
         if (!targetId) { return undefined; }
@@ -471,7 +516,9 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       subtitle: scopeLabel(scope),
       query: baseQuery,
       createPayload: basePayload,
-      wsChannel
+      wsChannel,
+      readOnly,
+      readOnlyReason
     };
   }
 

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -579,7 +579,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     // Backend auto-subscribes both `user:<own_id>` and `global` on WS connect,
     // but we still register a local handler so events get dispatched here.
     this.wsService.subscribe([userChannel, GLOBAL_CHANNEL], this.wsHandlerId, {
-      onMessageNew: (channel) => this.handleInboxEvent(channel),
+      onMessageNew: (channel, data) => this.handleInboxNewMessage(channel, data),
       onMessageUpdate: (channel) => this.handleInboxEvent(channel),
       onMessageDelete: (channel) => this.handleInboxEvent(channel),
       onReadUpdate: (channel) => this.handleInboxEvent(channel)
@@ -587,14 +587,61 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     this.wsSubscribedForUserId = this.currentUserId;
   }
 
+  private isInboxChannel(channel: string): boolean {
+    if (!this.currentUserId) { return false; }
+    return channel === `user:${this.currentUserId}` || channel === GLOBAL_CHANNEL;
+  }
+
   private handleInboxEvent(channel: string): void {
-    if (!this.currentUserId) {
-      return;
-    }
-    if (channel !== `user:${this.currentUserId}` && channel !== GLOBAL_CHANNEL) {
-      return;
-    }
+    if (!this.isInboxChannel(channel)) { return; }
     void this.requestReload();
+  }
+
+  private handleInboxNewMessage(channel: string, data: Record<string, unknown>): void {
+    if (!this.isInboxChannel(channel)) { return; }
+    void this.requestReload();
+    // WS payload nests the MessageGet under `data` for message:new (see
+    // MessagesWebviewProvider.handleWsMessageNew for the same unwrap).
+    const inner = (data && typeof data === 'object' && 'data' in data ? (data as any).data : data) as Record<string, unknown> | undefined;
+    if (!inner) { return; }
+    if (inner.author_id && inner.author_id === this.currentUserId) {
+      // Don't notify the user about their own posts.
+      return;
+    }
+    void this.showNewMessageToast(inner);
+  }
+
+  private async showNewMessageToast(message: Record<string, unknown>): Promise<void> {
+    const scope = (typeof message.scope === 'string' ? message.scope : 'global') as MessageScope;
+    const author = formatToastAuthor(message);
+    const preview = formatToastPreview(message);
+    const scopeText = scopeLabel(scope);
+    const text = author
+      ? `${author} (${scopeText}): ${preview}`
+      : `${scopeText}: ${preview}`;
+
+    const choice = await vscode.window.showInformationMessage(text, 'Open');
+    if (choice !== 'Open') { return; }
+    await this.openMessageInPanel(message, scope);
+  }
+
+  private async openMessageInPanel(message: Record<string, unknown>, scope: MessageScope): Promise<void> {
+    const messageAsList = message as unknown as MessageList;
+    const targetId = this.targetIdFor(scope, messageAsList);
+    // Reveal the chat container alongside the panel for context.
+    void vscode.commands.executeCommand('computor.chat.inbox.focus');
+    const synthetic: ChatThread = {
+      scope,
+      targetId,
+      title: '',
+      lastMessage: messageAsList,
+      unreadCount: 0,
+      messageCount: 1,
+      messages: [messageAsList]
+    };
+    const target = await this.buildTargetContext(synthetic);
+    if (!target) { return; }
+    await this.messagesProvider.showMessages(target);
   }
 
   // ----- Persistence -----
@@ -643,4 +690,22 @@ function compareThreadRecency(a: ChatThread, b: ChatThread): number {
   const ta = a.lastMessage?.created_at ? Date.parse(a.lastMessage.created_at) : 0;
   const tb = b.lastMessage?.created_at ? Date.parse(b.lastMessage.created_at) : 0;
   return ta - tb;
+}
+
+function formatToastAuthor(message: Record<string, unknown>): string {
+  const author = (message.author ?? {}) as Record<string, unknown>;
+  const given = typeof author.given_name === 'string' ? author.given_name : '';
+  const family = typeof author.family_name === 'string' ? author.family_name : '';
+  const full = `${given} ${family}`.trim();
+  if (full) { return full; }
+  if (typeof author.username === 'string' && author.username) { return author.username; }
+  if (typeof author.email === 'string' && author.email) { return author.email; }
+  return '';
+}
+
+function formatToastPreview(message: Record<string, unknown>): string {
+  const content = typeof message.content === 'string' ? message.content : '';
+  const cleaned = content.replace(/\s+/g, ' ').trim();
+  if (cleaned.length === 0) { return '(no content)'; }
+  return cleaned.length > 120 ? `${cleaned.slice(0, 117)}…` : cleaned;
 }

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -38,6 +38,8 @@ type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingI
 export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeItem> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<AnyTreeItem | undefined | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+  private readonly _onDidChangeUnread = new vscode.EventEmitter<number>();
+  readonly onDidChangeUnread = this._onDidChangeUnread.event;
 
   private readonly api: ComputorApiService;
   private readonly context: vscode.ExtensionContext;
@@ -79,6 +81,10 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     this.scopeItems = [];
     this.loadError = undefined;
     void this.reload();
+  }
+
+  getTotalUnread(): number {
+    return this.scopeItems.reduce((sum, item) => sum + item.unreadCount, 0);
   }
 
   isUnreadOnly(): boolean {
@@ -193,6 +199,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     } finally {
       this.loading = false;
       this._onDidChangeTreeData.fire(undefined);
+      this._onDidChangeUnread.fire(this.getTotalUnread());
     }
   }
 

--- a/src/ui/tree/lecturer/LecturerTreeItems.ts
+++ b/src/ui/tree/lecturer/LecturerTreeItems.ts
@@ -36,11 +36,12 @@ export class OrganizationTreeItem extends vscode.TreeItem {
     public readonly organization: OrganizationList,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.Collapsed
   ) {
-    super(organization.title || organization.path, collapsibleState);
+    const orgTitle = organization.title || organization.path;
+    super(orgTitle, collapsibleState);
     this.id = `org-${organization.id}`;
     this.contextValue = 'organization';
     this.iconPath = new vscode.ThemeIcon('organization');
-    this.tooltip = organization.title || organization.path;
+    this.tooltip = `Organization: ${orgTitle}`;
     this.description = 'Organization';
   }
 }
@@ -51,11 +52,13 @@ export class CourseFamilyTreeItem extends vscode.TreeItem {
     public readonly organization: OrganizationList,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.Collapsed
   ) {
-    super(courseFamily.title || courseFamily.path, collapsibleState);
+    const familyTitle = courseFamily.title || courseFamily.path;
+    const orgTitle = organization.title || organization.path;
+    super(familyTitle, collapsibleState);
     this.id = `family-${courseFamily.id}`;
     this.contextValue = 'courseFamily';
     this.iconPath = new vscode.ThemeIcon('folder-library');
-    this.tooltip = courseFamily.title || courseFamily.path;
+    this.tooltip = `Course Family: ${familyTitle}\nOrganization: ${orgTitle}`;
     this.description = 'Course Family';
   }
 }
@@ -67,12 +70,15 @@ export class CourseTreeItem extends vscode.TreeItem {
     public readonly organization: OrganizationList,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.Collapsed
   ) {
-    super(course.title || course.path, collapsibleState);
+    const courseTitle = course.title || course.path;
+    const familyTitle = courseFamily.title || courseFamily.path;
+    const orgTitle = organization.title || organization.path;
+    super(courseTitle, collapsibleState);
     this.id = `course-${course.id}`;
     this.contextValue = 'course';
     this.iconPath = new vscode.ThemeIcon('book');
-    this.tooltip = course.title || course.path;
-    
+    this.tooltip = `Course: ${courseTitle}\nCourse Family: ${familyTitle}\nOrganization: ${orgTitle}`;
+
     // Set description to indicate this is a Course
     this.description = 'Course';
   }

--- a/src/ui/tree/tutor/tutor-filter-tree-items.ts
+++ b/src/ui/tree/tutor/tutor-filter-tree-items.ts
@@ -41,6 +41,35 @@ export function compareMembersByName(a: TutorCourseMemberList, b: TutorCourseMem
   return formatMemberName(a).localeCompare(formatMemberName(b));
 }
 
+export class TutorOrganizationFilterItem extends vscode.TreeItem {
+  constructor(
+    public readonly organizationId: string,
+    label: string,
+    expanded: boolean
+  ) {
+    super(label, expanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
+    this.id = `tutor-filter-org-${organizationId}`;
+    this.contextValue = 'tutorFilterOrganization';
+    this.iconPath = new vscode.ThemeIcon('organization');
+    this.description = 'Organization';
+  }
+}
+
+export class TutorCourseFamilyFilterItem extends vscode.TreeItem {
+  constructor(
+    public readonly courseFamilyId: string,
+    public readonly organizationId: string,
+    label: string,
+    expanded: boolean
+  ) {
+    super(label, expanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
+    this.id = `tutor-filter-family-${courseFamilyId}`;
+    this.contextValue = 'tutorFilterCourseFamily';
+    this.iconPath = new vscode.ThemeIcon('folder-library');
+    this.description = 'Course Family';
+  }
+}
+
 export class TutorCourseFilterItem extends vscode.TreeItem {
   constructor(
     public readonly course: { id: string; title?: string | null; path?: string; name?: string },

--- a/src/ui/tree/tutor/tutor-filter-tree-items.ts
+++ b/src/ui/tree/tutor/tutor-filter-tree-items.ts
@@ -73,10 +73,11 @@ export class TutorCourseFamilyFilterItem extends vscode.TreeItem {
 export class TutorCourseFilterItem extends vscode.TreeItem {
   constructor(
     public readonly course: { id: string; title?: string | null; path?: string; name?: string },
-    public readonly isSelected: boolean
+    public readonly isSelected: boolean,
+    expanded: boolean = isSelected
   ) {
     const label = course.title || course.path || course.name || course.id;
-    super(label, isSelected ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
+    super(label, expanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
     this.id = `tutor-filter-course-${course.id}`;
     this.contextValue = isSelected ? 'tutorFilterCourse.selected' : 'tutorFilterCourse';
     this.iconPath = new vscode.ThemeIcon(isSelected ? 'book' : 'book');

--- a/src/ui/tree/tutor/tutor-filter-tree-items.ts
+++ b/src/ui/tree/tutor/tutor-filter-tree-items.ts
@@ -51,6 +51,7 @@ export class TutorOrganizationFilterItem extends vscode.TreeItem {
     this.id = `tutor-filter-org-${organizationId}`;
     this.contextValue = 'tutorFilterOrganization';
     this.iconPath = new vscode.ThemeIcon('organization');
+    this.tooltip = `Organization: ${label}`;
     this.description = 'Organization';
   }
 }
@@ -60,12 +61,16 @@ export class TutorCourseFamilyFilterItem extends vscode.TreeItem {
     public readonly courseFamilyId: string,
     public readonly organizationId: string,
     label: string,
-    expanded: boolean
+    expanded: boolean,
+    organizationLabel?: string
   ) {
     super(label, expanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
     this.id = `tutor-filter-family-${courseFamilyId}`;
     this.contextValue = 'tutorFilterCourseFamily';
     this.iconPath = new vscode.ThemeIcon('folder-library');
+    this.tooltip = organizationLabel
+      ? `Course Family: ${label}\nOrganization: ${organizationLabel}`
+      : `Course Family: ${label}`;
     this.description = 'Course Family';
   }
 }
@@ -74,13 +79,22 @@ export class TutorCourseFilterItem extends vscode.TreeItem {
   constructor(
     public readonly course: { id: string; title?: string | null; path?: string; name?: string },
     public readonly isSelected: boolean,
-    expanded: boolean = isSelected
+    expanded: boolean = isSelected,
+    parents?: { courseFamilyLabel?: string; organizationLabel?: string }
   ) {
     const label = course.title || course.path || course.name || course.id;
     super(label, expanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
     this.id = `tutor-filter-course-${course.id}`;
     this.contextValue = isSelected ? 'tutorFilterCourse.selected' : 'tutorFilterCourse';
     this.iconPath = new vscode.ThemeIcon(isSelected ? 'book' : 'book');
+    const tooltipLines: string[] = [`Course: ${label}`];
+    if (parents?.courseFamilyLabel) {
+      tooltipLines.push(`Course Family: ${parents.courseFamilyLabel}`);
+    }
+    if (parents?.organizationLabel) {
+      tooltipLines.push(`Organization: ${parents.organizationLabel}`);
+    }
+    this.tooltip = tooltipLines.join('\n');
     if (isSelected) {
       this.description = '(selected)';
     }

--- a/src/ui/tree/tutor/tutor-filter-tree-provider.ts
+++ b/src/ui/tree/tutor/tutor-filter-tree-provider.ts
@@ -208,11 +208,13 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
       return aLabel.localeCompare(bLabel);
     });
     const selectedFamilyId = this.findCourseFamilyId(this.selection.getCurrentCourseId());
+    const orgLabel = this.resolveOrgLabel(orgItem.organizationId);
     return familyKeys.map(familyKey => new TutorCourseFamilyFilterItem(
       familyKey,
       orgItem.organizationId,
       this.resolveFamilyLabel(familyKey),
-      familyKey === selectedFamilyId || this.isExpanded(`tutor-filter-family-${familyKey}`)
+      familyKey === selectedFamilyId || this.isExpanded(`tutor-filter-family-${familyKey}`),
+      orgLabel
     ));
   }
 
@@ -224,10 +226,12 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
       return aLabel.localeCompare(bLabel);
     });
     const selectedCourseId = this.selection.getCurrentCourseId();
+    const courseFamilyLabel = this.resolveFamilyLabel(familyItem.courseFamilyId);
+    const organizationLabel = this.resolveOrgLabel(familyItem.organizationId);
     return courses.map(course => {
       const isSelected = course.id === selectedCourseId;
       const expanded = isSelected || this.isExpanded(`tutor-filter-course-${course.id}`);
-      return new TutorCourseFilterItem(course, isSelected, expanded);
+      return new TutorCourseFilterItem(course, isSelected, expanded, { courseFamilyLabel, organizationLabel });
     });
   }
 

--- a/src/ui/tree/tutor/tutor-filter-tree-provider.ts
+++ b/src/ui/tree/tutor/tutor-filter-tree-provider.ts
@@ -1,18 +1,25 @@
 import * as vscode from 'vscode';
 import type { ComputorApiService } from '../../../services/ComputorApiService';
 import type { TutorSelectionService } from '../../../services/TutorSelectionService';
-import type { TutorCourseMemberList, CourseGroupList } from '../../../types/generated/courses';
+import type { CourseTutorList, TutorCourseMemberList, CourseGroupList } from '../../../types/generated/courses';
 import {
+  TutorCourseFamilyFilterItem,
   TutorCourseFilterItem,
   TutorGroupFilterItem,
   TutorGroupOptionItem,
   TutorMemberFilterItem,
+  TutorOrganizationFilterItem,
   NO_GROUP_SENTINEL,
   formatMemberName,
   compareMembersByName
 } from './tutor-filter-tree-items';
 
+const NO_ORG_KEY = '__no_org__';
+const NO_FAMILY_KEY = '__no_family__';
+
 type FilterTreeItem =
+  | TutorOrganizationFilterItem
+  | TutorCourseFamilyFilterItem
   | TutorCourseFilterItem
   | TutorGroupFilterItem
   | TutorGroupOptionItem
@@ -22,7 +29,14 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
   private _onDidChangeTreeData = new vscode.EventEmitter<FilterTreeItem | undefined | null | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-  private courses: Array<{ id: string; title?: string | null; path?: string; name?: string }> = [];
+  private courses: CourseTutorList[] = [];
+  private orgLabels = new Map<string, string>();
+  private familyLabels = new Map<string, string>();
+  private familiesByOrg = new Map<string, string[]>();
+  private coursesByFamily = new Map<string, CourseTutorList[]>();
+  private hierarchyLoaded = false;
+  private hierarchyLoadingPromise?: Promise<void>;
+
   private groupsCache = new Map<string, CourseGroupList[]>();
   private membersCache = new Map<string, TutorCourseMemberList[]>();
 
@@ -42,6 +56,12 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
     if (!element) {
       return this.getRootChildren();
     }
+    if (element instanceof TutorOrganizationFilterItem) {
+      return this.getOrganizationChildren(element);
+    }
+    if (element instanceof TutorCourseFamilyFilterItem) {
+      return this.getCourseFamilyChildren(element);
+    }
     if (element instanceof TutorCourseFilterItem) {
       return this.getCourseChildren(element);
     }
@@ -53,6 +73,12 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
 
   refresh(): void {
     this.courses = [];
+    this.orgLabels.clear();
+    this.familyLabels.clear();
+    this.familiesByOrg.clear();
+    this.coursesByFamily.clear();
+    this.hierarchyLoaded = false;
+    this.hierarchyLoadingPromise = undefined;
     this.groupsCache.clear();
     this.membersCache.clear();
     this._onDidChangeTreeData.fire(undefined);
@@ -62,14 +88,132 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
     this.refresh();
   }
 
-  private async getRootChildren(): Promise<FilterTreeItem[]> {
-    if (this.courses.length === 0) {
-      this.courses = await this.api.getTutorCourses(false) || [];
+  private async ensureHierarchyLoaded(): Promise<void> {
+    if (this.hierarchyLoaded) { return; }
+    if (this.hierarchyLoadingPromise) {
+      await this.hierarchyLoadingPromise;
+      return;
     }
+    this.hierarchyLoadingPromise = this.loadHierarchy().finally(() => {
+      this.hierarchyLoadingPromise = undefined;
+    });
+    await this.hierarchyLoadingPromise;
+  }
+
+  private async loadHierarchy(): Promise<void> {
+    const courses = (await this.api.getTutorCourses(false)) || [];
+    this.courses = courses as CourseTutorList[];
+
+    const orgIds = new Set<string>();
+    const familyIds = new Set<string>();
+    for (const course of this.courses) {
+      if (course.organization_id) { orgIds.add(course.organization_id); }
+      if (course.course_family_id) { familyIds.add(course.course_family_id); }
+    }
+
+    const [orgs, families] = await Promise.all([
+      Promise.all([...orgIds].map(id => this.api.getOrganization(id).catch(() => undefined))),
+      Promise.all([...familyIds].map(id => this.api.getCourseFamily(id).catch(() => undefined)))
+    ]);
+
+    for (const org of orgs) {
+      if (org && typeof org === 'object' && 'id' in org && typeof (org as any).id === 'string') {
+        const label = (org as any).title || (org as any).path || (org as any).id;
+        this.orgLabels.set((org as any).id, label);
+      }
+    }
+    for (const family of families) {
+      if (family && typeof family === 'object' && 'id' in family && typeof (family as any).id === 'string') {
+        const label = (family as any).title || (family as any).path || (family as any).id;
+        this.familyLabels.set((family as any).id, label);
+      }
+    }
+
+    this.familiesByOrg.clear();
+    this.coursesByFamily.clear();
+    for (const course of this.courses) {
+      const orgKey = course.organization_id || NO_ORG_KEY;
+      const familyKey = course.course_family_id || NO_FAMILY_KEY;
+      const familyList = this.familiesByOrg.get(orgKey) ?? [];
+      if (!familyList.includes(familyKey)) {
+        familyList.push(familyKey);
+        this.familiesByOrg.set(orgKey, familyList);
+      }
+      const courseList = this.coursesByFamily.get(familyKey) ?? [];
+      courseList.push(course);
+      this.coursesByFamily.set(familyKey, courseList);
+    }
+
+    this.hierarchyLoaded = true;
+  }
+
+  private async getRootChildren(): Promise<FilterTreeItem[]> {
+    await this.ensureHierarchyLoaded();
     const selectedCourseId = this.selection.getCurrentCourseId();
-    return this.courses.map(
-      course => new TutorCourseFilterItem(course, course.id === selectedCourseId)
-    );
+    const selectedOrgId = this.findCourseOrgId(selectedCourseId);
+
+    const orgKeys = Array.from(this.familiesByOrg.keys()).sort((a, b) => {
+      const aLabel = this.resolveOrgLabel(a);
+      const bLabel = this.resolveOrgLabel(b);
+      return aLabel.localeCompare(bLabel);
+    });
+
+    return orgKeys.map(orgKey => new TutorOrganizationFilterItem(
+      orgKey,
+      this.resolveOrgLabel(orgKey),
+      orgKey === selectedOrgId
+    ));
+  }
+
+  private async getOrganizationChildren(orgItem: TutorOrganizationFilterItem): Promise<FilterTreeItem[]> {
+    await this.ensureHierarchyLoaded();
+    const familyKeys = (this.familiesByOrg.get(orgItem.organizationId) ?? []).slice().sort((a, b) => {
+      const aLabel = this.resolveFamilyLabel(a);
+      const bLabel = this.resolveFamilyLabel(b);
+      return aLabel.localeCompare(bLabel);
+    });
+    const selectedFamilyId = this.findCourseFamilyId(this.selection.getCurrentCourseId());
+    return familyKeys.map(familyKey => new TutorCourseFamilyFilterItem(
+      familyKey,
+      orgItem.organizationId,
+      this.resolveFamilyLabel(familyKey),
+      familyKey === selectedFamilyId
+    ));
+  }
+
+  private async getCourseFamilyChildren(familyItem: TutorCourseFamilyFilterItem): Promise<FilterTreeItem[]> {
+    await this.ensureHierarchyLoaded();
+    const courses = (this.coursesByFamily.get(familyItem.courseFamilyId) ?? []).slice().sort((a, b) => {
+      const aLabel = a.title || a.path || a.id;
+      const bLabel = b.title || b.path || b.id;
+      return aLabel.localeCompare(bLabel);
+    });
+    const selectedCourseId = this.selection.getCurrentCourseId();
+    return courses.map(course => new TutorCourseFilterItem(course, course.id === selectedCourseId));
+  }
+
+  private resolveOrgLabel(orgKey: string): string {
+    if (orgKey === NO_ORG_KEY) { return '(No Organization)'; }
+    return this.orgLabels.get(orgKey) || orgKey;
+  }
+
+  private resolveFamilyLabel(familyKey: string): string {
+    if (familyKey === NO_FAMILY_KEY) { return '(No Course Family)'; }
+    return this.familyLabels.get(familyKey) || familyKey;
+  }
+
+  private findCourseOrgId(courseId: string | null | undefined): string | undefined {
+    if (!courseId) { return undefined; }
+    const course = this.courses.find(c => c.id === courseId);
+    if (!course) { return undefined; }
+    return course.organization_id || NO_ORG_KEY;
+  }
+
+  private findCourseFamilyId(courseId: string | null | undefined): string | undefined {
+    if (!courseId) { return undefined; }
+    const course = this.courses.find(c => c.id === courseId);
+    if (!course) { return undefined; }
+    return course.course_family_id || NO_FAMILY_KEY;
   }
 
   private async getCourseChildren(courseItem: TutorCourseFilterItem): Promise<FilterTreeItem[]> {

--- a/src/ui/tree/tutor/tutor-filter-tree-provider.ts
+++ b/src/ui/tree/tutor/tutor-filter-tree-provider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import type { ComputorApiService } from '../../../services/ComputorApiService';
+import type { ComputorSettingsManager } from '../../../settings/ComputorSettingsManager';
 import type { TutorSelectionService } from '../../../services/TutorSelectionService';
 import type { CourseTutorList, TutorCourseMemberList, CourseGroupList } from '../../../types/generated/courses';
 import {
@@ -43,10 +44,44 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
   private currentGroupFetchCourseId?: string | null;
   private currentMemberFetchKey?: { courseId: string | null; groupId: string | null };
 
+  private expandedStates: Record<string, boolean> = {};
+
   constructor(
     private readonly api: ComputorApiService,
-    private readonly selection: TutorSelectionService
-  ) {}
+    private readonly selection: TutorSelectionService,
+    private readonly settingsManager?: ComputorSettingsManager
+  ) {
+    void this.loadExpandedStates();
+  }
+
+  private async loadExpandedStates(): Promise<void> {
+    if (!this.settingsManager) { return; }
+    try {
+      this.expandedStates = await this.settingsManager.getTutorTreeExpandedStates();
+    } catch (error) {
+      console.error('[TutorFilterTree] Failed to load expanded states:', error);
+      this.expandedStates = {};
+    }
+  }
+
+  async setNodeExpanded(nodeId: string, expanded: boolean): Promise<void> {
+    if (expanded) {
+      this.expandedStates[nodeId] = true;
+    } else {
+      delete this.expandedStates[nodeId];
+    }
+    if (this.settingsManager) {
+      try {
+        await this.settingsManager.setTutorNodeExpandedState(nodeId, expanded);
+      } catch (error) {
+        console.error('[TutorFilterTree] Failed to persist expanded state:', error);
+      }
+    }
+  }
+
+  private isExpanded(nodeId: string): boolean {
+    return this.expandedStates[nodeId] === true;
+  }
 
   getTreeItem(element: FilterTreeItem): vscode.TreeItem {
     return element;
@@ -161,7 +196,7 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
     return orgKeys.map(orgKey => new TutorOrganizationFilterItem(
       orgKey,
       this.resolveOrgLabel(orgKey),
-      orgKey === selectedOrgId
+      orgKey === selectedOrgId || this.isExpanded(`tutor-filter-org-${orgKey}`)
     ));
   }
 
@@ -177,7 +212,7 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
       familyKey,
       orgItem.organizationId,
       this.resolveFamilyLabel(familyKey),
-      familyKey === selectedFamilyId
+      familyKey === selectedFamilyId || this.isExpanded(`tutor-filter-family-${familyKey}`)
     ));
   }
 
@@ -189,7 +224,11 @@ export class TutorFilterTreeProvider implements vscode.TreeDataProvider<FilterTr
       return aLabel.localeCompare(bLabel);
     });
     const selectedCourseId = this.selection.getCurrentCourseId();
-    return courses.map(course => new TutorCourseFilterItem(course, course.id === selectedCourseId));
+    return courses.map(course => {
+      const isSelected = course.id === selectedCourseId;
+      const expanded = isSelected || this.isExpanded(`tutor-filter-course-${course.id}`);
+      return new TutorCourseFilterItem(course, isSelected, expanded);
+    });
   }
 
   private resolveOrgLabel(orgKey: string): string {

--- a/src/ui/webviews/MessagesWebviewProvider.ts
+++ b/src/ui/webviews/MessagesWebviewProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { BaseWebviewProvider } from './BaseWebviewProvider';
 import { ComputorApiService } from '../../services/ComputorApiService';
+import { canReplyInScope, deriveScopeFromCreatePayload } from '../../services/MessagePermissions';
 import { MessageGet, MessageList, MessageQuery } from '../../types/generated';
 import type { MessagesInputPanelProvider } from '../panels/MessagesInputPanel';
 import { WebSocketService } from '../../services/WebSocketService';
@@ -25,6 +26,8 @@ export interface MessageTargetContext {
   readOnly?: boolean;
   /** Optional reason shown alongside the read-only notice. */
   readOnlyReason?: string;
+  /** Whether replies are permitted in this scope (computed from createPayload). */
+  allowReplies?: boolean;
 }
 
 interface MessagesWebviewData {
@@ -60,11 +63,20 @@ export class MessagesWebviewProvider extends BaseWebviewProvider {
     this.inputPanel = inputPanel;
   }
 
+  private withReplyPolicy(target: MessageTargetContext): MessageTargetContext {
+    if (target.allowReplies !== undefined) {
+      return target;
+    }
+    const scope = deriveScopeFromCreatePayload(target.createPayload);
+    return { ...target, allowReplies: canReplyInScope(scope) };
+  }
+
   public setWebSocketService(wsService: WebSocketService): void {
     this.wsService = wsService;
   }
 
   async showMessages(target: MessageTargetContext): Promise<void> {
+    target = this.withReplyPolicy(target);
     const currentUserId = this.apiService.getCurrentUserId();
     const [identity, rawMessages] = await Promise.all([
       currentUserId ? this.apiService.getCurrentUser().catch(() => undefined) : Promise.resolve(undefined),
@@ -312,6 +324,12 @@ export class MessagesWebviewProvider extends BaseWebviewProvider {
     switch (message.command) {
       case 'replyTo':
         if (this.inputPanel && message.data) {
+          const target = this.getCurrentTarget();
+          if (target && target.allowReplies === false) {
+            // Webview button should already be hidden, but defend in case the
+            // command arrives via a stale render or another path.
+            return;
+          }
           this.inputPanel.setReplyTo(message.data);
           await this.inputPanel.reveal();
         }

--- a/src/ui/webviews/MessagesWebviewProvider.ts
+++ b/src/ui/webviews/MessagesWebviewProvider.ts
@@ -600,13 +600,19 @@ export class MessagesWebviewProvider extends BaseWebviewProvider {
       .filter((part) => part.length > 0);
     const fullName = trimmedParts.join(' ');
     const hasFullName = fullName.length > 0;
+    // The backend strips `is_author` from WS broadcasts (it's per-recipient),
+    // so we recompute it client-side. Without this, edit/delete buttons never
+    // appear on freshly arrived own messages until the user hits Refresh.
+    const currentUserId = this.apiService.getCurrentUserId();
+    const isAuthor = currentUserId ? message.author_id === currentUserId : (message.is_author ?? false);
 
     return {
       ...message,
       author_display: hasFullName ? fullName : undefined,
       author_name: hasFullName ? fullName : undefined,
-      can_edit: message.is_author ?? false,
-      can_delete: message.is_author ?? false
+      can_edit: isAuthor,
+      can_delete: isAuthor,
+      is_author: isAuthor
     } satisfies EnrichedMessage;
   }
 

--- a/src/ui/webviews/MessagesWebviewProvider.ts
+++ b/src/ui/webviews/MessagesWebviewProvider.ts
@@ -5,8 +5,6 @@ import { MessageGet, MessageList, MessageQuery } from '../../types/generated';
 import type { MessagesInputPanelProvider } from '../panels/MessagesInputPanel';
 import { WebSocketService } from '../../services/WebSocketService';
 
-export type MessageTargetType = 'course' | 'courseGroup' | 'courseContent' | 'submissionGroup' | 'courseMember';
-
 export interface MessageFilters {
   unread?: boolean;
   created_after?: string;
@@ -23,6 +21,10 @@ export interface MessageTargetContext {
   sourceRole?: 'student' | 'tutor' | 'lecturer';
   /** WebSocket channel for real-time updates (e.g., "submission_group:uuid") */
   wsChannel?: string;
+  /** When true, the input panel hides compose UI and shows a read-only notice. */
+  readOnly?: boolean;
+  /** Optional reason shown alongside the read-only notice. */
+  readOnlyReason?: string;
 }
 
 interface MessagesWebviewData {
@@ -251,6 +253,8 @@ export class MessagesWebviewProvider extends BaseWebviewProvider {
       .markMessageRead(messageId)
       .then(() => {
         console.log('[MessagesWebviewProvider] Successfully marked message as read via API:', messageId);
+        // Inbox unread badges depend on this; see notifyIndicatorsUpdated for context.
+        void vscode.commands.executeCommand('computor.chat.refresh');
       })
       .catch((error) => {
         console.error(`Failed to mark message ${messageId} as read:`, error);
@@ -457,6 +461,12 @@ export class MessagesWebviewProvider extends BaseWebviewProvider {
       default:
         break;
     }
+
+    // Refresh the chat inbox so its unread badges drop after a read sweep.
+    // Backend WS read:update only fires for submission_group today, so any
+    // other scope (course_group, course_content, course, family, org, global)
+    // would otherwise show stale unread counts until manual refresh.
+    void vscode.commands.executeCommand('computor.chat.refresh');
   }
 
   private async handleConfirmDeleteMessage(data: { messageId: string; title?: string }): Promise<void> {

--- a/src/utils/progressLock.ts
+++ b/src/utils/progressLock.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const inFlightKeys = new Set<string>();
+
+export interface ProgressLockOptions {
+  /** Unique key — concurrent attempts with the same key are blocked. */
+  key: string;
+  /** Notification title shown while work runs. */
+  title: string;
+  /** Friendly message shown when a duplicate click is rejected. Omit to silently ignore. */
+  duplicateMessage?: string;
+  /** Hard cap on lock + progress duration. Defaults to 60 s. */
+  timeoutMs?: number;
+}
+
+/**
+ * Run `work` under a non-cancellable progress notification with a per-key
+ * in-flight guard. Re-clicking the same `key` while work is running is a
+ * no-op (or a friendly toast if `duplicateMessage` is set). The lock is
+ * released as soon as work resolves/rejects, or after `timeoutMs` as a
+ * safety net for hung calls.
+ *
+ * Returns the result of `work`, or `undefined` if a duplicate click was
+ * rejected.
+ */
+export async function runLockedWithProgress<T>(
+  options: ProgressLockOptions,
+  work: () => Promise<T>
+): Promise<T | undefined> {
+  if (inFlightKeys.has(options.key)) {
+    if (options.duplicateMessage) {
+      void vscode.window.showInformationMessage(options.duplicateMessage);
+    }
+    return undefined;
+  }
+
+  inFlightKeys.add(options.key);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  try {
+    return await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        cancellable: false,
+        title: options.title
+      },
+      async () => {
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(() => {
+            reject(new Error('Operation timed out'));
+          }, timeoutMs);
+        });
+        try {
+          return await Promise.race([work(), timeoutPromise]);
+        } finally {
+          if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+          }
+        }
+      }
+    );
+  } finally {
+    inFlightKeys.delete(options.key);
+  }
+}

--- a/webview-ui/messages-input.css
+++ b/webview-ui/messages-input.css
@@ -42,6 +42,27 @@ body {
   max-width: 200px;
 }
 
+.read-only-notice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: var(--vscode-editorWidget-background);
+  color: var(--vscode-descriptionForeground);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.read-only-icon {
+  font-size: 14px;
+  opacity: 0.8;
+}
+
+.read-only-text {
+  flex: 1;
+}
+
 .input-container {
   display: flex;
   flex-direction: column;

--- a/webview-ui/messages-input.js
+++ b/webview-ui/messages-input.js
@@ -213,6 +213,23 @@
       container.appendChild(header);
     }
 
+    if (state.target.readOnly) {
+      const notice = createElement('div', { className: 'read-only-notice' });
+      const icon = createElement('span', {
+        className: 'read-only-icon',
+        textContent: '🔒'
+      });
+      const text = createElement('span', {
+        className: 'read-only-text',
+        textContent: state.target.readOnlyReason || 'You can read but not post messages here.'
+      });
+      notice.appendChild(icon);
+      notice.appendChild(text);
+      container.appendChild(notice);
+      mount.appendChild(container);
+      return;
+    }
+
     const form = createElement('div', { className: 'input-form' });
 
     // Title row: subject input + send button

--- a/webview-ui/messages.js
+++ b/webview-ui/messages.js
@@ -303,7 +303,8 @@
 
     const metaRight = createElement('div', { className: 'message-meta-right' });
 
-    if (createButton) {
+    const repliesAllowed = state.target?.allowReplies !== false;
+    if (createButton && repliesAllowed) {
       const replyButton = createButton({
         text: 'Reply',
         size: 'xs',

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,14 +255,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
-  version "0.3.31"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
-  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
@@ -270,6 +262,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+  version "0.3.31"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@kwsites/file-exists@^1.1.1":
   version "1.1.1"
@@ -291,7 +291,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -441,7 +441,7 @@
     table "^6.9.0"
     text-table "^0.2.0"
 
-"@textlint/module-interop@^15.2.0", "@textlint/module-interop@15.2.3":
+"@textlint/module-interop@15.2.3", "@textlint/module-interop@^15.2.0":
   version "15.2.3"
   resolved "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.2.3.tgz"
   integrity sha512-dV6M3ptOFJjR5bgYUMeVqc8AqFrMtCEFaZEiLAfMufX29asYonI2K8arqivOA69S2Lh6esyij6V7qpQiXeK/cA==
@@ -451,7 +451,7 @@
   resolved "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.2.3.tgz"
   integrity sha512-Qd3udqo2sWa3u0sYgDVd9M/iybBVBJLrWGaID6Yzl9GyhdGi0E6ngo3b9r+H6psbJDIaCKi54IxvC9q5didWfA==
 
-"@textlint/types@^15.2.0", "@textlint/types@15.2.3":
+"@textlint/types@15.2.3", "@textlint/types@^15.2.0":
   version "15.2.3"
   resolved "https://registry.npmjs.org/@textlint/types/-/types-15.2.3.tgz"
   integrity sha512-i8XVmDHJwykMXcGgkSxZLjdbeqnl+voYAcIr94KIe0STwgkHIhwHJgb/tEVFawGClHo+gPczF12l1C5+TAZEzQ==
@@ -580,7 +580,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@^5.45.0":
+"@typescript-eslint/parser@^5.45.0":
   version "5.62.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz"
   integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
@@ -662,6 +662,51 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@vscode/vsce-sign-alpine-arm64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz#2cd244caf5e8ec543f42fb91d4df3b933641c8fa"
+  integrity sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==
+
+"@vscode/vsce-sign-alpine-x64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz#b0e80a4792001c66e27feee2c11e821ad1fa1680"
+  integrity sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==
+
+"@vscode/vsce-sign-darwin-arm64@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.2.tgz#10aa69feb7f81a3dc68c242038ca03eaff19c12e"
+  integrity sha512-rz8F4pMcxPj8fjKAJIfkUT8ycG9CjIp888VY/6pq6cuI2qEzQ0+b5p3xb74CJnBbSC0p2eRVoe+WgNCAxCLtzQ==
+
+"@vscode/vsce-sign-darwin-x64@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.2.tgz#3315528f3ea1007a648b3320bff36a33a9e07aa5"
+  integrity sha512-MCjPrQ5MY/QVoZ6n0D92jcRb7eYvxAujG/AH2yM6lI0BspvJQxp0o9s5oiAM9r32r9tkLpiy5s2icsbwefAQIw==
+
+"@vscode/vsce-sign-linux-arm64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz#b3d8560144040b920d8c6edd4374314b58255481"
+  integrity sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==
+
+"@vscode/vsce-sign-linux-arm@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz#0a27c42a4adb37e96eec78cd7bfa388cd4e9fbef"
+  integrity sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==
+
+"@vscode/vsce-sign-linux-x64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz#ade11caeeed524fc16bd6c43ca49aea00295de8c"
+  integrity sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==
+
+"@vscode/vsce-sign-win32-arm64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz#0688968148e03eb392479c8491c72506721beffc"
+  integrity sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==
+
+"@vscode/vsce-sign-win32-x64@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz#74430eff41d26818c23f9826b045d8c75732eaeb"
+  integrity sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==
+
 "@vscode/vsce-sign@^2.0.0":
   version "2.0.8"
   resolved "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.8.tgz"
@@ -714,7 +759,7 @@
   optionalDependencies:
     keytar "^7.7.0"
 
-"@webassemblyjs/ast@^1.14.1", "@webassemblyjs/ast@1.14.1":
+"@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
   version "1.14.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz"
   integrity sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==
@@ -815,7 +860,7 @@
     "@webassemblyjs/wasm-gen" "1.14.1"
     "@webassemblyjs/wasm-parser" "1.14.1"
 
-"@webassemblyjs/wasm-parser@^1.14.1", "@webassemblyjs/wasm-parser@1.14.1":
+"@webassemblyjs/wasm-parser@1.14.1", "@webassemblyjs/wasm-parser@^1.14.1":
   version "1.14.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz"
   integrity sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==
@@ -877,7 +922,7 @@ acorn-walk@^8.1.1:
   dependencies:
     acorn "^8.11.0"
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.11.0, acorn@^8.14.0, acorn@^8.15.0, acorn@^8.4.1, acorn@^8.9.0:
+acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1, acorn@^8.9.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -916,7 +961,7 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.0.1, ajv@^8.17.1, ajv@^8.8.2, ajv@^8.9.0:
+ajv@^8.0.0, ajv@^8.0.1, ajv@^8.17.1, ajv@^8.9.0:
   version "8.17.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
@@ -1105,7 +1150,7 @@ browser-stdout@^1.3.1:
   resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.26.3, "browserslist@>= 4.21.0":
+browserslist@^4.26.3:
   version "4.26.3"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz"
   integrity sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==
@@ -1421,7 +1466,7 @@ css-what@^6.1.0:
   resolved "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz"
   integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
-debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3, debug@4:
+debug@4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1667,7 +1712,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-scope@^5.1.1, eslint-scope@5.1.1:
+eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -1688,7 +1733,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@*, "eslint@^6.0.0 || ^7.0.0 || ^8.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@^8.28.0:
+eslint@^8.28.0:
   version "8.57.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -1939,6 +1984,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -1990,14 +2040,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
-  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
-  dependencies:
-    is-glob "^4.0.3"
-
-glob-parent@^6.0.2:
+glob-parent@^6.0.1, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -2176,7 +2219,7 @@ https-proxy-agent@^7.0.0:
     agent-base "^7.1.2"
     debug "4"
 
-iconv-lite@^0.6.3, iconv-lite@0.6.3:
+iconv-lite@0.6.3, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -2237,7 +2280,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@2:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2638,12 +2681,7 @@ loupe@^2.3.6:
   dependencies:
     get-func-name "^2.0.1"
 
-lru-cache@^10.0.1:
-  version "10.4.3"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
-  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
-
-lru-cache@^10.2.0:
+lru-cache@^10.0.1, lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -3086,7 +3124,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.3:
+picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -3534,20 +3572,6 @@ ssf@~0.11.2:
   dependencies:
     frac "~1.1.2"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
-
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
@@ -3575,6 +3599,20 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
@@ -3589,14 +3627,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1:
-  version "7.1.2"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz"
-  integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
-  dependencies:
-    ansi-regex "^6.0.1"
-
-strip-ansi@^7.1.0:
+strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz"
   integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
@@ -3632,14 +3663,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0:
-  version "8.1.1"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
-
-supports-color@^8.1.1:
+supports-color@^8.0.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -3861,7 +3885,7 @@ typed-rest-client@^1.8.4:
     tunnel "0.0.6"
     underscore "^1.12.1"
 
-typescript@*, typescript@^4.9.4, typescript@>=2.7, "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta":
+typescript@^4.9.4:
   version "4.9.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
@@ -3875,11 +3899,6 @@ underscore@^1.12.1:
   version "1.13.7"
   resolved "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz"
   integrity sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==
-
-undici-types@~7.14.0:
-  version "7.14.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz"
-  integrity sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==
 
 undici@^7.12.0:
   version "7.16.0"
@@ -3971,7 +3990,7 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
-webpack-cli@^6.0.1, webpack-cli@6.x.x:
+webpack-cli@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz"
   integrity sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==
@@ -4004,7 +4023,7 @@ webpack-sources@^3.3.3:
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz"
   integrity sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==
 
-webpack@^5.0.0, webpack@^5.1.0, webpack@^5.101.3, webpack@^5.82.0:
+webpack@^5.101.3:
   version "5.102.1"
   resolved "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz"
   integrity sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==


### PR DESCRIPTION
## Summary

12 commits covering the messages scope refactor, live WS inbox, and tutor-tree parity with lecturer/student.

### Messages
- `cbfc19a` scope-aware compose with `/user/scopes` gating
- `2de1b86` unread message badge on chat sidebar icon
- `0c2c08c` stop chat tree flicker on unread thread selection
- `5d0f66f` live inbox via per-user WS channel
- `91ab793` toast notification for new messages with click-to-open
- `4ebc621` debounce WS-driven inbox reloads to absorb burst events
- `34778a1` hide reply button on broadcast-style scopes
- `dec8e02` derive `is_author` client-side so edit button shows on own WS messages

### UX polish
- `1191210` lock and progress popup for course/member progress commands

### Tutor tree
- `c63734b` organization and course family levels in tutor courses & members tree
- `1a278a3` persist tutor tree expansion across refreshes and sessions
- `5aad806` prefix tooltips on lecturer and tutor org/family/course tree items

## Test plan
- [ ] Smoke-test compose: org / course-family targets gate correctly via `/user/scopes`; non-`_owner`/`_manager` see read-only banner
- [ ] Receive a new message in any scope — toast appears with Open button, clicking focuses chat tree and opens the panel
- [ ] Unread badge on the chat activity-bar icon reflects total unread; drops to zero after reading
- [ ] Open an unread thread with multiple unread messages — no flicker, badge updates once
- [ ] Reply button only visible on `user`, `course_member`, `submission_group` scopes
- [ ] Edit button appears immediately on own messages received via WS (no refresh needed)
- [ ] Course progress / member progress commands show non-cancellable loading popup; second click while loading is rejected
- [ ] Tutor tree shows Organization → Course Family → Course hierarchy; tooltips match student-tree style
- [ ] Tutor tree expansion survives refresh and VS Code restart