### PR TITLE
Per-scope membership management for organizations and course families

### DIFF
--- a/package.json
+++ b/package.json
@@ -673,6 +673,18 @@
         "category": "Computor Lecturer"
       },
       {
+        "command": "computor.lecturer.manageOrganizationMembers",
+        "title": "Manage Members",
+        "icon": "$(organization)",
+        "category": "Computor Lecturer"
+      },
+      {
+        "command": "computor.lecturer.manageCourseFamilyMembers",
+        "title": "Manage Members",
+        "icon": "$(organization)",
+        "category": "Computor Lecturer"
+      },
+      {
         "command": "computor.lecturer.openAssignmentFolder",
         "title": "Open Assignment Folder",
         "icon": "$(folder-opened)",
@@ -1284,9 +1296,19 @@
           "group": "2_discussion@1"
         },
         {
+          "command": "computor.lecturer.manageOrganizationMembers",
+          "when": "view == computor.lecturer.courses && viewItem == organization",
+          "group": "2_discussion@2"
+        },
+        {
           "command": "computor.lecturer.showMessages",
           "when": "view == computor.lecturer.courses && viewItem == courseFamily",
           "group": "2_discussion@1"
+        },
+        {
+          "command": "computor.lecturer.manageCourseFamilyMembers",
+          "when": "view == computor.lecturer.courses && viewItem == courseFamily",
+          "group": "2_discussion@2"
         },
         {
           "command": "computor.lecturer.showMessages",

--- a/package.json
+++ b/package.json
@@ -1297,7 +1297,7 @@
         },
         {
           "command": "computor.lecturer.manageOrganizationMembers",
-          "when": "view == computor.lecturer.courses && viewItem == organization && computor.lecturer.canManageScopeMembership",
+          "when": "view == computor.lecturer.courses && viewItem == organization && computor.lecturer.canManageOrgMembers",
           "group": "2_discussion@2"
         },
         {
@@ -1307,7 +1307,7 @@
         },
         {
           "command": "computor.lecturer.manageCourseFamilyMembers",
-          "when": "view == computor.lecturer.courses && viewItem == courseFamily && computor.lecturer.canManageScopeMembership",
+          "when": "view == computor.lecturer.courses && viewItem == courseFamily && computor.lecturer.canManageFamilyMembers",
           "group": "2_discussion@2"
         },
         {

--- a/package.json
+++ b/package.json
@@ -1297,7 +1297,7 @@
         },
         {
           "command": "computor.lecturer.manageOrganizationMembers",
-          "when": "view == computor.lecturer.courses && viewItem == organization",
+          "when": "view == computor.lecturer.courses && viewItem == organization && computor.lecturer.canManageScopeMembership",
           "group": "2_discussion@2"
         },
         {
@@ -1307,7 +1307,7 @@
         },
         {
           "command": "computor.lecturer.manageCourseFamilyMembers",
-          "when": "view == computor.lecturer.courses && viewItem == courseFamily",
+          "when": "view == computor.lecturer.courses && viewItem == courseFamily && computor.lecturer.canManageScopeMembership",
           "group": "2_discussion@2"
         },
         {

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -2501,22 +2501,38 @@ export class LecturerCommands {
     );
   }
 
-  // Sets the `computor.lecturer.canManageScopeMembership` context key so the
-  // org/course-family "Manage Members" entries only appear for users who hold
-  // an `_owner` or `_manager` claim somewhere (or are admin). Per-scope
-  // precision is enforced inside the webview itself.
+  // Sets the per-scope-kind "Manage Members" context keys. The menu shows when:
+  //   - the user is admin, OR
+  //   - holds the global system role for that scope kind
+  //     (`_organization_manager` / `_course_family_manager`), OR
+  //   - holds an `_owner`/`_manager` claim on at least one scope of that kind.
+  // Per-scope precision is enforced inside the webview and on the backend.
   private async applyScopeMembershipContextKey(): Promise<void> {
     try {
-      const scopes = await this.apiService.getUserScopes();
-      const canManage = !!scopes && (
-        scopes.is_admin === true ||
-        hasManagerClaim(scopes.organization) ||
-        hasManagerClaim(scopes.course_family)
+      const [scopes, currentUser] = await Promise.all([
+        this.apiService.getUserScopes(),
+        this.apiService.getUserAccount().catch(() => undefined)
+      ]);
+      const isAdmin = scopes?.is_admin === true;
+      const globalRoles = new Set(
+        (currentUser?.user_roles ?? [])
+          .map(r => r?.role_id)
+          .filter((id): id is string => typeof id === 'string')
       );
-      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageScopeMembership', canManage);
+
+      const canManageOrg = isAdmin
+        || globalRoles.has('_organization_manager')
+        || hasManagerClaim(scopes?.organization);
+      const canManageFamily = isAdmin
+        || globalRoles.has('_course_family_manager')
+        || hasManagerClaim(scopes?.course_family);
+
+      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageOrgMembers', canManageOrg);
+      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageFamilyMembers', canManageFamily);
     } catch (err) {
-      console.warn('[LecturerCommands] Failed to compute scope-membership context key:', err);
-      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageScopeMembership', false);
+      console.warn('[LecturerCommands] Failed to compute scope-membership context keys:', err);
+      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageOrgMembers', false);
+      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageFamilyMembers', false);
     }
   }
 }

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -32,6 +32,7 @@ import type { CourseDeploymentList } from '../types/generated';
 import { LecturerRepositoryManager } from '../services/LecturerRepositoryManager';
 import { canPostToCourseFamily, canPostToOrganization } from '../services/MessagePermissions';
 import { runLockedWithProgress } from '../utils/progressLock';
+import { canManageAnyCourseFamilyMembers, canManageAnyOrganizationMembers } from '../services/ScopePermissions';
 import type { MessagesInputPanelProvider } from '../ui/panels/MessagesInputPanel';
 import type { WebSocketService } from '../services/WebSocketService';
 import { commandRegistrar } from './commandHelpers';
@@ -2501,48 +2502,26 @@ export class LecturerCommands {
     );
   }
 
-  // Sets the per-scope-kind "Manage Members" context keys. The menu shows when:
-  //   - the user is admin, OR
-  //   - holds the global system role for that scope kind
-  //     (`_organization_manager` / `_course_family_manager`), OR
-  //   - holds an `_owner`/`_manager` claim on at least one scope of that kind.
-  // Per-scope precision is enforced inside the webview and on the backend.
+  // Sets the per-scope-kind "Manage Members" context keys. See
+  // `services/ScopePermissions.ts` for the rules.
   private async applyScopeMembershipContextKey(): Promise<void> {
     try {
       const [scopes, currentUser] = await Promise.all([
         this.apiService.getUserScopes(),
         this.apiService.getUserAccount().catch(() => undefined)
       ]);
-      const isAdmin = scopes?.is_admin === true;
       const globalRoles = new Set(
         (currentUser?.user_roles ?? [])
           .map(r => r?.role_id)
           .filter((id): id is string => typeof id === 'string')
       );
-
-      const canManageOrg = isAdmin
-        || globalRoles.has('_organization_manager')
-        || hasManagerClaim(scopes?.organization);
-      const canManageFamily = isAdmin
-        || globalRoles.has('_course_family_manager')
-        || hasManagerClaim(scopes?.course_family);
-
-      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageOrgMembers', canManageOrg);
-      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageFamilyMembers', canManageFamily);
+      const ctx = { scopes, globalRoles };
+      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageOrgMembers', canManageAnyOrganizationMembers(ctx));
+      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageFamilyMembers', canManageAnyCourseFamilyMembers(ctx));
     } catch (err) {
       console.warn('[LecturerCommands] Failed to compute scope-membership context keys:', err);
       await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageOrgMembers', false);
       await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageFamilyMembers', false);
     }
   }
