### PR TITLE
Refactor user management with role editor and admin gating

### DIFF
--- a/package.json
+++ b/package.json
@@ -520,6 +520,12 @@
         "category": "Computor User Manager"
       },
       {
+        "command": "computor.userManager.createUser",
+        "title": "New User",
+        "icon": "$(add)",
+        "category": "Computor User Manager"
+      },
+      {
         "command": "computor.userManager.openUserDetails",
         "title": "Open User Details",
         "icon": "$(account)",
@@ -1119,6 +1125,11 @@
           "command": "computor.student.offline.refresh",
           "when": "view == computor.student.offline.view",
           "group": "navigation@1"
+        },
+        {
+          "command": "computor.userManager.createUser",
+          "when": "view == computor.usermanager.users",
+          "group": "navigation@0"
         },
         {
           "command": "computor.userManager.searchUsers",

--- a/package.json
+++ b/package.json
@@ -890,7 +890,7 @@
         {
           "id": "computor-user-manager",
           "title": "Computor User Manager",
-          "icon": "$(organization)",
+          "icon": "$(account)",
           "when": "computor.user_manager.show"
         },
         {

--- a/package.json
+++ b/package.json
@@ -537,6 +537,18 @@
         "category": "Computor User Manager"
       },
       {
+        "command": "computor.userManager.toggleArchived",
+        "title": "Toggle Archived Users",
+        "icon": "$(archive)",
+        "category": "Computor User Manager"
+      },
+      {
+        "command": "computor.userManager.toggleService",
+        "title": "Toggle Service Accounts",
+        "icon": "$(robot)",
+        "category": "Computor User Manager"
+      },
+      {
         "command": "computor.logout",
         "title": "Logout",
         "icon": "$(sign-out)",
@@ -1114,9 +1126,19 @@
           "group": "navigation@1"
         },
         {
-          "command": "computor.userManager.refresh",
+          "command": "computor.userManager.toggleArchived",
           "when": "view == computor.usermanager.users",
           "group": "navigation@2"
+        },
+        {
+          "command": "computor.userManager.toggleService",
+          "when": "view == computor.usermanager.users",
+          "group": "navigation@3"
+        },
+        {
+          "command": "computor.userManager.refresh",
+          "when": "view == computor.usermanager.users",
+          "group": "navigation@4"
         },
         {
           "command": "computor.manageGitLabTokens",

--- a/src/commands/UserManagerCommands.ts
+++ b/src/commands/UserManagerCommands.ts
@@ -4,13 +4,15 @@ import { UserManagerTreeProvider } from '../ui/tree/user-manager/UserManagerTree
 import { UserManagementWebviewProvider } from '../ui/webviews/UserManagementWebviewProvider';
 import { commandRegistrar } from './commandHelpers';
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export class UserManagerCommands {
   private userManagementWebviewProvider: UserManagementWebviewProvider;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly treeProvider: UserManagerTreeProvider,
-    apiService: ComputorApiService
+    private readonly apiService: ComputorApiService
   ) {
     this.userManagementWebviewProvider = new UserManagementWebviewProvider(
       context,
@@ -53,6 +55,70 @@ export class UserManagerCommands {
     register('computor.userManager.toggleService', () => {
       this.treeProvider.toggleShowService();
     });
+
+    register('computor.userManager.createUser', async () => {
+      await this.handleCreateUser();
+    });
+  }
+
+  private async handleCreateUser(): Promise<void> {
+    const username = await vscode.window.showInputBox({
+      title: 'New user (1/4): Username',
+      prompt: 'Required. Must be unique.',
+      validateInput: (value) => {
+        const trimmed = (value ?? '').trim();
+        if (!trimmed) { return 'Username is required.'; }
+        if (/\s/.test(trimmed)) { return 'Username cannot contain whitespace.'; }
+        return undefined;
+      }
+    });
+    if (username === undefined) { return; }
+
+    const email = await vscode.window.showInputBox({
+      title: 'New user (2/4): Email',
+      prompt: 'Required. Must be a valid email.',
+      validateInput: (value) => {
+        const trimmed = (value ?? '').trim();
+        if (!trimmed) { return 'Email is required.'; }
+        if (!EMAIL_REGEX.test(trimmed)) { return 'Enter a valid email address.'; }
+        return undefined;
+      }
+    });
+    if (email === undefined) { return; }
+
+    const givenName = await vscode.window.showInputBox({
+      title: 'New user (3/4): Given name',
+      prompt: 'Optional.'
+    });
+    if (givenName === undefined) { return; }
+
+    const familyName = await vscode.window.showInputBox({
+      title: 'New user (4/4): Family name',
+      prompt: 'Optional.'
+    });
+    if (familyName === undefined) { return; }
+
+    try {
+      const created = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          cancellable: false,
+          title: `Creating user ${username.trim()}…`
+        },
+        () => this.apiService.createUser({
+          username: username.trim(),
+          email: email.trim(),
+          given_name: givenName.trim() || null,
+          family_name: familyName.trim() || null
+        })
+      );
+      vscode.window.showInformationMessage(`User ${created.username || created.email || created.id} created.`);
+      this.treeProvider.refresh();
+      await this.userManagementWebviewProvider.open(created.id);
+    } catch (error: any) {
+      const detail = error?.message || error?.response?.data?.detail || String(error);
+      vscode.window.showErrorMessage(`Failed to create user: ${detail}`);
+    }
   }
 
   private async handleRefresh(): Promise<void> {

--- a/src/commands/UserManagerCommands.ts
+++ b/src/commands/UserManagerCommands.ts
@@ -45,6 +45,14 @@ export class UserManagerCommands {
     register('computor.userManager.clearSearch', () => {
       this.treeProvider.clearSearch();
     });
+
+    register('computor.userManager.toggleArchived', () => {
+      this.treeProvider.toggleShowArchived();
+    });
+
+    register('computor.userManager.toggleService', () => {
+      this.treeProvider.toggleShowService();
+    });
   }
 
   private async handleRefresh(): Promise<void> {

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -2165,6 +2165,30 @@ export class ComputorApiService {
     }
   }
 
+  async archiveUser(userId: string): Promise<void> {
+    try {
+      const client = await this.getHttpClient();
+      await client.patch(`/users/${userId}/archive`);
+      multiTierCache.delete(`user-${userId}`);
+      multiTierCache.delete('allUsers');
+    } catch (error) {
+      console.error(`[archiveUser] Failed to archive user ${userId}:`, error);
+      throw error;
+    }
+  }
+
+  async unarchiveUser(userId: string): Promise<void> {
+    try {
+      const client = await this.getHttpClient();
+      await client.patch(`/users/${userId}/unarchive`);
+      multiTierCache.delete(`user-${userId}`);
+      multiTierCache.delete('allUsers');
+    } catch (error) {
+      console.error(`[unarchiveUser] Failed to unarchive user ${userId}:`, error);
+      throw error;
+    }
+  }
+
   // User Management: Reset user password
   async resetUserPassword(userId: string, managerPassword: string): Promise<void> {
     try {

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -2165,6 +2165,18 @@ export class ComputorApiService {
     }
   }
 
+  async createUser(payload: import('../types/generated/users').UserCreate): Promise<UserGet> {
+    try {
+      const client = await this.getHttpClient();
+      const response = await client.post<UserGet>('/users', payload);
+      multiTierCache.delete('allUsers');
+      return response.data;
+    } catch (error) {
+      console.error('[createUser] Failed to create user:', error);
+      throw error;
+    }
+  }
+
   async archiveUser(userId: string): Promise<void> {
     try {
       const client = await this.getHttpClient();

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -2165,6 +2165,48 @@ export class ComputorApiService {
     }
   }
 
+  async listRoles(): Promise<import('../types/generated/roles').RoleList[]> {
+    try {
+      const result = await this.cachedRequest({
+        cacheKey: 'allRoles',
+        tier: 'warm',
+        fetch: async () => {
+          const client = await this.getHttpClient();
+          return (await client.get<import('../types/generated/roles').RoleList[]>('/roles')).data;
+        },
+        retry: { maxRetries: 2 }
+      });
+      return result || [];
+    } catch (error) {
+      console.error('[listRoles] Failed to list roles:', error);
+      throw error;
+    }
+  }
+
+  async assignUserRole(userId: string, roleId: string): Promise<void> {
+    try {
+      const client = await this.getHttpClient();
+      await client.post('/user-roles', { user_id: userId, role_id: roleId });
+      multiTierCache.delete(`user-${userId}`);
+      multiTierCache.delete('allUsers');
+    } catch (error) {
+      console.error(`[assignUserRole] Failed to assign role ${roleId} to user ${userId}:`, error);
+      throw error;
+    }
+  }
+
+  async revokeUserRole(userId: string, roleId: string): Promise<void> {
+    try {
+      const client = await this.getHttpClient();
+      await client.delete(`/user-roles/users/${userId}/roles/${roleId}`);
+      multiTierCache.delete(`user-${userId}`);
+      multiTierCache.delete('allUsers');
+    } catch (error) {
+      console.error(`[revokeUserRole] Failed to revoke role ${roleId} from user ${userId}:`, error);
+      throw error;
+    }
+  }
+
   async createUser(payload: import('../types/generated/users').UserCreate): Promise<UserGet> {
     try {
       const client = await this.getHttpClient();

--- a/src/ui/tree/user-manager/UserManagerTreeProvider.ts
+++ b/src/ui/tree/user-manager/UserManagerTreeProvider.ts
@@ -2,6 +2,14 @@ import * as vscode from 'vscode';
 import { ComputorApiService } from '../../../services/ComputorApiService';
 import { UserList } from '../../../types/generated/users';
 
+const STATE_KEY = 'computor.userManager.filterState';
+
+interface FilterState {
+  search: string;
+  showArchived: boolean;
+  showService: boolean;
+}
+
 export class UserTreeItem extends vscode.TreeItem {
   constructor(
     public readonly user: UserList,
@@ -15,10 +23,11 @@ export class UserTreeItem extends vscode.TreeItem {
 
     super(displayName, collapsibleState);
 
-    this.contextValue = 'user';
+    this.contextValue = user.is_service ? 'user.service' : 'user';
     this.tooltip = this.buildTooltip();
     this.description = user.email || user.username || '';
-    this.iconPath = new vscode.ThemeIcon('account');
+    // Robot icon for service accounts, human icon for real users.
+    this.iconPath = new vscode.ThemeIcon(user.is_service ? 'robot' : 'account');
     this.command = {
       command: 'computor.userManager.openUserDetails',
       title: 'Open User Details',
@@ -53,6 +62,49 @@ export class UserTreeItem extends vscode.TreeItem {
   }
 }
 
+class UserManagerLoadingItem extends vscode.TreeItem {
+  constructor() {
+    super('Loading users…', vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon('loading~spin');
+    this.contextValue = 'userManagerLoading';
+  }
+}
+
+class UserManagerEmptyItem extends vscode.TreeItem {
+  constructor(message: string) {
+    super(message, vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon('inbox');
+    this.contextValue = 'userManagerEmpty';
+  }
+}
+
+class UserManagerStatItem extends vscode.TreeItem {
+  constructor(visible: number, total: number) {
+    const suffix = visible !== total ? ` of ${total}` : '';
+    super(`${visible}${suffix} user${visible === 1 ? '' : 's'}`, vscode.TreeItemCollapsibleState.None);
+    this.id = 'userManagerStat';
+    this.iconPath = new vscode.ThemeIcon('list-unordered');
+    this.contextValue = 'userManagerStat';
+  }
+}
+
+class UserManagerFilterChipItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    icon: string,
+    tooltip: string,
+    clickCommand: string,
+    chipKind: string
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.id = `userManagerChip:${chipKind}`;
+    this.iconPath = new vscode.ThemeIcon(icon);
+    this.tooltip = tooltip;
+    this.contextValue = `userManagerFilter.${chipKind}`;
+    this.command = { command: clickCommand, title: tooltip };
+  }
+}
+
 type TreeItem = UserTreeItem | vscode.TreeItem;
 
 export class UserManagerTreeProvider implements vscode.TreeDataProvider<TreeItem> {
@@ -60,32 +112,64 @@ export class UserManagerTreeProvider implements vscode.TreeDataProvider<TreeItem
   readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
 
   private users: UserList[] = [];
-  private searchQuery = '';
+  private filterState: FilterState;
+  private loading = false;
+  private loadError: string | undefined;
+  private hasLoaded = false;
 
   constructor(
     private readonly apiService: ComputorApiService,
-    context: vscode.ExtensionContext
+    private readonly context: vscode.ExtensionContext
   ) {
-    void context;
+    this.filterState = this.loadFilterState();
+    void this.applyContextKeys();
   }
 
-  refresh(): void {
-    this.users = [];
-    this.onDidChangeTreeDataEmitter.fire(undefined);
-  }
+  // ----- Filter state -----
 
   getSearchQuery(): string {
-    return this.searchQuery;
+    return this.filterState.search;
   }
 
   setSearchQuery(query: string): void {
-    this.searchQuery = query;
-    this.onDidChangeTreeDataEmitter.fire(undefined);
+    this.filterState.search = query;
+    void this.persistFilterState();
+    this.fireChange();
   }
 
   clearSearch(): void {
-    this.searchQuery = '';
-    this.onDidChangeTreeDataEmitter.fire(undefined);
+    this.filterState.search = '';
+    void this.persistFilterState();
+    this.fireChange();
+  }
+
+  isShowingArchived(): boolean {
+    return this.filterState.showArchived;
+  }
+
+  toggleShowArchived(): void {
+    this.filterState.showArchived = !this.filterState.showArchived;
+    void this.persistFilterState();
+    this.fireChange();
+  }
+
+  isShowingService(): boolean {
+    return this.filterState.showService;
+  }
+
+  toggleShowService(): void {
+    this.filterState.showService = !this.filterState.showService;
+    void this.persistFilterState();
+    this.fireChange();
+  }
+
+  // ----- Tree data -----
+
+  refresh(): void {
+    this.users = [];
+    this.hasLoaded = false;
+    this.loadError = undefined;
+    this.fireChange();
   }
 
   getTreeItem(element: TreeItem): vscode.TreeItem {
@@ -97,80 +181,161 @@ export class UserManagerTreeProvider implements vscode.TreeDataProvider<TreeItem
       return [];
     }
 
-    try {
-      if (this.users.length === 0) {
-        await this.loadUsers();
-      }
+    if (!this.hasLoaded && !this.loading) {
+      await this.loadUsers();
+    }
 
-      const items: TreeItem[] = [];
+    if (this.loading) {
+      return [new UserManagerLoadingItem()];
+    }
 
-      if (this.searchQuery) {
-        const searchItem = new vscode.TreeItem(
-          `Search: "${this.searchQuery}"`,
-          vscode.TreeItemCollapsibleState.None
-        );
-        searchItem.iconPath = new vscode.ThemeIcon('search');
-        searchItem.contextValue = 'searchFilter';
-        searchItem.tooltip = `Current search filter: ${this.searchQuery}\nClick to clear`;
-        searchItem.command = {
-          command: 'computor.userManager.clearSearch',
-          title: 'Clear Search',
-          arguments: []
-        };
-        items.push(searchItem);
-      }
+    if (this.loadError) {
+      const errorItem = new vscode.TreeItem(this.loadError, vscode.TreeItemCollapsibleState.None);
+      errorItem.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground'));
+      errorItem.contextValue = 'userManagerError';
+      return [errorItem];
+    }
 
-      let filtered = this.users;
-      if (this.searchQuery) {
-        const query = this.searchQuery.toLowerCase();
-        filtered = filtered.filter(user =>
-          (user.family_name || '').toLowerCase().includes(query) ||
-          (user.given_name || '').toLowerCase().includes(query) ||
-          (user.email || '').toLowerCase().includes(query) ||
-          (user.username || '').toLowerCase().includes(query)
-        );
-      }
+    const filtered = this.applyFilters(this.users);
+    const items: TreeItem[] = [];
 
-      for (const user of filtered) {
-        items.push(new UserTreeItem(user, vscode.TreeItemCollapsibleState.None));
-      }
+    items.push(new UserManagerStatItem(filtered.length, this.users.length));
+    items.push(...this.buildActiveFilterChips());
 
+    if (filtered.length === 0) {
+      items.push(new UserManagerEmptyItem(
+        this.users.length === 0
+          ? 'No users.'
+          : 'No users match the current filters.'
+      ));
       return items;
-    } catch (error: any) {
-      vscode.window.showErrorMessage(`Failed to load users: ${error?.message || error}`);
-      return [];
     }
-  }
 
-  private async loadUsers(): Promise<void> {
-    try {
-      const allUsers = await this.apiService.getUsers({ force: true });
-
-      if (!allUsers || allUsers.length === 0) {
-        this.users = [];
-        return;
-      }
-
-      this.users = allUsers.sort((a, b) => {
-        const aFamily = (a.family_name || '').toLowerCase();
-        const bFamily = (b.family_name || '').toLowerCase();
-
-        if (aFamily !== bFamily) {
-          return aFamily.localeCompare(bFamily);
-        }
-
-        const aGiven = (a.given_name || '').toLowerCase();
-        const bGiven = (b.given_name || '').toLowerCase();
-
-        return aGiven.localeCompare(bGiven);
-      });
-    } catch (error) {
-      console.error('[UserManagerTreeProvider] Failed to load users:', error);
-      throw error;
+    for (const user of filtered) {
+      items.push(new UserTreeItem(user, vscode.TreeItemCollapsibleState.None));
     }
+
+    return items;
   }
 
   getUserById(userId: string): UserList | undefined {
     return this.users.find(u => u.id === userId);
+  }
+
+  // ----- Internals -----
+
+  private async loadUsers(): Promise<void> {
+    this.loading = true;
+    this.loadError = undefined;
+    this.fireChange();
+    try {
+      const all = await this.apiService.getUsers({ force: true });
+      this.users = (all || []).slice().sort((a, b) => {
+        const aFamily = (a.family_name || '').toLowerCase();
+        const bFamily = (b.family_name || '').toLowerCase();
+        if (aFamily !== bFamily) {
+          return aFamily.localeCompare(bFamily);
+        }
+        const aGiven = (a.given_name || '').toLowerCase();
+        const bGiven = (b.given_name || '').toLowerCase();
+        return aGiven.localeCompare(bGiven);
+      });
+      this.hasLoaded = true;
+    } catch (error: any) {
+      console.error('[UserManagerTreeProvider] Failed to load users:', error);
+      this.loadError = `Failed to load users: ${error?.message || error}`;
+      this.users = [];
+    } finally {
+      this.loading = false;
+      this.fireChange();
+    }
+  }
+
+  private applyFilters(users: UserList[]): UserList[] {
+    let result = users;
+    if (!this.filterState.showArchived) {
+      result = result.filter(u => !u.archived_at);
+    }
+    if (!this.filterState.showService) {
+      result = result.filter(u => !u.is_service);
+    }
+    if (this.filterState.search) {
+      const q = this.filterState.search.toLowerCase();
+      result = result.filter(u =>
+        (u.family_name || '').toLowerCase().includes(q) ||
+        (u.given_name || '').toLowerCase().includes(q) ||
+        (u.email || '').toLowerCase().includes(q) ||
+        (u.username || '').toLowerCase().includes(q)
+      );
+    }
+    return result;
+  }
+
+  private buildActiveFilterChips(): TreeItem[] {
+    const chips: TreeItem[] = [];
+
+    if (this.filterState.search) {
+      chips.push(new UserManagerFilterChipItem(
+        `Search: "${this.filterState.search}"`,
+        'search',
+        'Clear search filter',
+        'computor.userManager.clearSearch',
+        'search'
+      ));
+    }
+
+    if (this.filterState.showArchived) {
+      chips.push(new UserManagerFilterChipItem(
+        'Showing archived users',
+        'archive',
+        'Hide archived users',
+        'computor.userManager.toggleArchived',
+        'archived'
+      ));
+    }
+
+    if (this.filterState.showService) {
+      chips.push(new UserManagerFilterChipItem(
+        'Showing service accounts',
+        'robot',
+        'Hide service accounts',
+        'computor.userManager.toggleService',
+        'service'
+      ));
+    }
+
+    return chips;
+  }
+
+  private fireChange(): void {
+    this.onDidChangeTreeDataEmitter.fire(undefined);
+  }
+
+  private loadFilterState(): FilterState {
+    try {
+      const stored = this.context.globalState.get<FilterState>(STATE_KEY);
+      return {
+        search: typeof stored?.search === 'string' ? stored.search : '',
+        showArchived: stored?.showArchived === true,
+        showService: stored?.showService === true
+      };
+    } catch (err) {
+      console.warn('[UserManagerTreeProvider] Failed to load filter state:', err);
+      return { search: '', showArchived: false, showService: false };
+    }
+  }
+
+  private async persistFilterState(): Promise<void> {
+    try {
+      await this.context.globalState.update(STATE_KEY, this.filterState);
+    } catch (err) {
+      console.warn('[UserManagerTreeProvider] Failed to persist filter state:', err);
+    }
+    await this.applyContextKeys();
+  }
+
+  private async applyContextKeys(): Promise<void> {
+    await vscode.commands.executeCommand('setContext', 'computor.userManager.showArchived', this.filterState.showArchived);
+    await vscode.commands.executeCommand('setContext', 'computor.userManager.showService', this.filterState.showService);
   }
 }

--- a/src/ui/webviews/UserManagementWebviewProvider.ts
+++ b/src/ui/webviews/UserManagementWebviewProvider.ts
@@ -104,6 +104,12 @@ export class UserManagementWebviewProvider extends BaseWebviewProvider {
       case 'resetPassword':
         await this.handleResetPassword(message.data);
         break;
+      case 'archiveUser':
+        await this.handleArchiveToggle(true);
+        break;
+      case 'unarchiveUser':
+        await this.handleArchiveToggle(false);
+        break;
       default:
         break;
     }
@@ -171,6 +177,39 @@ export class UserManagementWebviewProvider extends BaseWebviewProvider {
       await this.refreshState({ force: true, notice: { type: 'success', message: 'Email updated successfully.' } });
     } catch (error: any) {
       this.handleError('Failed to update email', error);
+    }
+  }
+
+  private async handleArchiveToggle(archive: boolean): Promise<void> {
+    if (!this.currentUserId) {
+      return;
+    }
+
+    const action = archive ? 'archive' : 'unarchive';
+    const confirmation = await vscode.window.showWarningMessage(
+      archive
+        ? 'Archive this user? They will be hidden from default lists and unable to authenticate.'
+        : 'Unarchive this user? They will reappear in lists and regain access.',
+      { modal: true },
+      archive ? 'Archive' : 'Unarchive'
+    );
+
+    if (!confirmation) {
+      return;
+    }
+
+    try {
+      if (archive) {
+        await this.apiService.archiveUser(this.currentUserId);
+      } else {
+        await this.apiService.unarchiveUser(this.currentUserId);
+      }
+      await this.refreshState({
+        force: true,
+        notice: { type: 'success', message: `User ${action}d.` }
+      });
+    } catch (error: any) {
+      this.handleError(`Failed to ${action} user`, error);
     }
   }
 

--- a/src/ui/webviews/UserManagementWebviewProvider.ts
+++ b/src/ui/webviews/UserManagementWebviewProvider.ts
@@ -14,6 +14,7 @@ interface UserManagementViewState {
   profile?: ProfileGet | null;
   studentProfiles: StudentProfileGet[];
   canResetPassword: boolean;
+  isAdmin: boolean;
 }
 
 type NoticeType = 'info' | 'success' | 'warning' | 'error';
@@ -97,6 +98,9 @@ export class UserManagementWebviewProvider extends BaseWebviewProvider {
       case 'updateEmail':
         await this.handleUpdateEmail(message.data);
         break;
+      case 'updateIdentity':
+        await this.handleUpdateIdentity(message.data);
+        break;
       case 'resetPassword':
         await this.handleResetPassword(message.data);
         break;
@@ -106,7 +110,10 @@ export class UserManagementWebviewProvider extends BaseWebviewProvider {
   }
 
   private async loadState(userId: string, options?: { force?: boolean }): Promise<UserManagementViewState> {
-    const user = await this.apiService.getUserById(userId, options);
+    const [user, scopes] = await Promise.all([
+      this.apiService.getUserById(userId, options),
+      this.apiService.getUserScopes(options).catch(() => undefined)
+    ]);
 
     if (!user) {
       throw new Error(`User not found: ${userId}`);
@@ -116,7 +123,8 @@ export class UserManagementWebviewProvider extends BaseWebviewProvider {
       user: user,
       profile: user.profile ?? null,
       studentProfiles: user.student_profiles ?? [],
-      canResetPassword: true
+      canResetPassword: true,
+      isAdmin: scopes?.is_admin === true
     };
   }
 
@@ -163,6 +171,53 @@ export class UserManagementWebviewProvider extends BaseWebviewProvider {
       await this.refreshState({ force: true, notice: { type: 'success', message: 'Email updated successfully.' } });
     } catch (error: any) {
       this.handleError('Failed to update email', error);
+    }
+  }
+
+  private async handleUpdateIdentity(raw: any): Promise<void> {
+    if (!raw || typeof raw !== 'object' || !this.currentUserId) {
+      return;
+    }
+
+    // Server enforces admin-only on these fields. We pre-gate the form so
+    // non-admins never see editable inputs, but defend here too.
+    const scopes = await this.apiService.getUserScopes().catch(() => undefined);
+    if (!scopes?.is_admin) {
+      this.postNotice({ type: 'error', message: 'Only administrators can edit name and username.' });
+      return;
+    }
+
+    const updates: UserUpdate = {};
+    let touched = false;
+    if (typeof raw.given_name === 'string') {
+      const value = raw.given_name.trim();
+      updates.given_name = value || null;
+      touched = true;
+    }
+    if (typeof raw.family_name === 'string') {
+      const value = raw.family_name.trim();
+      updates.family_name = value || null;
+      touched = true;
+    }
+    if (typeof raw.username === 'string') {
+      const value = raw.username.trim();
+      if (!value) {
+        this.postNotice({ type: 'warning', message: 'Username cannot be empty.' });
+        return;
+      }
+      updates.username = value;
+      touched = true;
+    }
+
+    if (!touched) {
+      return;
+    }
+
+    try {
+      await this.apiService.updateUser(this.currentUserId, updates);
+      await this.refreshState({ force: true, notice: { type: 'success', message: 'Identity updated.' } });
+    } catch (error: any) {
+      this.handleError('Failed to update identity', error);
     }
   }
 

--- a/src/ui/webviews/UserManagementWebviewProvider.ts
+++ b/src/ui/webviews/UserManagementWebviewProvider.ts
@@ -8,6 +8,7 @@ import {
   ProfileGet,
   StudentProfileGet
 } from '../../types/generated';
+import type { RoleList } from '../../types/generated/roles';
 
 interface UserManagementViewState {
   user?: UserGet;
@@ -15,6 +16,7 @@ interface UserManagementViewState {
   studentProfiles: StudentProfileGet[];
   canResetPassword: boolean;
   isAdmin: boolean;
+  availableRoles: RoleList[];
 }
 
 type NoticeType = 'info' | 'success' | 'warning' | 'error';
@@ -110,15 +112,22 @@ export class UserManagementWebviewProvider extends BaseWebviewProvider {
       case 'unarchiveUser':
         await this.handleArchiveToggle(false);
         break;
+      case 'assignRole':
+        await this.handleAssignRole(message.data);
+        break;
+      case 'revokeRole':
+        await this.handleRevokeRole(message.data);
+        break;
       default:
         break;
     }
   }
 
   private async loadState(userId: string, options?: { force?: boolean }): Promise<UserManagementViewState> {
-    const [user, scopes] = await Promise.all([
+    const [user, scopes, roles] = await Promise.all([
       this.apiService.getUserById(userId, options),
-      this.apiService.getUserScopes(options).catch(() => undefined)
+      this.apiService.getUserScopes(options).catch(() => undefined),
+      this.apiService.listRoles().catch(() => [])
     ]);
 
     if (!user) {
@@ -130,7 +139,8 @@ export class UserManagementWebviewProvider extends BaseWebviewProvider {
       profile: user.profile ?? null,
       studentProfiles: user.student_profiles ?? [],
       canResetPassword: true,
-      isAdmin: scopes?.is_admin === true
+      isAdmin: scopes?.is_admin === true,
+      availableRoles: roles ?? []
     };
   }
 
@@ -177,6 +187,46 @@ export class UserManagementWebviewProvider extends BaseWebviewProvider {
       await this.refreshState({ force: true, notice: { type: 'success', message: 'Email updated successfully.' } });
     } catch (error: any) {
       this.handleError('Failed to update email', error);
+    }
+  }
+
+  private async handleAssignRole(raw: any): Promise<void> {
+    if (!raw || typeof raw !== 'object' || !this.currentUserId) {
+      return;
+    }
+    const roleId = typeof raw.role_id === 'string' ? raw.role_id.trim() : '';
+    if (!roleId) {
+      return;
+    }
+    try {
+      await this.apiService.assignUserRole(this.currentUserId, roleId);
+      await this.refreshState({ force: true, notice: { type: 'success', message: `Role "${roleId}" assigned.` } });
+    } catch (error: any) {
+      this.handleError(`Failed to assign role "${roleId}"`, error);
+    }
+  }
+
+  private async handleRevokeRole(raw: any): Promise<void> {
+    if (!raw || typeof raw !== 'object' || !this.currentUserId) {
+      return;
+    }
+    const roleId = typeof raw.role_id === 'string' ? raw.role_id.trim() : '';
+    if (!roleId) {
+      return;
+    }
+    const confirmation = await vscode.window.showWarningMessage(
+      `Remove role "${roleId}" from this user?`,
+      { modal: true },
+      'Remove'
+    );
+    if (confirmation !== 'Remove') {
+      return;
+    }
+    try {
+      await this.apiService.revokeUserRole(this.currentUserId, roleId);
+      await this.refreshState({ force: true, notice: { type: 'success', message: `Role "${roleId}" removed.` } });
+    } catch (error: any) {
+      this.handleError(`Failed to remove role "${roleId}"`, error);
     }
   }
 

--- a/webview-ui/user-management.css
+++ b/webview-ui/user-management.css
@@ -127,15 +127,48 @@
 }
 
 .role-badge {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   background: var(--vscode-badge-background);
   color: var(--vscode-badge-foreground);
-  padding: 2px 8px;
+  padding: 2px 4px 2px 8px;
   border-radius: 12px;
   font-size: 11px;
   font-weight: 600;
   margin-right: 6px;
   margin-bottom: 4px;
+}
+
+.role-badge-label {
+  line-height: 1;
+}
+
+.role-badge-remove {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 4px;
+  border-radius: 8px;
+  opacity: 0.7;
+}
+
+.role-badge-remove:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.role-add-form {
+  margin-top: 12px;
+}
+
+.role-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .form-field {

--- a/webview-ui/user-management.js
+++ b/webview-ui/user-management.js
@@ -6,6 +6,7 @@
     profile: null,
     studentProfiles: [],
     canResetPassword: false,
+    isAdmin: false,
     ...(window.__INITIAL_STATE__ || {})
   };
 
@@ -106,8 +107,29 @@
       <section class="user-section" aria-labelledby="section-identity">
         <div>
           <h2 id="section-identity">Identity</h2>
-          <p class="section-description">Core account fields. Name and username edits are admin-only.</p>
+          <p class="section-description">Core account fields.${state.isAdmin ? '' : ' Name and username edits are admin-only.'}</p>
         </div>
+        ${state.isAdmin ? `
+        <form id="identity-form">
+          <div class="info-grid">
+            <div class="form-field">
+              <label for="user-given-name">Given Name</label>
+              <input id="user-given-name" name="given_name" type="text" value="${escapeHtml(toInputValue(user.given_name))}" autocomplete="given-name">
+            </div>
+            <div class="form-field">
+              <label for="user-family-name">Family Name</label>
+              <input id="user-family-name" name="family_name" type="text" value="${escapeHtml(toInputValue(user.family_name))}" autocomplete="family-name">
+            </div>
+            <div class="form-field">
+              <label for="user-username">Username</label>
+              <input id="user-username" name="username" type="text" value="${escapeHtml(toInputValue(user.username))}" autocomplete="username">
+            </div>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="primary">Save Identity</button>
+          </div>
+        </form>
+        ` : `
         <div class="info-grid">
           <div class="info-field">
             <label>Given Name</label>
@@ -122,6 +144,7 @@
             <div class="info-value">${escapeHtml(user.username || 'Not set')}</div>
           </div>
         </div>
+        `}
         <form id="email-form">
           <div class="form-field">
             <label for="user-email">Email Address</label>
@@ -233,10 +256,34 @@
       emailForm.addEventListener('submit', handleEmailUpdate);
     }
 
+    const identityForm = document.getElementById('identity-form');
+    if (identityForm) {
+      identityForm.addEventListener('submit', handleIdentityUpdate);
+    }
+
     const passwordResetForm = document.getElementById('password-reset-form');
     if (passwordResetForm) {
       passwordResetForm.addEventListener('submit', handlePasswordReset);
     }
+  }
+
+  function handleIdentityUpdate(event) {
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    const givenName = formData.get('given_name');
+    const familyName = formData.get('family_name');
+    const username = formData.get('username');
+
+    if (typeof username === 'string' && !username.trim()) {
+      showNotice('warning', 'Username cannot be empty.');
+      return;
+    }
+
+    post('updateIdentity', {
+      given_name: typeof givenName === 'string' ? givenName : undefined,
+      family_name: typeof familyName === 'string' ? familyName : undefined,
+      username: typeof username === 'string' ? username : undefined
+    });
   }
 
   function handleEmailUpdate(event) {

--- a/webview-ui/user-management.js
+++ b/webview-ui/user-management.js
@@ -103,16 +103,12 @@
       ${archivedBanner}
       ${serviceAccountBanner}
 
-      <section class="user-section">
+      <section class="user-section" aria-labelledby="section-identity">
         <div>
-          <h2>User Information</h2>
-          <p class="section-description">Core user account details (read-only except email).</p>
+          <h2 id="section-identity">Identity</h2>
+          <p class="section-description">Core account fields. Name and username edits are admin-only.</p>
         </div>
         <div class="info-grid">
-          <div class="info-field">
-            <label>User ID</label>
-            <div class="info-value">${escapeHtml(user.id)}</div>
-          </div>
           <div class="info-field">
             <label>Given Name</label>
             <div class="info-value">${escapeHtml(user.given_name || 'Not set')}</div>
@@ -125,25 +121,6 @@
             <label>Username</label>
             <div class="info-value">${escapeHtml(user.username || 'Not set')}</div>
           </div>
-          <div class="info-field">
-            <label>Created</label>
-            <div class="info-value">${formatDate(user.created_at)}</div>
-          </div>
-          <div class="info-field">
-            <label>Updated</label>
-            <div class="info-value">${formatDate(user.updated_at)}</div>
-          </div>
-          <div class="info-field full-width">
-            <label>Roles</label>
-            <div class="info-value">${userRolesHtml}</div>
-          </div>
-        </div>
-      </section>
-
-      <section class="user-section">
-        <div>
-          <h2>Email Address</h2>
-          <p class="section-description">Update the user's email address.</p>
         </div>
         <form id="email-form">
           <div class="form-field">
@@ -156,9 +133,19 @@
         </form>
       </section>
 
-      <section class="user-section">
+      <section class="user-section" aria-labelledby="section-roles">
         <div>
-          <h2>Profile</h2>
+          <h2 id="section-roles">Roles</h2>
+          <p class="section-description">System roles assigned to this user.</p>
+        </div>
+        <div class="info-field full-width">
+          <div class="info-value">${userRolesHtml}</div>
+        </div>
+      </section>
+
+      <section class="user-section" aria-labelledby="section-profile">
+        <div>
+          <h2 id="section-profile">Profile</h2>
           <p class="section-description">User profile information (read-only).</p>
         </div>
         <div class="info-grid">
@@ -183,19 +170,44 @@
             <div class="info-value">${escapeHtml(profile.bio || 'Not set')}</div>
           </div>
         </div>
-      </section>
-
-      <section class="user-section">
+        ${studentProfiles.length > 0 ? `
         <div>
-          <h2>Student Profiles</h2>
-          <p class="section-description">Student profiles associated with this user (read-only).</p>
+          <h3>Student Profiles</h3>
+          ${studentProfilesHtml}
         </div>
-        ${studentProfilesHtml}
+        ` : ''}
       </section>
 
-      <section class="user-section danger-zone">
+      <section class="user-section" aria-labelledby="section-audit">
         <div>
-          <h2>Password Reset</h2>
+          <h2 id="section-audit">Audit</h2>
+          <p class="section-description">Identifiers and timestamps.</p>
+        </div>
+        <div class="info-grid">
+          <div class="info-field">
+            <label>User ID</label>
+            <div class="info-value">${escapeHtml(user.id)}</div>
+          </div>
+          <div class="info-field">
+            <label>Created</label>
+            <div class="info-value">${formatDate(user.created_at)}</div>
+          </div>
+          <div class="info-field">
+            <label>Updated</label>
+            <div class="info-value">${formatDate(user.updated_at)}</div>
+          </div>
+          ${user.archived_at ? `
+          <div class="info-field">
+            <label>Archived</label>
+            <div class="info-value">${formatDate(user.archived_at)}</div>
+          </div>
+          ` : ''}
+        </div>
+      </section>
+
+      <section class="user-section danger-zone" aria-labelledby="section-danger">
+        <div>
+          <h2 id="section-danger">Danger Zone</h2>
           <p class="section-description">Reset this user's password. This will set their password to NULL and they will need to set a new password on their next login.</p>
         </div>
         <form id="password-reset-form">

--- a/webview-ui/user-management.js
+++ b/webview-ui/user-management.js
@@ -7,6 +7,7 @@
     studentProfiles: [],
     canResetPassword: false,
     isAdmin: false,
+    availableRoles: [],
     ...(window.__INITIAL_STATE__ || {})
   };
 
@@ -57,9 +58,21 @@
     const profile = state.profile || {};
     const studentProfiles = Array.isArray(state.studentProfiles) ? state.studentProfiles : [];
 
-    const userRolesHtml = Array.isArray(user.user_roles) && user.user_roles.length > 0
-      ? user.user_roles.map(ur => `<span class="role-badge">${escapeHtml(ur.role_id)}</span>`).join('')
+    const assignedRoleIds = new Set((Array.isArray(user.user_roles) ? user.user_roles : []).map(ur => ur.role_id));
+    const userRolesHtml = assignedRoleIds.size > 0
+      ? Array.from(assignedRoleIds).map(roleId => `
+          <span class="role-badge">
+            <span class="role-badge-label">${escapeHtml(roleId)}</span>
+            <button type="button" class="role-badge-remove" data-role-remove="${escapeHtml(roleId)}" title="Remove role">×</button>
+          </span>
+        `).join('')
       : '<span class="empty-value">No roles assigned</span>';
+
+    const availableRoles = Array.isArray(state.availableRoles) ? state.availableRoles : [];
+    const assignableRoles = availableRoles.filter(r => !assignedRoleIds.has(r.id));
+    const addRoleOptionsHtml = assignableRoles.length > 0
+      ? assignableRoles.map(r => `<option value="${escapeHtml(r.id)}">${escapeHtml(r.title || r.id)}</option>`).join('')
+      : '';
 
     const studentProfilesHtml = studentProfiles.length > 0
       ? studentProfiles.map(sp => {
@@ -159,11 +172,25 @@
       <section class="user-section" aria-labelledby="section-roles">
         <div>
           <h2 id="section-roles">Roles</h2>
-          <p class="section-description">System roles assigned to this user.</p>
+          <p class="section-description">System roles assigned to this user. Granting <code>_admin</code> requires admin privileges and is enforced server-side.</p>
         </div>
         <div class="info-field full-width">
-          <div class="info-value">${userRolesHtml}</div>
+          <div class="info-value role-badges">${userRolesHtml}</div>
         </div>
+        ${assignableRoles.length > 0 ? `
+        <form id="add-role-form" class="role-add-form">
+          <div class="form-field">
+            <label for="role-add-select">Add a role</label>
+            <select id="role-add-select" name="role_id" required>
+              <option value="" disabled selected>Choose a role…</option>
+              ${addRoleOptionsHtml}
+            </select>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="primary">Assign Role</button>
+          </div>
+        </form>
+        ` : '<p class="field-hint">All available roles are already assigned.</p>'}
       </section>
 
       <section class="user-section" aria-labelledby="section-profile">
@@ -284,6 +311,29 @@
       archiveBtn.addEventListener('click', () => {
         const isArchived = !!(state.user && state.user.archived_at);
         post(isArchived ? 'unarchiveUser' : 'archiveUser');
+      });
+    }
+
+    document.querySelectorAll('[data-role-remove]').forEach((el) => {
+      el.addEventListener('click', (event) => {
+        event.preventDefault();
+        const target = event.currentTarget;
+        const roleId = target instanceof HTMLElement ? target.getAttribute('data-role-remove') : null;
+        if (roleId) {
+          post('revokeRole', { role_id: roleId });
+        }
+      });
+    });
+
+    const addRoleForm = document.getElementById('add-role-form');
+    if (addRoleForm) {
+      addRoleForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const select = document.getElementById('role-add-select');
+        const value = select && 'value' in select ? select.value : '';
+        if (value) {
+          post('assignRole', { role_id: value });
+        }
       });
     }
   }

--- a/webview-ui/user-management.js
+++ b/webview-ui/user-management.js
@@ -231,13 +231,26 @@
       <section class="user-section danger-zone" aria-labelledby="section-danger">
         <div>
           <h2 id="section-danger">Danger Zone</h2>
-          <p class="section-description">Reset this user's password. This will set their password to NULL and they will need to set a new password on their next login.</p>
+          <p class="section-description">Destructive actions on this account.</p>
         </div>
+
+        <div class="form-field">
+          <label>Archive Status</label>
+          <p class="field-hint">${user.archived_at
+            ? 'This user is archived. Unarchiving restores access.'
+            : 'Archiving hides the user from default lists and blocks authentication.'}</p>
+          <div class="form-actions">
+            <button type="button" id="archive-toggle-btn" class="${user.archived_at ? 'primary' : 'danger'}">
+              ${user.archived_at ? 'Unarchive User' : 'Archive User'}
+            </button>
+          </div>
+        </div>
+
         <form id="password-reset-form">
           <div class="form-field">
-            <label for="manager-password">Your Password (Required)</label>
+            <label for="manager-password">Reset Password — Your Password (Required)</label>
             <input id="manager-password" name="managerPassword" type="password" placeholder="Enter your password to confirm" autocomplete="current-password">
-            <p class="field-hint">Your password is required to perform this critical action.</p>
+            <p class="field-hint">Resets this user's password to NULL — they must set a new password on next login.</p>
           </div>
           <div class="form-actions">
             <button type="submit" class="danger">Reset User Password</button>
@@ -264,6 +277,14 @@
     const passwordResetForm = document.getElementById('password-reset-form');
     if (passwordResetForm) {
       passwordResetForm.addEventListener('submit', handlePasswordReset);
+    }
+
+    const archiveBtn = document.getElementById('archive-toggle-btn');
+    if (archiveBtn) {
+      archiveBtn.addEventListener('click', () => {
+        const isArchived = !!(state.user && state.user.archived_at);
+        post(isArchived ? 'unarchiveUser' : 'archiveUser');
+      });
     }
   }
 


### PR DESCRIPTION
Closes #81 (partial — scoped role editor deferred to follow-up).

## Summary

7 commits implementing the user management refactor:

- `7ce7bdf` human icon (`$(account)`) on the activity bar
- `a2a1a51` persistent filter chips, robot icon for service accounts, loading state
- `ac81109` webview split into Identity / Roles / Profile / Audit / Danger sections
- `db53fc9` admin-gated identity edit form (given_name, family_name, username)
- `f3c0639` archive / unarchive controls
- `a0361f6` "+ New user" flow via multi-step input
- `5e61648` global role editor backed by `/user-roles`

## Behaviour

**Tree (User Manager view)**
- Activity-bar icon: human (`$(account)`)
- Service accounts render with `$(robot)` icon
- Filter state persists to `globalState`: search, show-archived (default off), show-service (default off)
- Active filters render as chips at the top with click-to-clear
- Loading + error states
- Title-bar actions: New User, Search, Toggle Archived, Toggle Service, Refresh

**Webview**
- **Identity** — given_name / family_name / username editable for admins only (server-enforced); email + password reset available to all `user_manager` view holders
- **Roles** — list of assigned roles as removable chips; "Add role" picker fetches `/roles` and excludes already-assigned. Granting `_admin` returns the backend's permission error inline
- **Profile** — read-only profile + student profiles
- **Audit** — user id, created/updated/archived timestamps
- **Danger Zone** — archive/unarchive button + password reset

## Deferred to follow-up

Scoped role editing (org / course-family `_owner`/`_manager`/`_developer`) is a separate concern with its own backend endpoints (`/organization-members`, `/course-family-members`). It belongs on the lecturer-tree Organization / Course Family items, not on the user webview, so it gets its own branch + issue.

## Test plan

- [ ] Activity-bar icon is human, service accounts show robot icon
- [ ] Toggle archived / service from title bar; chips appear, default OFF persists across reloads
- [ ] Search input persists across reloads
- [ ] As admin: identity form shows editable name fields + Save button
- [ ] As non-admin user_manager: identity form is read-only
- [ ] Email update + password reset work for any user_manager
- [ ] Archive / unarchive flips banner + tree filtering
- [ ] "+ New user" multi-step input creates a user; webview opens on the new user
- [ ] Roles section: remove chip → confirms → role removed; Add picker → assign → role appears
- [ ] As non-admin: assigning `_admin` shows the backend's "forbidden" error inline