-}
-
-function hasManagerClaim(map: Record<string, string[]> | undefined): boolean {
-  if (!map) { return false; }
-  for (const roles of Object.values(map)) {
-    if (Array.isArray(roles) && roles.some(r => r === '_owner' || r === '_manager')) {
-      return true;
-    }
-  }
-  return false;
 }

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -100,6 +100,7 @@ export class LecturerCommands {
   registerCommands(): void {
 
     const register = commandRegistrar(this.context);
+    void this.applyScopeMembershipContextKey();
     register('computor.lecturer.refresh', async () => {
       this.apiService.clearCourseCache('');
       this.treeDataProvider.refresh();
@@ -2499,4 +2500,33 @@ export class LecturerCommands {
       }
     );
   }
+
+  // Sets the `computor.lecturer.canManageScopeMembership` context key so the
+  // org/course-family "Manage Members" entries only appear for users who hold
+  // an `_owner` or `_manager` claim somewhere (or are admin). Per-scope
+  // precision is enforced inside the webview itself.
+  private async applyScopeMembershipContextKey(): Promise<void> {
+    try {
+      const scopes = await this.apiService.getUserScopes();
+      const canManage = !!scopes && (
+        scopes.is_admin === true ||
+        hasManagerClaim(scopes.organization) ||
+        hasManagerClaim(scopes.course_family)
+      );
+      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageScopeMembership', canManage);
+    } catch (err) {
+      console.warn('[LecturerCommands] Failed to compute scope-membership context key:', err);
+      await vscode.commands.executeCommand('setContext', 'computor.lecturer.canManageScopeMembership', false);
+    }
+  }
+}
+
+function hasManagerClaim(map: Record<string, string[]> | undefined): boolean {
+  if (!map) { return false; }
+  for (const roles of Object.values(map)) {
+    if (Array.isArray(roles) && roles.some(r => r === '_owner' || r === '_manager')) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -20,6 +20,7 @@ import { DeploymentInfoWebviewProvider } from '../ui/webviews/DeploymentInfoWebv
 import { ReleaseValidationWebviewProvider } from '../ui/webviews/ReleaseValidationWebviewProvider';
 import { CourseProgressOverviewWebviewProvider } from '../ui/webviews/CourseProgressOverviewWebviewProvider';
 import { CourseMemberProgressWebviewProvider } from '../ui/webviews/CourseMemberProgressWebviewProvider';
+import { ScopeMembershipWebviewProvider } from '../ui/webviews/ScopeMembershipWebviewProvider';
 import { hasExampleAssigned, getExampleVersionId, classifyReleaseContents } from '../utils/deploymentHelpers';
 import type { ReleaseCandidate } from '../utils/deploymentHelpers';
 import { HttpError } from '../http/errors/HttpError';
@@ -58,6 +59,7 @@ export class LecturerCommands {
   private releaseValidationWebviewProvider: ReleaseValidationWebviewProvider;
   private courseProgressOverviewWebviewProvider: CourseProgressOverviewWebviewProvider;
   private courseMemberProgressWebviewProvider: CourseMemberProgressWebviewProvider;
+  private scopeMembershipWebviewProvider: ScopeMembershipWebviewProvider;
 
   constructor(
     private context: vscode.ExtensionContext,
@@ -91,6 +93,7 @@ export class LecturerCommands {
     this.releaseValidationWebviewProvider = new ReleaseValidationWebviewProvider(context, this.apiService);
     this.courseProgressOverviewWebviewProvider = new CourseProgressOverviewWebviewProvider(context, this.apiService);
     this.courseMemberProgressWebviewProvider = new CourseMemberProgressWebviewProvider(context, this.apiService);
+    this.scopeMembershipWebviewProvider = new ScopeMembershipWebviewProvider(context, this.apiService);
     this.courseGroupCommands = new CourseGroupCommands(this.apiService, this.treeDataProvider);
   }
 
@@ -144,6 +147,23 @@ export class LecturerCommands {
 
     register('computor.lecturer.showMessages', async (item: OrganizationTreeItem | CourseFamilyTreeItem | CourseTreeItem | CourseGroupTreeItem | CourseContentTreeItem) => {
       await this.showMessages(item);
+    });
+
+    register('computor.lecturer.manageOrganizationMembers', async (item: OrganizationTreeItem) => {
+      await this.scopeMembershipWebviewProvider.open({
+        kind: 'organization',
+        scopeId: item.organization.id,
+        scopeTitle: item.organization.title || item.organization.path
+      });
+    });
+
+    register('computor.lecturer.manageCourseFamilyMembers', async (item: CourseFamilyTreeItem) => {
+      await this.scopeMembershipWebviewProvider.open({
+        kind: 'course_family',
+        scopeId: item.courseFamily.id,
+        scopeTitle: item.courseFamily.title || item.courseFamily.path,
+        scopeSubtitle: item.organization.title || item.organization.path
+      });
     });
 
     register('computor.lecturer.showCourseMemberComments', async (item: CourseMemberTreeItem) => {

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -2207,6 +2207,160 @@ export class ComputorApiService {
     }
   }
 
+  // ----- Organization members & roles -----
+
+  async listOrganizationRoles(): Promise<import('../types/generated/organizations').OrganizationRoleList[]> {
+    try {
+      const result = await this.cachedRequest({
+        cacheKey: 'organizationRoles',
+        tier: 'warm',
+        fetch: async () => {
+          const client = await this.getHttpClient();
+          return (await client.get<import('../types/generated/organizations').OrganizationRoleList[]>('/organization-roles')).data;
+        },
+        retry: { maxRetries: 2 }
+      });
+      return result || [];
+    } catch (error) {
+      console.error('[listOrganizationRoles] Failed:', error);
+      throw error;
+    }
+  }
+
+  async listOrganizationMembers(organizationId: string): Promise<import('../types/generated/organizations').OrganizationMemberList[]> {
+    try {
+      const client = await this.getHttpClient();
+      const response = await client.get<import('../types/generated/organizations').OrganizationMemberList[]>(
+        '/organization-members',
+        { organization_id: organizationId, limit: 10000 }
+      );
+      return response.data || [];
+    } catch (error) {
+      console.error(`[listOrganizationMembers] Failed for ${organizationId}:`, error);
+      throw error;
+    }
+  }
+
+  async createOrganizationMember(
+    payload: import('../types/generated/organizations').OrganizationMemberCreate
+  ): Promise<import('../types/generated/organizations').OrganizationMemberGet> {
+    try {
+      const client = await this.getHttpClient();
+      const response = await client.post<import('../types/generated/organizations').OrganizationMemberGet>(
+        '/organization-members',
+        payload
+      );
+      return response.data;
+    } catch (error) {
+      console.error('[createOrganizationMember] Failed:', error);
+      throw error;
+    }
+  }
+
+  async updateOrganizationMember(
+    memberId: string,
+    updates: import('../types/generated/organizations').OrganizationMemberUpdate
+  ): Promise<import('../types/generated/organizations').OrganizationMemberGet> {
+    try {
+      const client = await this.getHttpClient();
+      const response = await client.patch<import('../types/generated/organizations').OrganizationMemberGet>(
+        `/organization-members/${memberId}`,
+        updates
+      );
+      return response.data;
+    } catch (error) {
+      console.error(`[updateOrganizationMember] Failed for ${memberId}:`, error);
+      throw error;
+    }
+  }
+
+  async deleteOrganizationMember(memberId: string): Promise<void> {
+    try {
+      const client = await this.getHttpClient();
+      await client.delete(`/organization-members/${memberId}`);
+    } catch (error) {
+      console.error(`[deleteOrganizationMember] Failed for ${memberId}:`, error);
+      throw error;
+    }
+  }
+
+  // ----- Course-family members & roles -----
+
+  async listCourseFamilyRoles(): Promise<import('../types/generated/courses').CourseFamilyRoleList[]> {
+    try {
+      const result = await this.cachedRequest({
+        cacheKey: 'courseFamilyRoles',
+        tier: 'warm',
+        fetch: async () => {
+          const client = await this.getHttpClient();
+          return (await client.get<import('../types/generated/courses').CourseFamilyRoleList[]>('/course-family-roles')).data;
+        },
+        retry: { maxRetries: 2 }
+      });
+      return result || [];
+    } catch (error) {
+      console.error('[listCourseFamilyRoles] Failed:', error);
+      throw error;
+    }
+  }
+
+  async listCourseFamilyMembers(courseFamilyId: string): Promise<import('../types/generated/courses').CourseFamilyMemberList[]> {
+    try {
+      const client = await this.getHttpClient();
+      const response = await client.get<import('../types/generated/courses').CourseFamilyMemberList[]>(
+        '/course-family-members',
+        { course_family_id: courseFamilyId, limit: 10000 }
+      );
+      return response.data || [];
+    } catch (error) {
+      console.error(`[listCourseFamilyMembers] Failed for ${courseFamilyId}:`, error);
+      throw error;
+    }
+  }
+
+  async createCourseFamilyMember(
+    payload: import('../types/generated/courses').CourseFamilyMemberCreate
+  ): Promise<import('../types/generated/courses').CourseFamilyMemberGet> {
+    try {
+      const client = await this.getHttpClient();
+      const response = await client.post<import('../types/generated/courses').CourseFamilyMemberGet>(
+        '/course-family-members',
+        payload
+      );
+      return response.data;
+    } catch (error) {
+      console.error('[createCourseFamilyMember] Failed:', error);
+      throw error;
+    }
+  }
+
+  async updateCourseFamilyMember(
+    memberId: string,
+    updates: import('../types/generated/courses').CourseFamilyMemberUpdate
+  ): Promise<import('../types/generated/courses').CourseFamilyMemberGet> {
+    try {
+      const client = await this.getHttpClient();
+      const response = await client.patch<import('../types/generated/courses').CourseFamilyMemberGet>(
+        `/course-family-members/${memberId}`,
+        updates
+      );
+      return response.data;
+    } catch (error) {
+      console.error(`[updateCourseFamilyMember] Failed for ${memberId}:`, error);
+      throw error;
+    }
+  }
+
+  async deleteCourseFamilyMember(memberId: string): Promise<void> {
+    try {
+      const client = await this.getHttpClient();
+      await client.delete(`/course-family-members/${memberId}`);
+    } catch (error) {
+      console.error(`[deleteCourseFamilyMember] Failed for ${memberId}:`, error);
+      throw error;
+    }
+  }
+
   async createUser(payload: import('../types/generated/users').UserCreate): Promise<UserGet> {
     try {
       const client = await this.getHttpClient();

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -2110,6 +2110,21 @@ export class ComputorApiService {
     await client.post('/user/password', payload);
   }
 
+  // User Management: lookup by exact filter (email / username / etc).
+  // Bypasses the cached "all users" list so the call still works for users
+  // who lack list-all permission but have access via the filtered endpoint.
+  async findUsers(query: { email?: string; username?: string; given_name?: string; family_name?: string }): Promise<UserList[]> {
+    const client = await this.getHttpClient();
+    const params: Record<string, string> = {};
+    if (query.email) { params.email = query.email; }
+    if (query.username) { params.username = query.username; }
+    if (query.given_name) { params.given_name = query.given_name; }
+    if (query.family_name) { params.family_name = query.family_name; }
+    if (Object.keys(params).length === 0) { return []; }
+    const response = await client.get<UserList[]>('/users', { ...params, limit: 25 });
+    return response.data || [];
+  }
+
   // User Management: List all users
   async getUsers(options?: { force?: boolean }): Promise<UserList[]> {
     try {

--- a/src/services/ScopePermissions.ts
+++ b/src/services/ScopePermissions.ts
@@ -1,0 +1,82 @@
+import type { UserScopes } from '../types/generated/users';
+
+const GLOBAL_ORG_MANAGER_ROLE = '_organization_manager';
+const GLOBAL_FAMILY_MANAGER_ROLE = '_course_family_manager';
+const POSTING_ROLES: ReadonlySet<string> = new Set(['_owner', '_manager']);
+
+export type ScopeKind = 'organization' | 'course_family';
+
+export interface ScopePermissionContext {
+  scopes?: UserScopes;
+  /** Role IDs from `user.user_roles[]` — i.e. system-wide roles. */
+  globalRoles?: ReadonlySet<string>;
+}
+
+function isAdmin(ctx: ScopePermissionContext): boolean {
+  return ctx.scopes?.is_admin === true;
+}
+
+function hasGlobalRole(ctx: ScopePermissionContext, roleId: string): boolean {
+  return ctx.globalRoles?.has(roleId) === true;
+}
+
+function hasScopeManagerClaim(
+  map: Record<string, string[]> | undefined,
+  scopeId?: string
+): boolean {
+  if (!map) {
+    return false;
+  }
+  if (scopeId !== undefined) {
+    const roles = map[scopeId];
+    return Array.isArray(roles) && roles.some(r => POSTING_ROLES.has(r));
+  }
+  for (const roles of Object.values(map)) {
+    if (Array.isArray(roles) && roles.some(r => POSTING_ROLES.has(r))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** True when the user can manage members on at least one organization. */
+export function canManageAnyOrganizationMembers(ctx: ScopePermissionContext): boolean {
+  return isAdmin(ctx)
+    || hasGlobalRole(ctx, GLOBAL_ORG_MANAGER_ROLE)
+    || hasScopeManagerClaim(ctx.scopes?.organization);
+}
+
+/** True when the user can manage members on at least one course family.
+ *  Organization-manager grants this transitively (course families nest under
+ *  organizations). */
+export function canManageAnyCourseFamilyMembers(ctx: ScopePermissionContext): boolean {
+  return isAdmin(ctx)
+    || hasGlobalRole(ctx, GLOBAL_ORG_MANAGER_ROLE)
+    || hasGlobalRole(ctx, GLOBAL_FAMILY_MANAGER_ROLE)
+    || hasScopeManagerClaim(ctx.scopes?.course_family);
+}
+
+/** True when the user can manage members on this specific scope. */
+export function canManageScopeMembership(
+  scopeKind: ScopeKind,
+  scopeId: string,
+  ctx: ScopePermissionContext
+): boolean {
+  if (isAdmin(ctx)) {
+    return true;
+  }
+  if (scopeKind === 'organization') {
+    if (hasGlobalRole(ctx, GLOBAL_ORG_MANAGER_ROLE)) {
+      return true;
+    }
+    return hasScopeManagerClaim(ctx.scopes?.organization, scopeId);
+  }
+  // course_family — org-manager grants transitive access.
+  if (hasGlobalRole(ctx, GLOBAL_ORG_MANAGER_ROLE)) {
+    return true;
+  }
+  if (hasGlobalRole(ctx, GLOBAL_FAMILY_MANAGER_ROLE)) {
+    return true;
+  }
+  return hasScopeManagerClaim(ctx.scopes?.course_family, scopeId);
+}

--- a/src/ui/webviews/ScopeMembershipWebviewProvider.ts
+++ b/src/ui/webviews/ScopeMembershipWebviewProvider.ts
@@ -30,7 +30,6 @@ interface ScopeMembershipViewState {
   target: ScopeMembershipTarget;
   members: NormalizedMember[];
   availableRoles: NormalizedRole[];
-  availableUsers: UserList[];
   canManage: boolean;
 }
 
@@ -109,6 +108,9 @@ export class ScopeMembershipWebviewProvider extends BaseWebviewProvider {
       case 'addMember':
         await this.handleAddMember(message.data);
         break;
+      case 'browseAndAdd':
+        await this.handleBrowseAndAdd(message.data);
+        break;
       case 'changeRole':
         await this.handleChangeRole(message.data);
         break;
@@ -123,10 +125,9 @@ export class ScopeMembershipWebviewProvider extends BaseWebviewProvider {
   // ----- State loading -----
 
   private async loadState(target: ScopeMembershipTarget): Promise<ScopeMembershipViewState> {
-    const [members, roles, users, scopes, currentUser] = await Promise.all([
+    const [members, roles, scopes, currentUser] = await Promise.all([
       this.fetchMembers(target),
       this.fetchRoles(target),
-      this.apiService.getUsers().catch(() => []),
       this.apiService.getUserScopes().catch(() => undefined),
       this.apiService.getUserAccount().catch(() => undefined)
     ]);
@@ -142,7 +143,6 @@ export class ScopeMembershipWebviewProvider extends BaseWebviewProvider {
       target,
       members,
       availableRoles: roles,
-      availableUsers: users || [],
       canManage
     };
   }
@@ -190,12 +190,108 @@ export class ScopeMembershipWebviewProvider extends BaseWebviewProvider {
 
   private async handleAddMember(raw: any): Promise<void> {
     if (!this.currentTarget || !raw || typeof raw !== 'object') { return; }
-    const userId = typeof raw.user_id === 'string' ? raw.user_id.trim() : '';
     const roleId = typeof raw.role_id === 'string' ? raw.role_id.trim() : '';
-    if (!userId || !roleId) {
-      this.postNotice({ type: 'warning', message: 'Pick a user and a role.' });
+    if (!roleId) {
+      this.postNotice({ type: 'warning', message: 'Pick a role.' });
       return;
     }
+
+    let userId = typeof raw.user_id === 'string' ? raw.user_id.trim() : '';
+    const identifier = typeof raw.identifier === 'string' ? raw.identifier.trim() : '';
+
+    if (!userId && identifier) {
+      try {
+        userId = await this.resolveUserIdentifier(identifier) ?? '';
+      } catch (error: any) {
+        this.handleError('Failed to look up user', error);
+        return;
+      }
+      if (!userId) {
+        this.postNotice({ type: 'warning', message: `No user found for "${identifier}".` });
+        return;
+      }
+    }
+
+    if (!userId) {
+      this.postNotice({ type: 'warning', message: 'Provide an email/username or pick from the list.' });
+      return;
+    }
+
+    await this.createMember(userId, roleId);
+  }
+
+  private async handleBrowseAndAdd(raw: any): Promise<void> {
+    if (!this.currentTarget || !raw || typeof raw !== 'object') { return; }
+    const roleId = typeof raw.role_id === 'string' ? raw.role_id.trim() : '';
+    if (!roleId) {
+      this.postNotice({ type: 'warning', message: 'Pick a role first.' });
+      return;
+    }
+
+    let users: UserList[] = [];
+    try {
+      users = await this.apiService.getUsers();
+    } catch (error: any) {
+      this.handleError('Cannot browse users (you may lack permission). Try email or username.', error);
+      return;
+    }
+    if (!users || users.length === 0) {
+      this.postNotice({ type: 'info', message: 'No users available to browse.' });
+      return;
+    }
+
+    const memberUserIds = new Set((this.currentData as ScopeMembershipViewState | undefined)?.members.map(m => m.user_id) ?? []);
+    const candidates = users
+      .filter(u => !u.archived_at && !u.is_service && !memberUserIds.has(u.id))
+      .sort((a, b) => formatUserLabel(a).localeCompare(formatUserLabel(b)));
+    if (candidates.length === 0) {
+      this.postNotice({ type: 'info', message: 'No additional users available to add.' });
+      return;
+    }
+
+    const picked = await vscode.window.showQuickPick(
+      candidates.map(u => ({
+        label: formatUserLabel(u),
+        description: u.email || u.username || '',
+        detail: u.username && u.email ? `@${u.username}` : undefined,
+        userId: u.id
+      })),
+      {
+        placeHolder: 'Select a user to add',
+        matchOnDescription: true,
+        matchOnDetail: true
+      }
+    );
+    if (!picked) { return; }
+
+    await this.createMember(picked.userId, roleId);
+  }
+
+  private async resolveUserIdentifier(identifier: string): Promise<string | undefined> {
+    // Try exact email then exact username via the standard /users filter
+    // params. Both calls fail-soft — the Add Member flow surfaces a
+    // friendly "no user found" notice if both come back empty.
+    try {
+      const matches = await this.apiService.findUsers({ email: identifier });
+      if (matches.length > 0 && matches[0]?.id) {
+        return matches[0].id;
+      }
+    } catch (err) {
+      console.warn('[ScopeMembershipWebview] email lookup failed:', err);
+    }
+    try {
+      const matches = await this.apiService.findUsers({ username: identifier });
+      if (matches.length > 0 && matches[0]?.id) {
+        return matches[0].id;
+      }
+    } catch (err) {
+      console.warn('[ScopeMembershipWebview] username lookup failed:', err);
+    }
+    return undefined;
+  }
+
+  private async createMember(userId: string, roleId: string): Promise<void> {
+    if (!this.currentTarget) { return; }
     try {
       if (this.currentTarget.kind === 'organization') {
         await this.apiService.createOrganizationMember({
@@ -271,4 +367,11 @@ export class ScopeMembershipWebviewProvider extends BaseWebviewProvider {
       this.panel.webview.postMessage({ command: 'notice', notice });
     }
   }
+}
+
+function formatUserLabel(user: UserList): string {
+  const family = user.family_name || '';
+  const given = user.given_name || '';
+  if (family && given) { return `${family}, ${given}`; }
+  return family || given || user.username || user.email || user.id;
 }

--- a/src/ui/webviews/ScopeMembershipWebviewProvider.ts
+++ b/src/ui/webviews/ScopeMembershipWebviewProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { BaseWebviewProvider } from './BaseWebviewProvider';
 import { ComputorApiService } from '../../services/ComputorApiService';
+import { canManageScopeMembership } from '../../services/ScopePermissions';
 import type { UserList } from '../../types/generated/users';
 
 export type ScopeKind = 'organization' | 'course_family';
@@ -122,14 +123,20 @@ export class ScopeMembershipWebviewProvider extends BaseWebviewProvider {
   // ----- State loading -----
 
   private async loadState(target: ScopeMembershipTarget): Promise<ScopeMembershipViewState> {
-    const [members, roles, users, scopes] = await Promise.all([
+    const [members, roles, users, scopes, currentUser] = await Promise.all([
       this.fetchMembers(target),
       this.fetchRoles(target),
       this.apiService.getUsers().catch(() => []),
-      this.apiService.getUserScopes().catch(() => undefined)
+      this.apiService.getUserScopes().catch(() => undefined),
+      this.apiService.getUserAccount().catch(() => undefined)
     ]);
 
-    const canManage = this.canManageScope(target, scopes);
+    const globalRoles = new Set(
+      (currentUser?.user_roles ?? [])
+        .map(r => r?.role_id)
+        .filter((id): id is string => typeof id === 'string')
+    );
+    const canManage = canManageScopeMembership(target.kind, target.scopeId, { scopes, globalRoles });
 
     return {
       target,
@@ -138,18 +145,6 @@ export class ScopeMembershipWebviewProvider extends BaseWebviewProvider {
       availableUsers: users || [],
       canManage
     };
-  }
-
-  private canManageScope(
-    target: ScopeMembershipTarget,
-    scopes: import('../../types/generated/users').UserScopes | undefined
-  ): boolean {
-    if (!scopes) { return false; }
-    if (scopes.is_admin) { return true; }
-    const map = target.kind === 'organization' ? scopes.organization : scopes.course_family;
-    const roles = map?.[target.scopeId];
-    if (!roles) { return false; }
-    return roles.some(r => r === '_owner' || r === '_manager');
   }
 
   private async refreshState(notice?: NoticeMessage): Promise<void> {

--- a/src/ui/webviews/ScopeMembershipWebviewProvider.ts
+++ b/src/ui/webviews/ScopeMembershipWebviewProvider.ts
@@ -1,0 +1,279 @@
+import * as vscode from 'vscode';
+import { BaseWebviewProvider } from './BaseWebviewProvider';
+import { ComputorApiService } from '../../services/ComputorApiService';
+import type { UserList } from '../../types/generated/users';
+
+export type ScopeKind = 'organization' | 'course_family';
+
+export interface ScopeMembershipTarget {
+  kind: ScopeKind;
+  scopeId: string;
+  scopeTitle: string;
+  /** Optional secondary line for the header (e.g. parent organization name). */
+  scopeSubtitle?: string;
+}
+
+interface NormalizedMember {
+  id: string;
+  user_id: string;
+  role_id: string;
+  user?: UserList | null;
+}
+
+interface NormalizedRole {
+  id: string;
+  title?: string | null;
+}
+
+interface ScopeMembershipViewState {
+  target: ScopeMembershipTarget;
+  members: NormalizedMember[];
+  availableRoles: NormalizedRole[];
+  availableUsers: UserList[];
+  canManage: boolean;
+}
+
+type NoticeType = 'info' | 'success' | 'warning' | 'error';
+
+interface NoticeMessage {
+  type: NoticeType;
+  message: string;
+}
+
+export class ScopeMembershipWebviewProvider extends BaseWebviewProvider {
+  private currentTarget?: ScopeMembershipTarget;
+
+  constructor(context: vscode.ExtensionContext, private readonly apiService: ComputorApiService) {
+    super(context, 'computor.usermanager.scopeMembershipView');
+  }
+
+  async open(target: ScopeMembershipTarget): Promise<void> {
+    try {
+      // Re-create the panel if the scope changed so cached state doesn't bleed across panels.
+      if (this.panel && this.currentTarget && (this.currentTarget.kind !== target.kind || this.currentTarget.scopeId !== target.scopeId)) {
+        this.panel.dispose();
+        this.panel = undefined;
+      }
+      this.currentTarget = target;
+      const state = await this.loadState(target);
+      const title = `${target.kind === 'organization' ? 'Organization' : 'Course Family'} members: ${target.scopeTitle}`;
+      await this.show(title, state);
+    } catch (error: any) {
+      vscode.window.showErrorMessage(`Failed to open members panel: ${error?.message || error}`);
+    }
+  }
+
+  protected async getWebviewContent(data?: ScopeMembershipViewState): Promise<string> {
+    if (!this.panel) {
+      return this.getBaseHtml('Members', '<p>Loading…</p>');
+    }
+    const webview = this.panel.webview;
+    const nonce = this.getNonce();
+    const initialState = JSON.stringify(data ?? null);
+    const componentsCssUri = this.getWebviewUri(webview, 'webview-ui', 'components', 'components.css');
+    const stylesUri = this.getWebviewUri(webview, 'webview-ui', 'scope-membership.css');
+    const componentsJsUri = this.getWebviewUri(webview, 'webview-ui', 'components.js');
+    const scriptUri = this.getWebviewUri(webview, 'webview-ui', 'scope-membership.js');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; img-src ${webview.cspSource} https: data:; script-src 'nonce-${nonce}';">
+  <title>Members</title>
+  <link rel="stylesheet" href="${componentsCssUri}">
+  <link rel="stylesheet" href="${stylesUri}">
+</head>
+<body>
+  <div id="app" class="scope-membership-root"></div>
+  <script nonce="${nonce}">
+    window.vscodeApi = window.vscodeApi || acquireVsCodeApi();
+    window.__INITIAL_STATE__ = ${initialState};
+  </script>
+  <script nonce="${nonce}" src="${componentsJsUri}"></script>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+  }
+
+  protected async handleMessage(message: any): Promise<void> {
+    if (!message || !this.currentTarget) {
+      return;
+    }
+    switch (message.command) {
+      case 'refresh':
+        await this.refreshState();
+        break;
+      case 'addMember':
+        await this.handleAddMember(message.data);
+        break;
+      case 'changeRole':
+        await this.handleChangeRole(message.data);
+        break;
+      case 'removeMember':
+        await this.handleRemoveMember(message.data);
+        break;
+      default:
+        break;
+    }
+  }
+
+  // ----- State loading -----
+
+  private async loadState(target: ScopeMembershipTarget): Promise<ScopeMembershipViewState> {
+    const [members, roles, users, scopes] = await Promise.all([
+      this.fetchMembers(target),
+      this.fetchRoles(target),
+      this.apiService.getUsers().catch(() => []),
+      this.apiService.getUserScopes().catch(() => undefined)
+    ]);
+
+    const canManage = this.canManageScope(target, scopes);
+
+    return {
+      target,
+      members,
+      availableRoles: roles,
+      availableUsers: users || [],
+      canManage
+    };
+  }
+
+  private canManageScope(
+    target: ScopeMembershipTarget,
+    scopes: import('../../types/generated/users').UserScopes | undefined
+  ): boolean {
+    if (!scopes) { return false; }
+    if (scopes.is_admin) { return true; }
+    const map = target.kind === 'organization' ? scopes.organization : scopes.course_family;
+    const roles = map?.[target.scopeId];
+    if (!roles) { return false; }
+    return roles.some(r => r === '_owner' || r === '_manager');
+  }
+
+  private async refreshState(notice?: NoticeMessage): Promise<void> {
+    if (!this.currentTarget || !this.panel) { return; }
+    try {
+      const state = await this.loadState(this.currentTarget);
+      this.currentData = state;
+      this.panel.webview.postMessage({ command: 'updateState', data: state, notice });
+    } catch (error: any) {
+      this.handleError('Failed to refresh members', error);
+    }
+  }
+
+  private async fetchMembers(target: ScopeMembershipTarget): Promise<NormalizedMember[]> {
+    if (target.kind === 'organization') {
+      const list = await this.apiService.listOrganizationMembers(target.scopeId);
+      return list.map(m => ({
+        id: m.id,
+        user_id: m.user_id,
+        role_id: m.organization_role_id,
+        user: m.user
+      }));
+    }
+    const list = await this.apiService.listCourseFamilyMembers(target.scopeId);
+    return list.map(m => ({
+      id: m.id,
+      user_id: m.user_id,
+      role_id: m.course_family_role_id,
+      user: m.user
+    }));
+  }
+
+  private async fetchRoles(target: ScopeMembershipTarget): Promise<NormalizedRole[]> {
+    if (target.kind === 'organization') {
+      const list = await this.apiService.listOrganizationRoles();
+      return list.map(r => ({ id: r.id, title: r.title }));
+    }
+    const list = await this.apiService.listCourseFamilyRoles();
+    return list.map(r => ({ id: r.id, title: r.title }));
+  }
+
+  // ----- Mutations -----
+
+  private async handleAddMember(raw: any): Promise<void> {
+    if (!this.currentTarget || !raw || typeof raw !== 'object') { return; }
+    const userId = typeof raw.user_id === 'string' ? raw.user_id.trim() : '';
+    const roleId = typeof raw.role_id === 'string' ? raw.role_id.trim() : '';
+    if (!userId || !roleId) {
+      this.postNotice({ type: 'warning', message: 'Pick a user and a role.' });
+      return;
+    }
+    try {
+      if (this.currentTarget.kind === 'organization') {
+        await this.apiService.createOrganizationMember({
+          user_id: userId,
+          organization_id: this.currentTarget.scopeId,
+          organization_role_id: roleId
+        });
+      } else {
+        await this.apiService.createCourseFamilyMember({
+          user_id: userId,
+          course_family_id: this.currentTarget.scopeId,
+          course_family_role_id: roleId
+        });
+      }
+      await this.refreshState({ type: 'success', message: 'Member added.' });
+    } catch (error: any) {
+      this.handleError('Failed to add member', error);
+    }
+  }
+
+  private async handleChangeRole(raw: any): Promise<void> {
+    if (!this.currentTarget || !raw || typeof raw !== 'object') { return; }
+    const memberId = typeof raw.member_id === 'string' ? raw.member_id : '';
+    const roleId = typeof raw.role_id === 'string' ? raw.role_id : '';
+    if (!memberId || !roleId) { return; }
+    try {
+      if (this.currentTarget.kind === 'organization') {
+        await this.apiService.updateOrganizationMember(memberId, { organization_role_id: roleId });
+      } else {
+        await this.apiService.updateCourseFamilyMember(memberId, { course_family_role_id: roleId });
+      }
+      await this.refreshState({ type: 'success', message: 'Role updated.' });
+    } catch (error: any) {
+      this.handleError('Failed to update role', error);
+    }
+  }
+
+  private async handleRemoveMember(raw: any): Promise<void> {
+    if (!this.currentTarget || !raw || typeof raw !== 'object') { return; }
+    const memberId = typeof raw.member_id === 'string' ? raw.member_id : '';
+    if (!memberId) { return; }
+
+    const confirmation = await vscode.window.showWarningMessage(
+      'Remove this user from the scope?',
+      { modal: true },
+      'Remove'
+    );
+    if (confirmation !== 'Remove') { return; }
+
+    try {
+      if (this.currentTarget.kind === 'organization') {
+        await this.apiService.deleteOrganizationMember(memberId);
+      } else {
+        await this.apiService.deleteCourseFamilyMember(memberId);
+      }
+      await this.refreshState({ type: 'success', message: 'Member removed.' });
+    } catch (error: any) {
+      this.handleError('Failed to remove member', error);
+    }
+  }
+
+  // ----- Helpers -----
+
+  private handleError(prefix: string, error: any): void {
+    const detail = error?.message || error?.response?.data?.detail || error?.response?.data?.message || String(error);
+    console.error(`[ScopeMembershipWebview] ${prefix}:`, error);
+    vscode.window.showErrorMessage(`${prefix}: ${detail}`);
+    this.postNotice({ type: 'error', message: `${prefix}: ${detail}` });
+  }
+
+  private postNotice(notice: NoticeMessage): void {
+    if (this.panel) {
+      this.panel.webview.postMessage({ command: 'notice', notice });
+    }
+  }
+}

--- a/webview-ui/scope-membership.css
+++ b/webview-ui/scope-membership.css
@@ -1,0 +1,206 @@
+.scope-membership-root {
+  padding: 16px 24px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.scope-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.scope-header h1 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.scope-subtitle {
+  margin: 0;
+  color: var(--vscode-descriptionForeground);
+  font-size: 12px;
+}
+
+.scope-notice {
+  padding: 10px 14px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  font-size: 13px;
+}
+
+.scope-notice-info {
+  background: var(--vscode-infoMessageBackground, rgba(0, 122, 204, 0.15));
+  border-color: var(--vscode-inputValidation-infoBorder, rgba(0, 122, 204, 0.4));
+}
+
+.scope-notice-success {
+  background: rgba(56, 142, 60, 0.18);
+  border-color: rgba(56, 142, 60, 0.5);
+}
+
+.scope-notice-warning {
+  background: rgba(255, 193, 7, 0.18);
+  border-color: rgba(255, 193, 7, 0.5);
+}
+
+.scope-notice-error {
+  background: rgba(211, 47, 47, 0.18);
+  border-color: rgba(211, 47, 47, 0.5);
+}
+
+.scope-section {
+  background: var(--vscode-editor-background);
+  border: 1px solid var(--vscode-editorWidget-border);
+  border-radius: 6px;
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.scope-section-header h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.scope-empty {
+  color: var(--vscode-descriptionForeground);
+  font-style: italic;
+  margin: 0;
+}
+
+.scope-members {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.scope-members th,
+.scope-members td {
+  text-align: left;
+  padding: 8px 10px;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--vscode-editorWidget-border);
+  font-size: 13px;
+}
+
+.scope-members th {
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.scope-members tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.member-name {
+  font-weight: 500;
+}
+
+.member-meta {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.member-actions {
+  text-align: right;
+  width: 1%;
+  white-space: nowrap;
+}
+
+.scope-members select {
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35)));
+  border-radius: 4px;
+  padding: 4px 6px;
+  font-size: 12px;
+}
+
+.role-tag {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.scope-add-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px 16px;
+  align-items: end;
+}
+
+.scope-add-form .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.scope-add-form .form-field label {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.scope-add-form .form-field select {
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35)));
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 13px;
+}
+
+.scope-add-form .form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.scope-add-form .form-actions button {
+  border: none;
+  border-radius: 4px;
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+}
+
+.scope-add-form .form-actions button.primary {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.scope-add-form .form-actions button:hover {
+  filter: brightness(1.1);
+}
+
+.member-actions button {
+  border: none;
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+}
+
+.member-actions button.danger {
+  background: rgba(211, 47, 47, 0.8);
+  color: #ffffff;
+}
+
+.member-actions button:hover {
+  filter: brightness(1.1);
+}

--- a/webview-ui/scope-membership.css
+++ b/webview-ui/scope-membership.css
@@ -137,7 +137,22 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 12px 16px;
-  align-items: end;
+  align-items: start;
+}
+
+.scope-add-form .form-field input {
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35)));
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 13px;
+}
+
+.scope-add-form .field-hint {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  margin: 4px 0 0;
 }
 
 .scope-add-form .form-field {

--- a/webview-ui/scope-membership.js
+++ b/webview-ui/scope-membership.js
@@ -3,7 +3,6 @@
 
   const state = window.__INITIAL_STATE__ || null;
   const localState = {
-    addUserId: '',
     addRoleId: '',
     pending: false,
     notice: null
@@ -51,12 +50,7 @@
       return;
     }
 
-    const { target, members, availableRoles, availableUsers, canManage } = state;
-    const memberUserIds = new Set(members.map(m => m.user_id));
-    const candidateUsers = availableUsers
-      .filter(u => !u.archived_at && !u.is_service && !memberUserIds.has(u.id))
-      .sort((a, b) => userDisplayName(a).localeCompare(userDisplayName(b)));
-
+    const { target, members, availableRoles, canManage } = state;
     const headerLabel = target.kind === 'organization' ? 'Organization' : 'Course Family';
 
     root.innerHTML = `
@@ -116,27 +110,24 @@
         <div class="scope-section-header">
           <h2>Add Member</h2>
         </div>
-        ${candidateUsers.length === 0
-          ? '<p class="scope-empty">No additional users available to add.</p>'
-          : `<form id="add-member-form" class="scope-add-form">
-              <div class="form-field">
-                <label for="add-user">User</label>
-                <select id="add-user" name="user_id" required>
-                  <option value="" disabled${localState.addUserId ? '' : ' selected'}>Choose a user…</option>
-                  ${candidateUsers.map(u => `<option value="${escapeHtml(u.id)}"${u.id === localState.addUserId ? ' selected' : ''}>${escapeHtml(userDisplayName(u))} — ${escapeHtml(u.email || u.username || u.id)}</option>`).join('')}
-                </select>
-              </div>
-              <div class="form-field">
-                <label for="add-role">Role</label>
-                <select id="add-role" name="role_id" required>
-                  <option value="" disabled${localState.addRoleId ? '' : ' selected'}>Choose a role…</option>
-                  ${availableRoles.map(r => `<option value="${escapeHtml(r.id)}"${r.id === localState.addRoleId ? ' selected' : ''}>${escapeHtml(r.title || r.id)}</option>`).join('')}
-                </select>
-              </div>
-              <div class="form-actions">
-                <button type="submit" class="primary">Add Member</button>
-              </div>
-            </form>`}
+        <form id="add-member-form" class="scope-add-form">
+          <div class="form-field">
+            <label for="add-role">Role</label>
+            <select id="add-role" name="role_id" required>
+              <option value="" disabled${localState.addRoleId ? '' : ' selected'}>Choose a role…</option>
+              ${availableRoles.map(r => `<option value="${escapeHtml(r.id)}"${r.id === localState.addRoleId ? ' selected' : ''}>${escapeHtml(r.title || r.id)}</option>`).join('')}
+            </select>
+          </div>
+          <div class="form-field">
+            <label for="add-identifier">Email or username</label>
+            <input id="add-identifier" name="identifier" type="text" placeholder="user@example.com or alice42" autocomplete="off" />
+            <p class="field-hint">Looks up the user by exact email, then by exact username.</p>
+          </div>
+          <div class="form-actions">
+            <button type="button" id="browse-users-btn" class="secondary">Browse users…</button>
+            <button type="submit" class="primary">Add Member</button>
+          </div>
+        </form>
       </section>
       ` : ''}
     `;
@@ -149,15 +140,32 @@
     if (addForm) {
       addForm.addEventListener('submit', (event) => {
         event.preventDefault();
-        const userSelect = document.getElementById('add-user');
         const roleSelect = document.getElementById('add-role');
-        const userId = userSelect && 'value' in userSelect ? userSelect.value : '';
+        const identifierInput = document.getElementById('add-identifier');
         const roleId = roleSelect && 'value' in roleSelect ? roleSelect.value : '';
-        if (!userId || !roleId) {
-          showNotice('warning', 'Pick a user and a role.');
+        const identifier = identifierInput && 'value' in identifierInput ? identifierInput.value.trim() : '';
+        if (!roleId) {
+          showNotice('warning', 'Pick a role.');
           return;
         }
-        post('addMember', { user_id: userId, role_id: roleId });
+        if (!identifier) {
+          showNotice('warning', 'Type an email/username or use Browse users…');
+          return;
+        }
+        post('addMember', { identifier, role_id: roleId });
+      });
+    }
+
+    const browseBtn = document.getElementById('browse-users-btn');
+    if (browseBtn) {
+      browseBtn.addEventListener('click', () => {
+        const roleSelect = document.getElementById('add-role');
+        const roleId = roleSelect && 'value' in roleSelect ? roleSelect.value : '';
+        if (!roleId) {
+          showNotice('warning', 'Pick a role first.');
+          return;
+        }
+        post('browseAndAdd', { role_id: roleId });
       });
     }
 

--- a/webview-ui/scope-membership.js
+++ b/webview-ui/scope-membership.js
@@ -1,0 +1,209 @@
+(function () {
+  const vscode = window.vscodeApi || acquireVsCodeApi();
+
+  const state = window.__INITIAL_STATE__ || null;
+  const localState = {
+    addUserId: '',
+    addRoleId: '',
+    pending: false,
+    notice: null
+  };
+
+  function escapeHtml(value) {
+    if (value === undefined || value === null) { return ''; }
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function post(command, data) {
+    vscode.postMessage({ command, data });
+  }
+
+  function userDisplayName(user) {
+    if (!user) { return ''; }
+    const family = user.family_name || '';
+    const given = user.given_name || '';
+    if (family && given) { return `${family}, ${given}`; }
+    return family || given || user.username || user.email || user.id;
+  }
+
+  function roleLabel(roleId, availableRoles) {
+    const found = availableRoles.find(r => r.id === roleId);
+    return found?.title || roleId;
+  }
+
+  function noticeHtml() {
+    if (!localState.notice) { return ''; }
+    const { type, message } = localState.notice;
+    return `<div class="scope-notice scope-notice-${escapeHtml(type)}">${escapeHtml(message)}</div>`;
+  }
+
+  function renderRoot() {
+    const root = document.getElementById('app');
+    if (!root) { return; }
+
+    if (!state) {
+      root.innerHTML = '<p>Loading…</p>';
+      return;
+    }
+
+    const { target, members, availableRoles, availableUsers, canManage } = state;
+    const memberUserIds = new Set(members.map(m => m.user_id));
+    const candidateUsers = availableUsers
+      .filter(u => !u.archived_at && !u.is_service && !memberUserIds.has(u.id))
+      .sort((a, b) => userDisplayName(a).localeCompare(userDisplayName(b)));
+
+    const headerLabel = target.kind === 'organization' ? 'Organization' : 'Course Family';
+
+    root.innerHTML = `
+      <header class="scope-header">
+        <h1>${escapeHtml(target.scopeTitle)}</h1>
+        <p class="scope-subtitle">${escapeHtml(target.scopeSubtitle || headerLabel)} · Members</p>
+        ${canManage ? '' : '<p class="scope-notice scope-notice-info">You have read-only access. Backend rejects mutations from non-managers.</p>'}
+      </header>
+
+      ${noticeHtml()}
+
+      <section class="scope-section">
+        <div class="scope-section-header">
+          <h2>Members (${members.length})</h2>
+        </div>
+        ${members.length === 0
+          ? '<p class="scope-empty">No members yet.</p>'
+          : `<table class="scope-members">
+              <thead>
+                <tr>
+                  <th>User</th>
+                  <th>Role</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                ${members.map(member => {
+                  const name = userDisplayName(member.user) || member.user_id;
+                  const roleOptions = availableRoles.map(r =>
+                    `<option value="${escapeHtml(r.id)}"${r.id === member.role_id ? ' selected' : ''}>${escapeHtml(r.title || r.id)}</option>`
+                  ).join('');
+                  return `
+                    <tr data-member-id="${escapeHtml(member.id)}">
+                      <td>
+                        <div class="member-name">${escapeHtml(name)}</div>
+                        <div class="member-meta">${escapeHtml(member.user?.email || member.user?.username || member.user_id)}</div>
+                      </td>
+                      <td>
+                        ${canManage
+                          ? `<select data-role-select data-member-id="${escapeHtml(member.id)}">${roleOptions}</select>`
+                          : `<span class="role-tag">${escapeHtml(roleLabel(member.role_id, availableRoles))}</span>`}
+                      </td>
+                      <td class="member-actions">
+                        ${canManage
+                          ? `<button type="button" class="danger" data-remove-member="${escapeHtml(member.id)}">Remove</button>`
+                          : ''}
+                      </td>
+                    </tr>
+                  `;
+                }).join('')}
+              </tbody>
+            </table>`}
+      </section>
+
+      ${canManage ? `
+      <section class="scope-section">
+        <div class="scope-section-header">
+          <h2>Add Member</h2>
+        </div>
+        ${candidateUsers.length === 0
+          ? '<p class="scope-empty">No additional users available to add.</p>'
+          : `<form id="add-member-form" class="scope-add-form">
+              <div class="form-field">
+                <label for="add-user">User</label>
+                <select id="add-user" name="user_id" required>
+                  <option value="" disabled${localState.addUserId ? '' : ' selected'}>Choose a user…</option>
+                  ${candidateUsers.map(u => `<option value="${escapeHtml(u.id)}"${u.id === localState.addUserId ? ' selected' : ''}>${escapeHtml(userDisplayName(u))} — ${escapeHtml(u.email || u.username || u.id)}</option>`).join('')}
+                </select>
+              </div>
+              <div class="form-field">
+                <label for="add-role">Role</label>
+                <select id="add-role" name="role_id" required>
+                  <option value="" disabled${localState.addRoleId ? '' : ' selected'}>Choose a role…</option>
+                  ${availableRoles.map(r => `<option value="${escapeHtml(r.id)}"${r.id === localState.addRoleId ? ' selected' : ''}>${escapeHtml(r.title || r.id)}</option>`).join('')}
+                </select>
+              </div>
+              <div class="form-actions">
+                <button type="submit" class="primary">Add Member</button>
+              </div>
+            </form>`}
+      </section>
+      ` : ''}
+    `;
+
+    attachListeners();
+  }
+
+  function attachListeners() {
+    const addForm = document.getElementById('add-member-form');
+    if (addForm) {
+      addForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const userSelect = document.getElementById('add-user');
+        const roleSelect = document.getElementById('add-role');
+        const userId = userSelect && 'value' in userSelect ? userSelect.value : '';
+        const roleId = roleSelect && 'value' in roleSelect ? roleSelect.value : '';
+        if (!userId || !roleId) {
+          showNotice('warning', 'Pick a user and a role.');
+          return;
+        }
+        post('addMember', { user_id: userId, role_id: roleId });
+      });
+    }
+
+    document.querySelectorAll('[data-role-select]').forEach((el) => {
+      el.addEventListener('change', (event) => {
+        const target = event.currentTarget;
+        if (!(target instanceof HTMLSelectElement)) { return; }
+        const memberId = target.getAttribute('data-member-id');
+        if (!memberId) { return; }
+        post('changeRole', { member_id: memberId, role_id: target.value });
+      });
+    });
+
+    document.querySelectorAll('[data-remove-member]').forEach((el) => {
+      el.addEventListener('click', (event) => {
+        event.preventDefault();
+        const target = event.currentTarget;
+        if (!(target instanceof HTMLElement)) { return; }
+        const memberId = target.getAttribute('data-remove-member');
+        if (!memberId) { return; }
+        post('removeMember', { member_id: memberId });
+      });
+    });
+  }
+
+  function showNotice(type, message) {
+    localState.notice = { type, message };
+    renderRoot();
+  }
+
+  window.addEventListener('message', (event) => {
+    const message = event.data;
+    if (!message) { return; }
+    switch (message.command) {
+      case 'updateState':
+        Object.assign(state || {}, message.data || {});
+        if (message.notice) { localState.notice = message.notice; }
+        renderRoot();
+        break;
+      case 'notice':
+        if (message.notice) { showNotice(message.notice.type, message.notice.message); }
+        break;
+      default:
+        break;
+    }
+  });
+
+  renderRoot();
+})();


### PR DESCRIPTION
Closes #83.

Depends on backend fix `fix/scoped-manager-member-claims` (commit `d898698`) which extends `claims_organization_manager` to include `OrganizationMemberInterface` + `CourseFamilyMemberInterface` claim values. Without that, `_organization_manager` users get 404 on member CRUD.

## Summary

6 commits adding per-scope member management on the lecturer tree:

- `6d6c77d` API methods for org-member + family-member CRUD + role catalogs
- `134addc` `ScopeMembershipWebviewProvider` (parameterised by scope kind) + webview JS/CSS
- `a9a5789` Lecturer commands + right-click menu entries on Organization / CourseFamily tree items
- `a16f352` Initial menu gating via context keys
- `0b54e27` Per-scope-kind context keys (org vs family)
- `0f93781` Recognise global `_organization_manager` / `_course_family_manager` roles in addition to scope-bound `_owner`/`_manager` claims

## Behaviour

- Right-click Organization or Course Family in the lecturer tree → **Manage Members**
- Webview lists current members (user + role) with a role dropdown per row and a Remove button
- "Add member" form: pick an existing user (search-filterable list, excluding archived/service/already-members) and a role; submits via `POST /(organization|course-family)-members`
- Backend remains source of truth on permissions; webview shows read-only mode if the viewer lacks scope authority

## Permission rules (centralised in `src/services/ScopePermissions.ts`)

- `is_admin` → everything
- Global `_organization_manager` → all orgs **and** all course families (transitive — families nest inside orgs)
- Global `_course_family_manager` → all course families
- Scope-bound `_owner`/`_manager` claim on a specific org or family → that scope only

Both menu visibility (per-scope-kind context keys) and webview canManage flag use the same helper.

## Test plan

- [ ] As `_organization_manager`: Manage Members menu appears on every Organization and Course Family node; can add/remove/change-role
- [ ] As `_course_family_manager` only: menu appears on Course Family nodes only
- [ ] As scope-bound `organization:_manager:o1`: menu appears (gated by per-kind context key); webview is editable for org o1, read-only banner on other orgs
- [ ] As non-manager / non-admin: menu hidden entirely
- [ ] Add a non-existing user → 404 user-id error; add user already a member → 4xx
- [ ] Change an `_owner` row as a `_manager` (not owner) → backend 403 surfaces inline