### PR TITLE
fix(chat): clear unread badges immediately when opening a thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -388,9 +388,9 @@
         "category": "Computor Chat"
       },
       {
-        "command": "computor.chat.filterSubmissionsByTitle",
-        "title": "Filter by Title…",
-        "icon": "$(search)",
+        "command": "computor.chat.removeSubmissionCourse",
+        "title": "Remove Course Filter",
+        "icon": "$(close)",
         "category": "Computor Chat"
       },
       {
@@ -1266,14 +1266,9 @@
           "group": "2_filter@1"
         },
         {
-          "command": "computor.chat.filterSubmissionsByTitle",
-          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\.submission_group/",
-          "group": "2_filter@2"
-        },
-        {
           "command": "computor.chat.clearSubmissionFilters",
           "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\.submission_group/ && computor.chat.submissionFiltersActive",
-          "group": "2_filter@3"
+          "group": "2_filter@2"
         },
         {
           "command": "computor.lecturer.createNewExample",

--- a/package.json
+++ b/package.json
@@ -400,6 +400,12 @@
         "category": "Computor Chat"
       },
       {
+        "command": "computor.chat.loadMore",
+        "title": "Load More Messages",
+        "icon": "$(ellipsis)",
+        "category": "Computor Chat"
+      },
+      {
         "command": "computor.lecturer.checkoutMultipleExamples",
         "title": "Checkout Multiple Examples",
         "icon": "$(cloud-download)",

--- a/package.json
+++ b/package.json
@@ -382,6 +382,24 @@
         "category": "Computor Chat"
       },
       {
+        "command": "computor.chat.filterSubmissionsByCourse",
+        "title": "Filter by Course…",
+        "icon": "$(filter)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.filterSubmissionsByTitle",
+        "title": "Filter by Title…",
+        "icon": "$(search)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.clearSubmissionFilters",
+        "title": "Clear Submission Filters",
+        "icon": "$(close)",
+        "category": "Computor Chat"
+      },
+      {
         "command": "computor.lecturer.checkoutMultipleExamples",
         "title": "Checkout Multiple Examples",
         "icon": "$(cloud-download)",
@@ -1228,13 +1246,28 @@
       "view/item/context": [
         {
           "command": "computor.chat.markScopeRead",
-          "when": "view == computor.chat.inbox && viewItem == chatScope.unread",
+          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\..+\\.unread$/",
           "group": "1_actions@1"
         },
         {
           "command": "computor.chat.markThreadRead",
           "when": "view == computor.chat.inbox && viewItem == chatThread.unread",
           "group": "1_actions@1"
+        },
+        {
+          "command": "computor.chat.filterSubmissionsByCourse",
+          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\.submission_group/",
+          "group": "2_filter@1"
+        },
+        {
+          "command": "computor.chat.filterSubmissionsByTitle",
+          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\.submission_group/",
+          "group": "2_filter@2"
+        },
+        {
+          "command": "computor.chat.clearSubmissionFilters",
+          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\.submission_group/ && computor.chat.submissionFiltersActive",
+          "group": "2_filter@3"
         },
         {
           "command": "computor.lecturer.createNewExample",

--- a/package.json
+++ b/package.json
@@ -382,24 +382,6 @@
         "category": "Computor Chat"
       },
       {
-        "command": "computor.chat.filterSubmissionsByCourse",
-        "title": "Filter by Course…",
-        "icon": "$(filter)",
-        "category": "Computor Chat"
-      },
-      {
-        "command": "computor.chat.removeSubmissionCourse",
-        "title": "Remove Course Filter",
-        "icon": "$(close)",
-        "category": "Computor Chat"
-      },
-      {
-        "command": "computor.chat.clearSubmissionFilters",
-        "title": "Clear Submission Filters",
-        "icon": "$(close)",
-        "category": "Computor Chat"
-      },
-      {
         "command": "computor.chat.loadMore",
         "title": "Load More Messages",
         "icon": "$(ellipsis)",
@@ -1259,16 +1241,6 @@
           "command": "computor.chat.markThreadRead",
           "when": "view == computor.chat.inbox && viewItem == chatThread.unread",
           "group": "1_actions@1"
-        },
-        {
-          "command": "computor.chat.filterSubmissionsByCourse",
-          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\.submission_group/",
-          "group": "2_filter@1"
-        },
-        {
-          "command": "computor.chat.clearSubmissionFilters",
-          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\.submission_group/ && computor.chat.submissionFiltersActive",
-          "group": "2_filter@2"
         },
         {
           "command": "computor.lecturer.createNewExample",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1281,6 +1281,9 @@ class UnifiedController {
       }),
       vscode.commands.registerCommand('computor.chat.clearSubmissionFilters', () => {
         tree.clearSubmissionFilters();
+      }),
+      vscode.commands.registerCommand('computor.chat.loadMore', () => {
+        void tree.loadMoreInboxMessages();
       })
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1187,7 +1187,7 @@ class UnifiedController {
 
   private async initializeChatView(api: ComputorApiService): Promise<void> {
     const { ChatInboxTreeProvider } = await import('./ui/tree/chat/ChatInboxTreeProvider');
-    const { ChatScopeItem, ChatThreadItem } = await import('./ui/tree/chat/ChatInboxTreeItems');
+    const { ChatScopeItem, ChatThreadItem, ChatCourseGroupItem } = await import('./ui/tree/chat/ChatInboxTreeItems');
 
     // The chat view drives the existing MessagesWebviewProvider + bottom Compose
     // panel, so reuse the input panel + WebSocket service we already instantiated.
@@ -1210,11 +1210,15 @@ class UnifiedController {
       onExpand: (event) => {
         if (event.element instanceof ChatScopeItem) {
           tree.recordExpanded(event.element.scope, true);
+        } else if (event.element instanceof ChatCourseGroupItem) {
+          tree.recordCourseGroupExpanded(event.element.scope, event.element.courseId, true);
         }
       },
       onCollapse: (event) => {
         if (event.element instanceof ChatScopeItem) {
           tree.recordExpanded(event.element.scope, false);
+        } else if (event.element instanceof ChatCourseGroupItem) {
+          tree.recordCourseGroupExpanded(event.element.scope, event.element.courseId, false);
         }
       },
       onVisibility: (event) => {
@@ -1276,8 +1280,11 @@ class UnifiedController {
       vscode.commands.registerCommand('computor.chat.clearSubmissionFilters', () => {
         tree.clearSubmissionFilters();
       }),
-      vscode.commands.registerCommand('computor.chat.loadMore', (scope: unknown) => {
-        if (typeof scope === 'string' && scope.length > 0) {
+      vscode.commands.registerCommand('computor.chat.loadMore', (scope: unknown, courseId?: unknown) => {
+        if (typeof scope !== 'string' || scope.length === 0) { return; }
+        if (typeof courseId === 'string' && courseId.length > 0) {
+          void tree.loadMoreForCourseScope(scope as any, courseId);
+        } else {
           void tree.loadMoreForScope(scope as any);
         }
       })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1276,8 +1276,10 @@ class UnifiedController {
       vscode.commands.registerCommand('computor.chat.clearSubmissionFilters', () => {
         tree.clearSubmissionFilters();
       }),
-      vscode.commands.registerCommand('computor.chat.loadMore', () => {
-        void tree.loadMoreInboxMessages();
+      vscode.commands.registerCommand('computor.chat.loadMore', (scope: unknown) => {
+        if (typeof scope === 'string' && scope.length > 0) {
+          void tree.loadMoreForScope(scope as any);
+        }
       })
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1250,6 +1250,37 @@ class UnifiedController {
         if (item instanceof ChatThreadItem) {
           void tree.markThreadRead(item);
         }
+      }),
+      vscode.commands.registerCommand('computor.chat.filterSubmissionsByCourse', async () => {
+        const courses = tree.getSubmissionFilterCourses();
+        if (courses.length === 0) {
+          vscode.window.showInformationMessage('No submission-group messages to filter by course.');
+          return;
+        }
+        const picked = await vscode.window.showQuickPick(
+          courses.map(c => ({ label: c.label, description: c.id, picked: c.selected, courseId: c.id })),
+          {
+            canPickMany: true,
+            placeHolder: 'Select courses to keep in Submission Groups (none = all)',
+            title: 'Filter Submission Groups by Course'
+          }
+        );
+        if (!picked) { return; } // user cancelled — leave filter as is
+        tree.setSubmissionCourseFilter(picked.map(p => p.courseId));
+      }),
+      vscode.commands.registerCommand('computor.chat.filterSubmissionsByTitle', async () => {
+        const value = await vscode.window.showInputBox({
+          title: 'Filter Submission Groups by Title',
+          prompt: 'Match any message whose title contains this text (case-insensitive). Empty to clear.',
+          placeHolder: 'e.g. ai-help',
+          value: tree.getSubmissionTitleFilter(),
+          ignoreFocusOut: true
+        });
+        if (value === undefined) { return; } // cancelled
+        tree.setSubmissionTitleFilter(value);
+      }),
+      vscode.commands.registerCommand('computor.chat.clearSubmissionFilters', () => {
+        tree.clearSubmissionFilters();
       })
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1255,31 +1255,6 @@ class UnifiedController {
           void tree.markThreadRead(item);
         }
       }),
-      vscode.commands.registerCommand('computor.chat.filterSubmissionsByCourse', async () => {
-        const courses = tree.getSubmissionFilterCourses();
-        if (courses.length === 0) {
-          vscode.window.showInformationMessage('No submission-group messages to filter by course.');
-          return;
-        }
-        const picked = await vscode.window.showQuickPick(
-          courses.map(c => ({ label: c.label, description: c.id, picked: c.selected, courseId: c.id })),
-          {
-            canPickMany: true,
-            placeHolder: 'Select courses to keep in Submission Groups (none = all)',
-            title: 'Filter Submission Groups by Course'
-          }
-        );
-        if (!picked) { return; } // user cancelled — leave filter as is
-        tree.setSubmissionCourseFilter(picked.map(p => p.courseId));
-      }),
-      vscode.commands.registerCommand('computor.chat.removeSubmissionCourse', (courseId: unknown) => {
-        if (typeof courseId === 'string' && courseId.length > 0) {
-          tree.removeSubmissionCourse(courseId);
-        }
-      }),
-      vscode.commands.registerCommand('computor.chat.clearSubmissionFilters', () => {
-        tree.clearSubmissionFilters();
-      }),
       vscode.commands.registerCommand('computor.chat.loadMore', (scope: unknown, courseId?: unknown) => {
         if (typeof scope !== 'string' || scope.length === 0) { return; }
         if (typeof courseId === 'string' && courseId.length > 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1268,16 +1268,10 @@ class UnifiedController {
         if (!picked) { return; } // user cancelled — leave filter as is
         tree.setSubmissionCourseFilter(picked.map(p => p.courseId));
       }),
-      vscode.commands.registerCommand('computor.chat.filterSubmissionsByTitle', async () => {
-        const value = await vscode.window.showInputBox({
-          title: 'Filter Submission Groups by Title',
-          prompt: 'Match any message whose title contains this text (case-insensitive). Empty to clear.',
-          placeHolder: 'e.g. ai-help',
-          value: tree.getSubmissionTitleFilter(),
-          ignoreFocusOut: true
-        });
-        if (value === undefined) { return; } // cancelled
-        tree.setSubmissionTitleFilter(value);
+      vscode.commands.registerCommand('computor.chat.removeSubmissionCourse', (courseId: unknown) => {
+        if (typeof courseId === 'string' && courseId.length > 0) {
+          tree.removeSubmissionCourse(courseId);
+        }
       }),
       vscode.commands.registerCommand('computor.chat.clearSubmissionFilters', () => {
         tree.clearSubmissionFilters();

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -2681,13 +2681,54 @@ export class ComputorApiService {
       const client = await this.getHttpClient();
       // course_member_id is carried in the params for cache invalidation hooks
       // upstream but isn't a backend query parameter — strip it before sending.
-      const query = Object.fromEntries(
+      const baseQuery = Object.fromEntries(
         Object.entries(params).filter(([key, value]) =>
           value !== undefined && value !== null && key !== 'course_member_id'
         )
       );
-      const response = await client.get<MessageList[]>('/messages', query);
-      return response.data;
+
+      // Caller-controlled pagination: if either skip or limit is set, do a
+      // single bounded request and respect the caller's window verbatim.
+      if (typeof baseQuery.skip === 'number' || typeof baseQuery.limit === 'number') {
+        const response = await client.get<MessageList[]>('/messages', baseQuery);
+        return response.data;
+      }
+
+      // Otherwise auto-page through every result (backend default page is
+      // small — 100 items; on busy accounts the inbox needs the full list to
+      // group/unread-count correctly). Capped at MAX_PAGES * PAGE_SIZE to
+      // avoid runaway loops if X-Total-Count is missing or wrong.
+      const PAGE_SIZE = 500;
+      const MAX_PAGES = 20; // 10k items hard cap
+      const collected: MessageList[] = [];
+      let skip = 0;
+      let expectedTotal: number | undefined;
+
+      for (let page = 0; page < MAX_PAGES; page += 1) {
+        const response = await client.get<MessageList[]>('/messages', {
+          ...baseQuery,
+          skip,
+          limit: PAGE_SIZE
+        });
+        const batch = response.data || [];
+        collected.push(...batch);
+
+        if (expectedTotal === undefined) {
+          const totalHeader = response.headers?.['x-total-count'];
+          if (typeof totalHeader === 'string') {
+            const parsed = Number.parseInt(totalHeader, 10);
+            if (Number.isFinite(parsed) && parsed >= 0) { expectedTotal = parsed; }
+          }
+        }
+
+        // Stop early when the server returned a short page (no more rows) or
+        // when we've reached the announced total.
+        if (batch.length < PAGE_SIZE) { break; }
+        if (expectedTotal !== undefined && collected.length >= expectedTotal) { break; }
+        skip += PAGE_SIZE;
+      }
+
+      return collected;
     }, {
       maxRetries: 2,
       exponentialBackoff: true

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -2735,6 +2735,32 @@ export class ComputorApiService {
     });
   }
 
+  /**
+   * Fetches a single page of messages with the caller's exact skip/limit and
+   * returns both the items and the total count from the X-Total-Count header
+   * — used by callers that want to render a "Load more" affordance instead
+   * of auto-paging.
+   */
+  async listMessagesPage(params: MessageQuery = {}): Promise<{ items: MessageList[]; total: number }> {
+    return errorRecoveryService.executeWithRecovery(async () => {
+      const client = await this.getHttpClient();
+      const query = Object.fromEntries(
+        Object.entries(params).filter(([key, value]) =>
+          value !== undefined && value !== null && key !== 'course_member_id'
+        )
+      );
+      const response = await client.get<MessageList[]>('/messages', query);
+      const items = response.data || [];
+      const totalHeader = response.headers?.['x-total-count'];
+      const parsedTotal = typeof totalHeader === 'string' ? Number.parseInt(totalHeader, 10) : NaN;
+      const total = Number.isFinite(parsedTotal) && parsedTotal >= 0 ? parsedTotal : items.length;
+      return { items, total };
+    }, {
+      maxRetries: 2,
+      exponentialBackoff: true
+    });
+  }
+
   async getMessage(id: string): Promise<MessageGet | undefined> {
     return errorRecoveryService.executeWithRecovery(async () => {
       const client = await this.getHttpClient();

--- a/src/types/generated/messages.ts
+++ b/src/types/generated/messages.ts
@@ -125,7 +125,6 @@ export interface MessageQuery {
   submission_group_id?: string | null;
   course_member_id?: string | null;
   user_id?: string | null;
-  course_id_all_messages?: boolean | null;
   scope?: "global" | "organization" | "course_family" | "course" | "course_content" | "course_group" | "submission_group" | "course_member" | "user" | null;
   /** Filter messages created at or after this datetime (inclusive) */
   created_after?: string | null;

--- a/src/ui/tree/chat/ChatInboxTreeItems.ts
+++ b/src/ui/tree/chat/ChatInboxTreeItems.ts
@@ -155,6 +155,24 @@ export class ChatErrorItem extends vscode.TreeItem {
   }
 }
 
+export class ChatLoadMoreItem extends vscode.TreeItem {
+  constructor(loaded: number, total: number) {
+    const remaining = Math.max(total - loaded, 0);
+    super(`Load more (${loaded} of ${total})`, vscode.TreeItemCollapsibleState.None);
+    this.id = 'chat-load-more';
+    this.iconPath = new vscode.ThemeIcon('ellipsis');
+    this.contextValue = 'chatLoadMore';
+    this.description = remaining > 0 ? `${remaining} more` : '';
+    this.tooltip = remaining > 0
+      ? `Click to fetch the next batch (${remaining} more available).`
+      : 'No more messages to load.';
+    this.command = {
+      command: 'computor.chat.loadMore',
+      title: 'Load More Messages'
+    };
+  }
+}
+
 function formatPreview(message: MessageList): string {
   const author = formatAuthor(message);
   const text = (message.content || '').replace(/\s+/g, ' ').trim();

--- a/src/ui/tree/chat/ChatInboxTreeItems.ts
+++ b/src/ui/tree/chat/ChatInboxTreeItems.ts
@@ -63,7 +63,8 @@ export class ChatScopeItem extends vscode.TreeItem {
     public readonly scope: MessageScope,
     public readonly threads: ChatThread[],
     public readonly unreadCount: number,
-    expanded: boolean
+    expanded: boolean,
+    public readonly filterActive: boolean = false
   ) {
     super(
       SCOPE_LABELS[scope],
@@ -74,14 +75,23 @@ export class ChatScopeItem extends vscode.TreeItem {
           : vscode.TreeItemCollapsibleState.Collapsed
     );
     this.id = `chat-scope-${scope}`;
-    this.contextValue = unreadCount > 0 ? 'chatScope.unread' : 'chatScope';
+    // contextValue carries the scope name and an unread suffix, so menus
+    // can target either every scope (e.g. /\.unread$/), or a single scope
+    // (e.g. /^chatScope\.submission_group/) without ambiguity.
+    this.contextValue = unreadCount > 0
+      ? `chatScope.${scope}.unread`
+      : `chatScope.${scope}`;
     this.iconPath = new vscode.ThemeIcon(SCOPE_ICONS[scope]);
+    const filterSuffix = filterActive ? ' · filter on' : '';
     this.description = unreadCount > 0
-      ? `${unreadCount} unread · ${threads.length}`
-      : `${threads.length}`;
-    this.tooltip = unreadCount > 0
+      ? `${unreadCount} unread · ${threads.length}${filterSuffix}`
+      : `${threads.length}${filterSuffix}`;
+    const tooltipBase = unreadCount > 0
       ? `${SCOPE_LABELS[scope]}: ${unreadCount} unread of ${threads.length} thread(s)`
       : `${SCOPE_LABELS[scope]}: ${threads.length} thread(s)`;
+    this.tooltip = filterActive
+      ? `${tooltipBase}\nFilter active — right-click to manage`
+      : tooltipBase;
   }
 }
 

--- a/src/ui/tree/chat/ChatInboxTreeItems.ts
+++ b/src/ui/tree/chat/ChatInboxTreeItems.ts
@@ -64,11 +64,19 @@ export class ChatScopeItem extends vscode.TreeItem {
     public readonly threads: ChatThread[],
     public readonly unreadCount: number,
     expanded: boolean,
-    public readonly filterActive: boolean = false
+    public readonly filterActive: boolean = false,
+    /** When set, the scope renders course nodes as children instead of
+     *  threads — used for the four course-grouped scopes (submission_group /
+     *  course / course_content / course_group). The number is shown in the
+     *  description and the row stays collapsible even with zero threads. */
+    public readonly courseChildCount?: number
   ) {
+    const isCourseGrouped = courseChildCount !== undefined;
+    const childCount = isCourseGrouped ? courseChildCount! : threads.length;
+    const childKind = isCourseGrouped ? 'course' : 'thread';
     super(
       SCOPE_LABELS[scope],
-      threads.length === 0
+      childCount === 0
         ? vscode.TreeItemCollapsibleState.None
         : expanded
           ? vscode.TreeItemCollapsibleState.Expanded
@@ -84,11 +92,11 @@ export class ChatScopeItem extends vscode.TreeItem {
     this.iconPath = new vscode.ThemeIcon(SCOPE_ICONS[scope]);
     const filterSuffix = filterActive ? ' · filter on' : '';
     this.description = unreadCount > 0
-      ? `${unreadCount} unread · ${threads.length}${filterSuffix}`
-      : `${threads.length}${filterSuffix}`;
+      ? `${unreadCount} unread · ${childCount}${filterSuffix}`
+      : `${childCount}${filterSuffix}`;
     const tooltipBase = unreadCount > 0
-      ? `${SCOPE_LABELS[scope]}: ${unreadCount} unread of ${threads.length} thread(s)`
-      : `${SCOPE_LABELS[scope]}: ${threads.length} thread(s)`;
+      ? `${SCOPE_LABELS[scope]}: ${unreadCount} unread of ${childCount} ${childKind}(s)`
+      : `${SCOPE_LABELS[scope]}: ${childCount} ${childKind}(s)`;
     this.tooltip = filterActive
       ? `${tooltipBase}\nFilter active — right-click to manage`
       : tooltipBase;
@@ -155,6 +163,42 @@ export class ChatErrorItem extends vscode.TreeItem {
   }
 }
 
+export class ChatCourseGroupItem extends vscode.TreeItem {
+  constructor(
+    public readonly scope: MessageScope,
+    public readonly courseId: string,
+    public readonly courseLabel: string,
+    /** Aggregate unread for messages of `scope` belonging to `courseId` that
+     *  have already been pulled. Zero when the course node hasn't been
+     *  expanded yet. */
+    public readonly unreadCount: number,
+    /** Number of distinct threads for messages of `scope` × `courseId` that
+     *  have already been pulled. */
+    public readonly threadCount: number,
+    /** Whether the backend reports more messages for (scope, courseId) than
+     *  we've pulled so far — drives the trailing Load more visibility. */
+    public readonly hasMore: boolean,
+    expanded: boolean
+  ) {
+    super(courseLabel, expanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
+    this.id = `chat-course-group-${scope}-${courseId}`;
+    this.contextValue = unreadCount > 0
+      ? `chatCourseGroup.${scope}.unread`
+      : `chatCourseGroup.${scope}`;
+    this.iconPath = new vscode.ThemeIcon('mortar-board');
+    if (threadCount === 0) {
+      this.description = expanded ? 'no messages' : 'click to load';
+    } else {
+      this.description = unreadCount > 0
+        ? `${unreadCount} unread · ${threadCount}${hasMore ? ' · …' : ''}`
+        : `${threadCount}${hasMore ? ' · …' : ''}`;
+    }
+    this.tooltip = unreadCount > 0
+      ? `${courseLabel}: ${unreadCount} unread of ${threadCount} thread(s)`
+      : `${courseLabel}: ${threadCount} thread(s)`;
+  }
+}
+
 export class ChatFilterChipItem extends vscode.TreeItem {
   constructor(
     label: string,
@@ -177,10 +221,17 @@ export class ChatFilterChipItem extends vscode.TreeItem {
 }
 
 export class ChatLoadMoreItem extends vscode.TreeItem {
-  constructor(public readonly scope: MessageScope, loaded: number, total: number) {
+  constructor(
+    public readonly scope: MessageScope,
+    loaded: number,
+    total: number,
+    public readonly courseId?: string
+  ) {
     const remaining = Math.max(total - loaded, 0);
     super(`Load more (${loaded} of ${total})`, vscode.TreeItemCollapsibleState.None);
-    this.id = `chat-load-more-${scope}`;
+    this.id = courseId
+      ? `chat-load-more-${scope}-${courseId}`
+      : `chat-load-more-${scope}`;
     this.iconPath = new vscode.ThemeIcon('ellipsis');
     this.contextValue = 'chatLoadMore';
     this.description = remaining > 0 ? `${remaining} more` : '';
@@ -190,7 +241,7 @@ export class ChatLoadMoreItem extends vscode.TreeItem {
     this.command = {
       command: 'computor.chat.loadMore',
       title: 'Load More Messages',
-      arguments: [scope]
+      arguments: courseId ? [scope, courseId] : [scope]
     };
   }
 }

--- a/src/ui/tree/chat/ChatInboxTreeItems.ts
+++ b/src/ui/tree/chat/ChatInboxTreeItems.ts
@@ -155,6 +155,27 @@ export class ChatErrorItem extends vscode.TreeItem {
   }
 }
 
+export class ChatFilterChipItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    tooltip: string,
+    removeCommand: string,
+    removeArgs: unknown[] = []
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    // Stable per-label id so VS Code can diff the tree without flicker.
+    this.id = `chat-filter-chip-${label}`;
+    this.contextValue = 'chatFilterChip';
+    this.iconPath = new vscode.ThemeIcon('close');
+    this.tooltip = tooltip;
+    this.command = {
+      command: removeCommand,
+      title: 'Remove Filter',
+      arguments: removeArgs
+    };
+  }
+}
+
 export class ChatLoadMoreItem extends vscode.TreeItem {
   constructor(loaded: number, total: number) {
     const remaining = Math.max(total - loaded, 0);

--- a/src/ui/tree/chat/ChatInboxTreeItems.ts
+++ b/src/ui/tree/chat/ChatInboxTreeItems.ts
@@ -177,10 +177,10 @@ export class ChatFilterChipItem extends vscode.TreeItem {
 }
 
 export class ChatLoadMoreItem extends vscode.TreeItem {
-  constructor(loaded: number, total: number) {
+  constructor(public readonly scope: MessageScope, loaded: number, total: number) {
     const remaining = Math.max(total - loaded, 0);
     super(`Load more (${loaded} of ${total})`, vscode.TreeItemCollapsibleState.None);
-    this.id = 'chat-load-more';
+    this.id = `chat-load-more-${scope}`;
     this.iconPath = new vscode.ThemeIcon('ellipsis');
     this.contextValue = 'chatLoadMore';
     this.description = remaining > 0 ? `${remaining} more` : '';
@@ -189,7 +189,8 @@ export class ChatLoadMoreItem extends vscode.TreeItem {
       : 'No more messages to load.';
     this.command = {
       command: 'computor.chat.loadMore',
-      title: 'Load More Messages'
+      title: 'Load More Messages',
+      arguments: [scope]
     };
   }
 }

--- a/src/ui/tree/chat/ChatInboxTreeItems.ts
+++ b/src/ui/tree/chat/ChatInboxTreeItems.ts
@@ -64,7 +64,6 @@ export class ChatScopeItem extends vscode.TreeItem {
     public readonly threads: ChatThread[],
     public readonly unreadCount: number,
     expanded: boolean,
-    public readonly filterActive: boolean = false,
     /** When set, the scope renders course nodes as children instead of
      *  threads — used for the four course-grouped scopes (submission_group /
      *  course / course_content / course_group). The number is shown in the
@@ -90,16 +89,12 @@ export class ChatScopeItem extends vscode.TreeItem {
       ? `chatScope.${scope}.unread`
       : `chatScope.${scope}`;
     this.iconPath = new vscode.ThemeIcon(SCOPE_ICONS[scope]);
-    const filterSuffix = filterActive ? ' · filter on' : '';
     this.description = unreadCount > 0
-      ? `${unreadCount} unread · ${childCount}${filterSuffix}`
-      : `${childCount}${filterSuffix}`;
-    const tooltipBase = unreadCount > 0
+      ? `${unreadCount} unread · ${childCount}`
+      : `${childCount}`;
+    this.tooltip = unreadCount > 0
       ? `${SCOPE_LABELS[scope]}: ${unreadCount} unread of ${childCount} ${childKind}(s)`
       : `${SCOPE_LABELS[scope]}: ${childCount} ${childKind}(s)`;
-    this.tooltip = filterActive
-      ? `${tooltipBase}\nFilter active — right-click to manage`
-      : tooltipBase;
   }
 }
 
@@ -196,27 +191,6 @@ export class ChatCourseGroupItem extends vscode.TreeItem {
     this.tooltip = unreadCount > 0
       ? `${courseLabel}: ${unreadCount} unread of ${threadCount} thread(s)`
       : `${courseLabel}: ${threadCount} thread(s)`;
-  }
-}
-
-export class ChatFilterChipItem extends vscode.TreeItem {
-  constructor(
-    label: string,
-    tooltip: string,
-    removeCommand: string,
-    removeArgs: unknown[] = []
-  ) {
-    super(label, vscode.TreeItemCollapsibleState.None);
-    // Stable per-label id so VS Code can diff the tree without flicker.
-    this.id = `chat-filter-chip-${label}`;
-    this.contextValue = 'chatFilterChip';
-    this.iconPath = new vscode.ThemeIcon('close');
-    this.tooltip = tooltip;
-    this.command = {
-      command: removeCommand,
-      title: 'Remove Filter',
-      arguments: removeArgs
-    };
   }
 }
 

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -271,7 +271,9 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     this.submissionCourseFilter = new Set(ids);
     void this.persistState();
     this.applySubmissionFiltersContextKey();
-    this.rebuildScopeItemsFromCache();
+    // Filter is enforced server-side, so re-fetch the submission-group slice
+    // with the new params; non-sub scopes don't change.
+    this.refresh();
   }
 
   getSubmissionTitleFilter(): string {
@@ -284,7 +286,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     this.submissionTitleFilter = trimmed;
     void this.persistState();
     this.applySubmissionFiltersContextKey();
-    this.rebuildScopeItemsFromCache();
+    this.refresh();
   }
 
   clearSubmissionFilters(): void {
@@ -293,22 +295,50 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     this.submissionTitleFilter = '';
     void this.persistState();
     this.applySubmissionFiltersContextKey();
-    this.rebuildScopeItemsFromCache();
+    this.refresh();
   }
 
-  private threadMatchesSubmissionFilters(msgs: MessageList[]): boolean {
-    if (this.submissionCourseFilter.size > 0) {
-      const ok = msgs.some(m =>
-        typeof m.course_id === 'string' && this.submissionCourseFilter.has(m.course_id)
-      );
-      if (!ok) { return false; }
+  private hasSubmissionFilter(): boolean {
+    return this.submissionCourseFilter.size > 0 || this.submissionTitleFilter.length > 0;
+  }
+
+  /**
+   * When submission-group filters are active, fetches the matching messages
+   * via the backend (scope=submission_group + course_id_all_messages=true +
+   * tag_scope=...). Multi-course is fanned out per course because the backend
+   * takes one course_id at a time. Returns deduped results.
+   */
+  private async fetchFilteredSubmissionMessages(): Promise<MessageList[]> {
+    const tagScope = this.submissionTitleFilter || undefined;
+    const courseIds = Array.from(this.submissionCourseFilter);
+
+    if (courseIds.length === 0) {
+      // Title-only filter
+      return await this.api.listMessages({
+        scope: 'submission_group',
+        ...(tagScope ? { tag_scope: tagScope } : {})
+      });
     }
-    if (this.submissionTitleFilter) {
-      const needle = this.submissionTitleFilter.toLowerCase();
-      const ok = msgs.some(m => typeof m.title === 'string' && m.title.toLowerCase().includes(needle));
-      if (!ok) { return false; }
+
+    const fetches = courseIds.map(courseId =>
+      this.api.listMessages({
+        scope: 'submission_group',
+        course_id: courseId,
+        course_id_all_messages: true,
+        ...(tagScope ? { tag_scope: tagScope } : {})
+      })
+    );
+    const results = await Promise.all(fetches);
+    const seen = new Set<string>();
+    const merged: MessageList[] = [];
+    for (const list of results) {
+      for (const m of list) {
+        if (seen.has(m.id)) { continue; }
+        seen.add(m.id);
+        merged.push(m);
+      }
     }
-    return true;
+    return merged;
   }
 
   private applySubmissionFiltersContextKey(): void {
@@ -405,7 +435,24 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       this.userScopes = scopes;
       this.maybeSubscribeUserChannels();
 
-      this.cachedMessages = messages || [];
+      let assembled = messages || [];
+
+      // When submission-group filters are active, swap the unfiltered
+      // submission_group slice for the backend-filtered version. course_id is
+      // not always populated on submission_group messages, so client-side
+      // filtering by course_id is unreliable — we rely on the backend's
+      // course_id_all_messages + tag_scope filters instead.
+      if (this.hasSubmissionFilter()) {
+        try {
+          const filteredSub = await this.fetchFilteredSubmissionMessages();
+          const nonSub = assembled.filter(m => m.scope !== 'submission_group');
+          assembled = [...nonSub, ...filteredSub];
+        } catch (err) {
+          console.warn('[ChatInbox] Failed to fetch filtered submission messages, falling back to unfiltered:', err);
+        }
+      }
+
+      this.cachedMessages = assembled;
       const grouped = this.groupMessages(this.cachedMessages);
       await this.resolveLabels(grouped);
       this.scopeItems = this.buildScopeItems(grouped);
@@ -556,12 +603,9 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
       const threads: ChatThread[] = [];
       for (const [targetId, msgs] of byTarget) {
-        // Submission-group-only filters: by parent course id, and by message
-        // title substring. Both are AND-combined; thread is kept only if at
-        // least one of its messages matches each active filter.
-        if (scope === 'submission_group' && !this.threadMatchesSubmissionFilters(msgs)) {
-          continue;
-        }
+        // Submission-group filters are now enforced server-side: when the
+        // filter is active, the cached payload's submission_group slice is
+        // already the result of a filtered fetch, so nothing else to do here.
         const sortedMessages = msgs.slice().sort((a, b) => compareCreated(a, b));
         const lastMessage = sortedMessages[sortedMessages.length - 1];
         // Exclude the user's own messages — backend doesn't auto-stamp authors

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -944,10 +944,14 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       }
 
       const byTarget = grouped.get(scope);
-      if (!byTarget || byTarget.size === 0) { continue; }
+      // Global stays visible even with zero messages so users always have a
+      // way to read announcements (and admins always have a place to post
+      // from).
+      const alwaysShow = scope === 'global';
+      if ((!byTarget || byTarget.size === 0) && !alwaysShow) { continue; }
 
       const threads: ChatThread[] = [];
-      for (const [targetId, msgs] of byTarget) {
+      for (const [targetId, msgs] of (byTarget ?? new Map<string, MessageList[]>())) {
         const sortedMessages = msgs.slice().sort((a, b) => compareCreated(a, b));
         const lastMessage = sortedMessages[sortedMessages.length - 1];
         // Exclude the user's own messages — backend doesn't auto-stamp authors
@@ -969,7 +973,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         });
       }
 
-      if (threads.length === 0) { continue; }
+      if (threads.length === 0 && !alwaysShow) { continue; }
 
       threads.sort((a, b) => {
         if ((b.unreadCount > 0 ? 1 : 0) !== (a.unreadCount > 0 ? 1 : 0)) {

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -51,6 +51,9 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   private loading = false;
   private loadError: string | undefined;
   private scopeItems: ChatScopeItem[] = [];
+  /** Last raw inbox payload, kept so we can rebuild scope items without
+   *  re-fetching when local read-state changes optimistically. */
+  private cachedMessages: MessageList[] = [];
   private currentUserId?: string;
   private userScopes?: import('../../../types/generated').UserScopes;
   private userScopesPromise?: Promise<void>;
@@ -146,7 +149,42 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       vscode.window.showWarningMessage('Cannot open this conversation: target context unavailable.');
       return;
     }
+
+    // Optimistically clear unread for this thread. The backend only broadcasts
+    // read:update on submission_group channels, so non-submission-group threads
+    // never receive a WS event when MessagesWebview marks their messages as
+    // read — the badge would otherwise stay until a manual refresh. Mutating
+    // the cached MessageList objects in place updates both the per-thread and
+    // per-scope counts on the next rebuild. The mark-read API call is fired
+    // here too; if MessagesWebview also fires it the call is idempotent.
+    const unread = threadItem.thread.messages.filter(
+      m => !m.is_read && m.author_id !== this.currentUserId
+    );
+    if (unread.length > 0) {
+      for (const m of unread) {
+        m.is_read = true;
+      }
+      this.rebuildScopeItemsFromCache();
+      void Promise.all(unread.map(m => this.api.markMessageRead(m.id).catch(() => undefined)));
+    }
+
     await this.messagesProvider.showMessages(ctx);
+  }
+
+  /**
+   * Re-groups + re-builds scope items from the cached message list without
+   * re-fetching from the backend. Used when local read state changes
+   * optimistically (e.g. opening a thread).
+   */
+  private rebuildScopeItemsFromCache(): void {
+    if (this.cachedMessages.length === 0) {
+      this.scopeItems = [];
+    } else {
+      const grouped = this.groupMessages(this.cachedMessages);
+      this.scopeItems = this.buildScopeItems(grouped);
+    }
+    this._onDidChangeTreeData.fire(undefined);
+    this._onDidChangeUnread.fire(this.getTotalUnread());
   }
 
   private async ensureUserScopes(): Promise<void> {
@@ -172,17 +210,23 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   async markThreadRead(threadItem: ChatThreadItem): Promise<void> {
     const unread = threadItem.thread.messages.filter(m => !m.is_read && m.author_id !== this.currentUserId);
     if (unread.length === 0) { return; }
+    for (const m of unread) {
+      m.is_read = true;
+    }
+    this.rebuildScopeItemsFromCache();
     await Promise.all(unread.map(m => this.api.markMessageRead(m.id).catch(() => undefined)));
-    this.refresh();
   }
 
   async markScopeRead(scopeItem: ChatScopeItem): Promise<void> {
-    const ids = scopeItem.threads.flatMap(t =>
-      t.messages.filter(m => !m.is_read && m.author_id !== this.currentUserId).map(m => m.id)
+    const unread = scopeItem.threads.flatMap(t =>
+      t.messages.filter(m => !m.is_read && m.author_id !== this.currentUserId)
     );
-    if (ids.length === 0) { return; }
-    await Promise.all(ids.map(id => this.api.markMessageRead(id).catch(() => undefined)));
-    this.refresh();
+    if (unread.length === 0) { return; }
+    for (const m of unread) {
+      m.is_read = true;
+    }
+    this.rebuildScopeItemsFromCache();
+    await Promise.all(unread.map(m => this.api.markMessageRead(m.id).catch(() => undefined)));
   }
 
   // ----- TreeDataProvider -----
@@ -229,12 +273,14 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       this.userScopes = scopes;
       this.maybeSubscribeUserChannels();
 
-      const grouped = this.groupMessages(messages || []);
+      this.cachedMessages = messages || [];
+      const grouped = this.groupMessages(this.cachedMessages);
       await this.resolveLabels(grouped);
       this.scopeItems = this.buildScopeItems(grouped);
     } catch (error: any) {
       this.loadError = `Failed to load messages: ${error?.message || error}`;
       this.scopeItems = [];
+      this.cachedMessages = [];
     } finally {
       this.loading = false;
       this._onDidChangeTreeData.fire(undefined);

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -13,6 +13,7 @@ import {
   ChatEmptyItem,
   ChatLoadingItem,
   ChatErrorItem,
+  ChatLoadMoreItem,
   MessageScope,
   scopeLabel
 } from './ChatInboxTreeItems';
@@ -38,7 +39,7 @@ interface PersistedState {
   submissionTitleFilter?: string;
 }
 
-type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem;
+type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem | ChatLoadMoreItem;
 
 export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeItem> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<AnyTreeItem | undefined | void>();
@@ -53,9 +54,22 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   private loading = false;
   private loadError: string | undefined;
   private scopeItems: ChatScopeItem[] = [];
-  /** Last raw inbox payload, kept so we can rebuild scope items without
-   *  re-fetching when local read-state changes optimistically. */
+  /** Last assembled inbox payload (= unfilteredBase ± submission filter
+   *  results) used by groupMessages + buildScopeItems. */
   private cachedMessages: MessageList[] = [];
+  /** Pristine accumulating page-1+ result of the unfiltered /messages query.
+   *  Grows as the user clicks "Load more". Used as the source for assembled. */
+  private unfilteredBase: MessageList[] = [];
+  /** X-Total-Count from the unfiltered /messages query — drives Load more
+   *  visibility. */
+  private unfilteredTotal: number | undefined;
+  /** How many unfiltered messages we've fetched (effectively the next skip). */
+  private unfilteredFetched = 0;
+  /** Page size for the unfiltered inbox fetch + each Load more click. */
+  private static readonly INBOX_PAGE_SIZE = 200;
+  /** Set during loadMoreInboxMessages so the user can't double-click and fan
+   *  out duplicate skip values. */
+  private loadingMore = false;
   private currentUserId?: string;
   private userScopes?: import('../../../types/generated').UserScopes;
   private userScopesPromise?: Promise<void>;
@@ -177,12 +191,11 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       m => !m.is_read && m.author_id !== this.currentUserId
     );
     if (unread.length > 0) {
-      for (const m of unread) {
-        m.is_read = true;
-      }
+      const ids = unread.map(m => m.id);
+      this.markIdsReadLocally(ids);
       this.rebuildScopeItemsFromCache();
       // Fire-and-forget but throttled — see markMessagesReadOnBackend.
-      void this.markMessagesReadOnBackend(unread.map(m => m.id));
+      void this.markMessagesReadOnBackend(ids);
     }
 
     await this.messagesProvider.showMessages(ctx);
@@ -227,11 +240,10 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   async markThreadRead(threadItem: ChatThreadItem): Promise<void> {
     const unread = threadItem.thread.messages.filter(m => !m.is_read && m.author_id !== this.currentUserId);
     if (unread.length === 0) { return; }
-    for (const m of unread) {
-      m.is_read = true;
-    }
+    const ids = unread.map(m => m.id);
+    this.markIdsReadLocally(ids);
     this.rebuildScopeItemsFromCache();
-    await this.markMessagesReadOnBackend(unread.map(m => m.id));
+    await this.markMessagesReadOnBackend(ids);
   }
 
   async markScopeRead(scopeItem: ChatScopeItem): Promise<void> {
@@ -239,11 +251,26 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       t.messages.filter(m => !m.is_read && m.author_id !== this.currentUserId)
     );
     if (unread.length === 0) { return; }
-    for (const m of unread) {
-      m.is_read = true;
-    }
+    const ids = unread.map(m => m.id);
+    this.markIdsReadLocally(ids);
     this.rebuildScopeItemsFromCache();
-    await this.markMessagesReadOnBackend(unread.map(m => m.id));
+    await this.markMessagesReadOnBackend(ids);
+  }
+
+  /** Sets is_read=true on every cached copy of the given message ids — both
+   *  in cachedMessages and in unfilteredBase. They share refs for most
+   *  scopes, but diverge for submission_group when the filter is active, so
+   *  marking only cachedMessages would lose the read state next time we
+   *  re-assemble from base (e.g. when the filter is cleared). */
+  private markIdsReadLocally(ids: string[]): void {
+    if (ids.length === 0) { return; }
+    const set = new Set(ids);
+    for (const m of this.cachedMessages) {
+      if (set.has(m.id)) { m.is_read = true; }
+    }
+    for (const m of this.unfilteredBase) {
+      if (set.has(m.id)) { m.is_read = true; }
+    }
   }
 
   // ----- Submission-group filters -----
@@ -347,6 +374,64 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   }
 
   /**
+   * Builds the assembled cachedMessages from unfilteredBase (+ filtered
+   * submission_group slice when the submission filter is on), then refreshes
+   * the scope items + tree.
+   */
+  private async applyAssembledFromBase(): Promise<void> {
+    let assembled = this.unfilteredBase;
+    if (this.hasSubmissionFilter()) {
+      try {
+        const filteredSub = await this.fetchFilteredSubmissionMessages();
+        const nonSub = assembled.filter(m => m.scope !== 'submission_group');
+        assembled = [...nonSub, ...filteredSub];
+      } catch (err) {
+        console.warn('[ChatInbox] Failed to fetch filtered submission messages, falling back to unfiltered:', err);
+      }
+    }
+    this.cachedMessages = assembled;
+    const grouped = this.groupMessages(this.cachedMessages);
+    await this.resolveLabels(grouped);
+    this.scopeItems = this.buildScopeItems(grouped);
+  }
+
+  /** Fetches the next page of unfiltered messages and merges into the cache. */
+  async loadMoreInboxMessages(): Promise<void> {
+    if (this.loadingMore) { return; }
+    if (this.unfilteredTotal !== undefined && this.unfilteredFetched >= this.unfilteredTotal) {
+      return;
+    }
+    this.loadingMore = true;
+    try {
+      const page = await this.api.listMessagesPage({
+        skip: this.unfilteredFetched,
+        limit: ChatInboxTreeProvider.INBOX_PAGE_SIZE
+      });
+      // Dedupe in case a WS-triggered insert added a message we'd otherwise
+      // see again at this offset.
+      const seen = new Set(this.unfilteredBase.map(m => m.id));
+      for (const m of page.items) {
+        if (!seen.has(m.id)) {
+          this.unfilteredBase.push(m);
+          seen.add(m.id);
+        }
+      }
+      // Track skip on the request size, not the dedupe survivors, so we don't
+      // get stuck re-querying the same offset forever if the backend grew.
+      this.unfilteredFetched += page.items.length;
+      this.unfilteredTotal = page.total;
+
+      await this.applyAssembledFromBase();
+    } catch (err: any) {
+      vscode.window.showErrorMessage(`Failed to load more messages: ${err?.message || err}`);
+    } finally {
+      this.loadingMore = false;
+      this._onDidChangeTreeData.fire(undefined);
+      this._onDidChangeUnread.fire(this.getTotalUnread());
+    }
+  }
+
+  /**
    * Posts mark-read for many message ids without flooding the backend.
    * - Caps in-flight requests at MARK_READ_CONCURRENCY (workers).
    * - Suppresses WS-driven reloads while it runs, so each backend
@@ -398,8 +483,16 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     if (!element) {
       if (this.loading) { return [new ChatLoadingItem()]; }
       if (this.loadError) { return [new ChatErrorItem(this.loadError)]; }
-      if (this.scopeItems.length === 0) { return [new ChatEmptyItem(this.unreadOnly ? 'No unread messages.' : 'No messages.')]; }
-      return this.scopeItems;
+      const items: AnyTreeItem[] = this.scopeItems.length === 0
+        ? [new ChatEmptyItem(this.unreadOnly ? 'No unread messages.' : 'No messages.')]
+        : [...this.scopeItems];
+      // Show "Load more" when the backend reported more unfiltered messages
+      // than we've fetched. Keep it visible regardless of unread/filter state
+      // so the user can always pull the rest down.
+      if (this.unfilteredTotal !== undefined && this.unfilteredFetched < this.unfilteredTotal) {
+        items.push(new ChatLoadMoreItem(this.unfilteredFetched, this.unfilteredTotal));
+      }
+      return items;
     }
 
     if (element instanceof ChatScopeItem) {
@@ -423,43 +516,28 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     }
 
     try {
-      const [identity, messages, scopes] = await Promise.all([
+      // Page 1 only — Load more (rendered as a tree leaf) walks the rest.
+      const [identity, page, scopes] = await Promise.all([
         this.api.getCurrentUser().catch(() => undefined),
-        // Always fetch the unfiltered inbox so the unread-only toggle can flip
-        // client-side without re-paginating the backend. buildScopeItems +
-        // rebuildScopeItemsFromCache handle the filtering on the cached array.
-        this.api.listMessages({}),
+        this.api.listMessagesPage({ skip: 0, limit: ChatInboxTreeProvider.INBOX_PAGE_SIZE }),
         this.api.getUserScopes().catch(() => undefined)
       ]);
       this.currentUserId = identity?.id;
       this.userScopes = scopes;
       this.maybeSubscribeUserChannels();
 
-      let assembled = messages || [];
+      this.unfilteredBase = page.items;
+      this.unfilteredTotal = page.total;
+      this.unfilteredFetched = page.items.length;
 
-      // When submission-group filters are active, swap the unfiltered
-      // submission_group slice for the backend-filtered version. course_id is
-      // not always populated on submission_group messages, so client-side
-      // filtering by course_id is unreliable — we rely on the backend's
-      // course_id_all_messages + tag_scope filters instead.
-      if (this.hasSubmissionFilter()) {
-        try {
-          const filteredSub = await this.fetchFilteredSubmissionMessages();
-          const nonSub = assembled.filter(m => m.scope !== 'submission_group');
-          assembled = [...nonSub, ...filteredSub];
-        } catch (err) {
-          console.warn('[ChatInbox] Failed to fetch filtered submission messages, falling back to unfiltered:', err);
-        }
-      }
-
-      this.cachedMessages = assembled;
-      const grouped = this.groupMessages(this.cachedMessages);
-      await this.resolveLabels(grouped);
-      this.scopeItems = this.buildScopeItems(grouped);
+      await this.applyAssembledFromBase();
     } catch (error: any) {
       this.loadError = `Failed to load messages: ${error?.message || error}`;
       this.scopeItems = [];
       this.cachedMessages = [];
+      this.unfilteredBase = [];
+      this.unfilteredTotal = undefined;
+      this.unfilteredFetched = 0;
     } finally {
       this.loading = false;
       this._onDidChangeTreeData.fire(undefined);

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -331,7 +331,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
   /**
    * When submission-group filters are active, fetches the matching messages
-   * via the backend (scope=submission_group + course_id_all_messages=true +
+   * via the backend (scope=submission_group +
    * tag_scope=...). Multi-course is fanned out per course because the backend
    * takes one course_id at a time. Returns deduped results.
    */
@@ -351,7 +351,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       this.api.listMessages({
         scope: 'submission_group',
         course_id: courseId,
-        course_id_all_messages: true,
         ...(tagScope ? { tag_scope: tagScope } : {})
       })
     );
@@ -677,10 +676,18 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
     for (const scope of SCOPE_ORDER) {
       const byTarget = grouped.get(scope);
-      if (!byTarget || byTarget.size === 0) { continue; }
+
+      // Submission Groups stays visible when its filter is active, even if
+      // the filtered fetch returned zero messages — otherwise the user has
+      // nowhere to right-click to clear the filter.
+      const filterActive = scope === 'submission_group' && (
+        this.submissionCourseFilter.size > 0 || this.submissionTitleFilter.length > 0
+      );
+
+      if ((!byTarget || byTarget.size === 0) && !filterActive) { continue; }
 
       const threads: ChatThread[] = [];
-      for (const [targetId, msgs] of byTarget) {
+      for (const [targetId, msgs] of (byTarget ?? new Map<string, MessageList[]>())) {
         // Submission-group filters are now enforced server-side: when the
         // filter is active, the cached payload's submission_group slice is
         // already the result of a filtered fetch, so nothing else to do here.
@@ -705,13 +712,9 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         });
       }
 
-      const filterActive = scope === 'submission_group' && (
-        this.submissionCourseFilter.size > 0 || this.submissionTitleFilter.length > 0
-      );
-
-      // Hide scopes with no matching threads — except keep submission_group
-      // visible when filters are active, otherwise the user can't right-click
-      // to clear filters that strip everything.
+      // Already handled the empty-and-no-filter case above; here we just
+      // need to skip non-submission-group empty scopes (which can't happen
+      // given the early continue, but keep belt-and-braces for clarity).
       if (threads.length === 0 && !filterActive) { continue; }
 
       threads.sort((a, b) => {

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -14,7 +14,6 @@ import {
   ChatLoadingItem,
   ChatErrorItem,
   ChatLoadMoreItem,
-  ChatFilterChipItem,
   ChatCourseGroupItem,
   MessageScope,
   scopeLabel
@@ -50,10 +49,9 @@ const STATE_KEY = 'computor.chat.inbox.state';
 interface PersistedState {
   expandedScopes: MessageScope[];
   unreadOnly: boolean;
-  submissionCourseFilter?: string[];
 }
 
-type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem | ChatLoadMoreItem | ChatFilterChipItem | ChatCourseGroupItem;
+type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem | ChatLoadMoreItem | ChatCourseGroupItem;
 
 interface ScopeFetchState {
   /** Accumulated messages for this scope; grows on each Load more. */
@@ -120,8 +118,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   // Persisted UI state
   private expandedScopes: Set<MessageScope> = new Set();
   private unreadOnly = false;
-  /** Course IDs to keep when rendering the submission_group scope. Empty = all. */
-  private submissionCourseFilter: Set<string> = new Set();
 
   // Label caches keyed by id
   private readonly orgLabels = new Map<string, string>();
@@ -306,84 +302,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     }
   }
 
-  // ----- Submission-group filters -----
-
-  /** Returns every course the user has access to as a candidate for the
-   *  Submission Groups filter. The submission_group slice is now lazy-fetched
-   *  per course on expand, so picking from the cached payload would only
-   *  surface courses the user has already opened — which is exactly the
-   *  opposite of what the filter is for. */
-  getSubmissionFilterCourses(): Array<{ id: string; label: string; selected: boolean }> {
-    const ids = new Set<string>();
-    const inner = this.courseScopeStates.get('submission_group');
-    if (inner) {
-      for (const id of inner.keys()) { ids.add(id); }
-    }
-    // Make sure currently-selected filter ids are always shown, even if they
-    // aren't in the accessible course list anymore (e.g. role revoked).
-    for (const id of this.submissionCourseFilter) { ids.add(id); }
-    const list = Array.from(ids).map(id => ({
-      id,
-      label: this.courseLabels.get(id) || shortId(id),
-      selected: this.submissionCourseFilter.has(id)
-    }));
-    list.sort((a, b) => a.label.localeCompare(b.label));
-    return list;
-  }
-
-  setSubmissionCourseFilter(ids: string[]): void {
-    this.submissionCourseFilter = new Set(ids);
-    void this.persistState();
-    this.applySubmissionFiltersContextKey();
-    // Filter is enforced server-side, so re-fetch the submission-group slice
-    // with the new params; non-sub scopes don't change.
-    this.refresh();
-  }
-
-  removeSubmissionCourse(courseId: string): void {
-    if (!this.submissionCourseFilter.has(courseId)) { return; }
-    this.submissionCourseFilter.delete(courseId);
-    void this.persistState();
-    this.applySubmissionFiltersContextKey();
-    this.refresh();
-  }
-
-  clearSubmissionFilters(): void {
-    if (this.submissionCourseFilter.size === 0) { return; }
-    this.submissionCourseFilter = new Set();
-    void this.persistState();
-    this.applySubmissionFiltersContextKey();
-    this.refresh();
-  }
-
-  private hasSubmissionFilter(): boolean {
-    return this.submissionCourseFilter.size > 0;
-  }
-
-  // (legacy fetchFilteredSubmissionMessages removed — fetchScopePage now
-  //  handles the submission_group filter case with bounded pagination.)
-
-  private applySubmissionFiltersContextKey(): void {
-    void vscode.commands.executeCommand('setContext', 'computor.chat.submissionFiltersActive', this.hasSubmissionFilter());
-  }
-
-  /** One chip per active course filter; clicking a chip removes that course
-   *  from the filter set (and triggers a refresh of the submission_group
-   *  slice). Empty array when no filter is active. */
-  private buildSubmissionFilterChips(): ChatFilterChipItem[] {
-    const chips: ChatFilterChipItem[] = [];
-    for (const courseId of this.submissionCourseFilter) {
-      const label = this.courseLabels.get(courseId) || shortId(courseId);
-      chips.push(new ChatFilterChipItem(
-        `Course: ${label}`,
-        `Click to remove "${label}" from the Submission Groups filter.`,
-        'computor.chat.removeSubmissionCourse',
-        [courseId]
-      ));
-    }
-    return chips;
-  }
-
   /** Fetches one page for a non-course-grouped scope. Course-grouped scopes
    *  use per-course requests instead — see getCourseGroupChildren and
    *  loadMoreForCourseScope. */
@@ -545,11 +463,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
     if (element instanceof ChatScopeItem) {
       const items: AnyTreeItem[] = [];
-      // Submission Groups gets per-active-filter chips up top — click a chip
-      // to remove that one filter, mirroring the examples-tree pattern.
-      if (element.scope === 'submission_group') {
-        items.push(...this.buildSubmissionFilterChips());
-      }
       if (isCourseGroupedScope(element.scope)) {
         items.push(...this.buildCourseGroupItems(element.scope));
         return items;
@@ -572,15 +485,11 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     return [];
   }
 
-  /** One ChatCourseGroupItem per course in the user's scope set, filtered by
-   *  any active submission_group course filter. */
+  /** One ChatCourseGroupItem per course the user has access to. */
   private buildCourseGroupItems(scope: MessageScope): ChatCourseGroupItem[] {
     const inner = this.courseScopeStates.get(scope);
     if (!inner) { return []; }
-    const filterActive = scope === 'submission_group' && this.submissionCourseFilter.size > 0;
-    const courseIds = Array.from(inner.keys()).filter(id =>
-      !filterActive || this.submissionCourseFilter.has(id)
-    );
+    const courseIds = Array.from(inner.keys());
     // Sort: courses with unread first, then alphabetical by label.
     const decorated = courseIds.map(id => {
       const state = inner.get(id)!;
@@ -912,34 +821,21 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     const result: ChatScopeItem[] = [];
 
     for (const scope of SCOPE_ORDER) {
-      const filterActive = scope === 'submission_group' && this.submissionCourseFilter.size > 0;
-
       // Course-grouped scopes always render — children are course nodes, not
       // threads, so the row stays collapsible even when no messages have been
       // pulled yet.
       if (isCourseGroupedScope(scope)) {
         const inner = this.courseScopeStates.get(scope);
         if (!inner || inner.size === 0) { continue; }
-        // Filter the visible course set when the user has narrowed the
-        // submission_group scope to specific courses.
-        const courseIds = Array.from(inner.keys()).filter(id => {
-          if (scope === 'submission_group' && filterActive) {
-            return this.submissionCourseFilter.has(id);
-          }
-          return true;
-        });
-        // Aggregate unread across the loaded slices of every course bucket.
         let totalUnread = 0;
-        for (const id of courseIds) {
-          const state = inner.get(id);
-          if (!state) { continue; }
+        for (const state of inner.values()) {
           for (const m of state.messages) {
             if (!m.is_read && m.author_id !== this.currentUserId) { totalUnread += 1; }
           }
         }
-        if (this.unreadOnly && totalUnread === 0 && !filterActive) { continue; }
+        if (this.unreadOnly && totalUnread === 0) { continue; }
         const expanded = this.expandedScopes.has(scope) || totalUnread > 0;
-        result.push(new ChatScopeItem(scope, [], totalUnread, expanded, filterActive, courseIds.length));
+        result.push(new ChatScopeItem(scope, [], totalUnread, expanded, inner.size));
         continue;
       }
 
@@ -984,7 +880,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
       const totalUnread = threads.reduce((acc, t) => acc + t.unreadCount, 0);
       const expanded = this.expandedScopes.has(scope) || totalUnread > 0;
-      result.push(new ChatScopeItem(scope, threads, totalUnread, expanded, false));
+      result.push(new ChatScopeItem(scope, threads, totalUnread, expanded));
     }
 
     return result;
@@ -1249,22 +1145,17 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         if (typeof stored.unreadOnly === 'boolean') {
           this.unreadOnly = stored.unreadOnly;
         }
-        if (Array.isArray(stored.submissionCourseFilter)) {
-          this.submissionCourseFilter = new Set(stored.submissionCourseFilter);
-        }
       }
     } catch (err) {
       console.warn('[ChatInbox] Failed to load persisted state:', err);
     }
     void vscode.commands.executeCommand('setContext', 'computor.chat.unreadOnly', this.unreadOnly);
-    this.applySubmissionFiltersContextKey();
   }
 
   private async persistState(): Promise<void> {
     const state: PersistedState = {
       expandedScopes: Array.from(this.expandedScopes),
-      unreadOnly: this.unreadOnly,
-      submissionCourseFilter: Array.from(this.submissionCourseFilter)
+      unreadOnly: this.unreadOnly
     };
     try {
       await this.context.globalState.update(STATE_KEY, state);

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -15,9 +15,23 @@ import {
   ChatErrorItem,
   ChatLoadMoreItem,
   ChatFilterChipItem,
+  ChatCourseGroupItem,
   MessageScope,
   scopeLabel
 } from './ChatInboxTreeItems';
+
+/** Scopes that are rendered as Course → threads inside the inbox tree.
+ *  All other scopes keep the original flat-per-scope rendering. */
+const COURSE_GROUPED_SCOPES = new Set<MessageScope>([
+  'submission_group',
+  'course',
+  'course_content',
+  'course_group'
+]);
+
+function isCourseGroupedScope(scope: MessageScope): boolean {
+  return COURSE_GROUPED_SCOPES.has(scope);
+}
 
 const SCOPE_ORDER: MessageScope[] = [
   'user',
@@ -39,7 +53,7 @@ interface PersistedState {
   submissionCourseFilter?: string[];
 }
 
-type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem | ChatLoadMoreItem | ChatFilterChipItem;
+type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem | ChatLoadMoreItem | ChatFilterChipItem | ChatCourseGroupItem;
 
 interface ScopeFetchState {
   /** Accumulated messages for this scope; grows on each Load more. */
@@ -69,14 +83,23 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
    *  + buildScopeItems and shared by mark-read mutations. Rebuilt from
    *  scopeFetchStates whenever they change. */
   private cachedMessages: MessageList[] = [];
-  /** Per-scope pagination + accumulation. Each scope has its own GET window
-   *  on the backend, so Load more is rendered inside the scope it advances. */
+  /** Per-scope pagination + accumulation for non-course-grouped scopes
+   *  (user / course_member / course_family / organization / global). */
   private scopeFetchStates: Map<MessageScope, ScopeFetchState> = new Map();
+  /** Per-(scope, courseId) pagination + accumulation for the course-grouped
+   *  scopes (submission_group, course, course_content, course_group). */
+  private courseScopeStates: Map<MessageScope, Map<string, ScopeFetchState>> = new Map();
+  /** Course nodes the user has expanded at least once — used both to drive
+   *  initial-collapse-state and to know whether to lazy-fetch on render. */
+  private expandedCourseGroups: Set<string> = new Set();
   /** Page size for every per-scope GET (initial + each Load more click). */
   private static readonly SCOPE_PAGE_SIZE = 200;
   /** Set of scopes whose Load more is in-flight, so a double-click doesn't
    *  fan out duplicate skip values. */
   private scopeLoadingMore: Set<MessageScope> = new Set();
+  /** Same idea but keyed `${scope}::${courseId}` for the per-course
+   *  pagination. */
+  private courseScopeLoadingMore: Set<string> = new Set();
   private currentUserId?: string;
   private userScopes?: import('../../../types/generated').UserScopes;
   private userScopesPromise?: Promise<void>;
@@ -262,7 +285,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   }
 
   /** Sets is_read=true on every cached copy of the given message ids, across
-   *  cachedMessages and every per-scope state's messages array. */
+   *  cachedMessages and every per-scope / per-course state's messages array. */
   private markIdsReadLocally(ids: string[]): void {
     if (ids.length === 0) { return; }
     const set = new Set(ids);
@@ -274,20 +297,31 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         if (set.has(m.id)) { m.is_read = true; }
       }
     }
+    for (const inner of this.courseScopeStates.values()) {
+      for (const state of inner.values()) {
+        for (const m of state.messages) {
+          if (set.has(m.id)) { m.is_read = true; }
+        }
+      }
+    }
   }
 
   // ----- Submission-group filters -----
 
-  /** Returns the courses that currently have at least one submission_group
-   *  message in the cached inbox payload, with resolved labels. */
+  /** Returns every course the user has access to as a candidate for the
+   *  Submission Groups filter. The submission_group slice is now lazy-fetched
+   *  per course on expand, so picking from the cached payload would only
+   *  surface courses the user has already opened — which is exactly the
+   *  opposite of what the filter is for. */
   getSubmissionFilterCourses(): Array<{ id: string; label: string; selected: boolean }> {
     const ids = new Set<string>();
-    for (const m of this.cachedMessages) {
-      if (m.scope !== 'submission_group') { continue; }
-      if (typeof m.course_id === 'string' && m.course_id) {
-        ids.add(m.course_id);
-      }
+    const inner = this.courseScopeStates.get('submission_group');
+    if (inner) {
+      for (const id of inner.keys()) { ids.add(id); }
     }
+    // Make sure currently-selected filter ids are always shown, even if they
+    // aren't in the accessible course list anymore (e.g. role revoked).
+    for (const id of this.submissionCourseFilter) { ids.add(id); }
     const list = Array.from(ids).map(id => ({
       id,
       label: this.courseLabels.get(id) || shortId(id),
@@ -350,41 +384,24 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     return chips;
   }
 
-  /**
-   * Fetches the first page for a single scope. For submission_group with the
-   * course filter active, fans out one request per selected course and sums
-   * the totals; otherwise a single GET /messages?scope=...&skip&limit.
-   */
+  /** Fetches one page for a non-course-grouped scope. Course-grouped scopes
+   *  use per-course requests instead — see getCourseGroupChildren and
+   *  loadMoreForCourseScope. */
   private async fetchScopePage(scope: MessageScope, skip: number, limit: number): Promise<{ items: MessageList[]; total: number }> {
-    if (scope === 'submission_group' && this.hasSubmissionFilter()) {
-      const courseIds = Array.from(this.submissionCourseFilter);
-      const fetches = courseIds.map(courseId =>
-        this.api.listMessagesPage({ scope: 'submission_group', course_id: courseId, skip, limit })
-      );
-      const results = await Promise.all(fetches);
-      const seen = new Set<string>();
-      const items: MessageList[] = [];
-      let total = 0;
-      for (const r of results) {
-        total += r.total;
-        for (const m of r.items) {
-          if (!seen.has(m.id)) {
-            seen.add(m.id);
-            items.push(m);
-          }
-        }
-      }
-      return { items, total };
-    }
     return await this.api.listMessagesPage({ scope, skip, limit });
   }
 
   /** Rebuilds cachedMessages as the flat union of every scope's accumulated
-   *  messages and refreshes the tree. */
+   *  messages (per-scope + per-course) and refreshes the tree. */
   private async rebuildAssembled(): Promise<void> {
     const flat: MessageList[] = [];
     for (const state of this.scopeFetchStates.values()) {
       flat.push(...state.messages);
+    }
+    for (const inner of this.courseScopeStates.values()) {
+      for (const state of inner.values()) {
+        flat.push(...state.messages);
+      }
     }
     this.cachedMessages = flat;
     const grouped = this.groupMessages(this.cachedMessages);
@@ -418,6 +435,53 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       this.scopeLoadingMore.delete(scope);
       this._onDidChangeTreeData.fire(undefined);
       this._onDidChangeUnread.fire(this.getTotalUnread());
+    }
+  }
+
+  /** Fetches the next page for a (scope, course) bucket and appends to its
+   *  per-course state. Used by the per-course Load more rendered inside each
+   *  ChatCourseGroupItem. */
+  async loadMoreForCourseScope(scope: MessageScope, courseId: string): Promise<void> {
+    const key = `${scope}::${courseId}`;
+    if (this.courseScopeLoadingMore.has(key)) { return; }
+    const inner = this.courseScopeStates.get(scope);
+    const state = inner?.get(courseId);
+    if (!state || state.total < 0 || state.fetched >= state.total) { return; }
+    this.courseScopeLoadingMore.add(key);
+    try {
+      const next = await this.api.listMessagesPage({
+        scope,
+        course_id: courseId,
+        skip: state.fetched,
+        limit: ChatInboxTreeProvider.SCOPE_PAGE_SIZE
+      });
+      const seen = new Set(state.messages.map(m => m.id));
+      for (const m of next.items) {
+        if (!seen.has(m.id)) {
+          state.messages.push(m);
+          seen.add(m.id);
+        }
+      }
+      state.fetched += next.items.length;
+      state.total = Math.max(state.total, next.total);
+      await this.rebuildAssembled();
+    } catch (err: any) {
+      vscode.window.showErrorMessage(`Failed to load more messages: ${err?.message || err}`);
+    } finally {
+      this.courseScopeLoadingMore.delete(key);
+      this._onDidChangeTreeData.fire(undefined);
+      this._onDidChangeUnread.fire(this.getTotalUnread());
+    }
+  }
+
+  /** Track expand/collapse for a course node so a refresh can keep the user's
+   *  open courses open. */
+  recordCourseGroupExpanded(scope: MessageScope, courseId: string, expanded: boolean): void {
+    const key = `${scope}::${courseId}`;
+    if (expanded) {
+      this.expandedCourseGroups.add(key);
+    } else {
+      this.expandedCourseGroups.delete(key);
     }
   }
 
@@ -486,6 +550,10 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       if (element.scope === 'submission_group') {
         items.push(...this.buildSubmissionFilterChips());
       }
+      if (isCourseGroupedScope(element.scope)) {
+        items.push(...this.buildCourseGroupItems(element.scope));
+        return items;
+      }
       items.push(...element.threads.map(t => new ChatThreadItem(t)));
       // Per-scope Load more: shown as the last child when the backend
       // reports more messages for this scope than we've pulled. Hidden when
@@ -497,7 +565,131 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       return items;
     }
 
+    if (element instanceof ChatCourseGroupItem) {
+      return await this.getCourseGroupChildren(element);
+    }
+
     return [];
+  }
+
+  /** One ChatCourseGroupItem per course in the user's scope set, filtered by
+   *  any active submission_group course filter. */
+  private buildCourseGroupItems(scope: MessageScope): ChatCourseGroupItem[] {
+    const inner = this.courseScopeStates.get(scope);
+    if (!inner) { return []; }
+    const filterActive = scope === 'submission_group' && this.submissionCourseFilter.size > 0;
+    const courseIds = Array.from(inner.keys()).filter(id =>
+      !filterActive || this.submissionCourseFilter.has(id)
+    );
+    // Sort: courses with unread first, then alphabetical by label.
+    const decorated = courseIds.map(id => {
+      const state = inner.get(id)!;
+      const unread = state.messages.reduce(
+        (acc, m) => acc + ((!m.is_read && m.author_id !== this.currentUserId) ? 1 : 0),
+        0
+      );
+      const threadCount = new Set(
+        state.messages.map(m => this.targetIdFor(scope, m) ?? '__none__')
+      ).size;
+      return {
+        id,
+        label: this.courseLabels.get(id) || shortId(id),
+        unread,
+        threadCount,
+        // total === -1 means we haven't fetched yet — show the "click to load" hint
+        // by reporting hasMore=false until expand triggers a fetch.
+        hasMore: state.total >= 0 && state.fetched < state.total
+      };
+    });
+    decorated.sort((a, b) => {
+      if ((b.unread > 0 ? 1 : 0) !== (a.unread > 0 ? 1 : 0)) {
+        return (b.unread > 0 ? 1 : 0) - (a.unread > 0 ? 1 : 0);
+      }
+      return a.label.localeCompare(b.label);
+    });
+    return decorated.map(d => {
+      const expanded = this.expandedCourseGroups.has(`${scope}::${d.id}`) || d.unread > 0;
+      return new ChatCourseGroupItem(
+        scope,
+        d.id,
+        d.label,
+        d.unread,
+        d.threadCount,
+        d.hasMore,
+        expanded
+      );
+    });
+  }
+
+  /** Lazy-fetch the first page on first expand, then return threads + a
+   *  per-course Load more. */
+  private async getCourseGroupChildren(element: ChatCourseGroupItem): Promise<AnyTreeItem[]> {
+    const { scope, courseId } = element;
+    const inner = this.courseScopeStates.get(scope);
+    const state = inner?.get(courseId);
+    if (!inner || !state) { return []; }
+    this.expandedCourseGroups.add(`${scope}::${courseId}`);
+
+    // First-time fetch: state.total === -1 means we haven't asked the backend
+    // for this (scope, course) yet. Pull the first page now.
+    if (state.total < 0) {
+      try {
+        const page = await this.api.listMessagesPage({
+          scope,
+          course_id: courseId,
+          skip: 0,
+          limit: ChatInboxTreeProvider.SCOPE_PAGE_SIZE
+        });
+        state.messages = page.items;
+        state.fetched = page.items.length;
+        state.total = page.total;
+        await this.rebuildAssembled();
+        this._onDidChangeUnread.fire(this.getTotalUnread());
+      } catch (err: any) {
+        return [new ChatErrorItem(`Failed to load messages: ${err?.message || err}`)];
+      }
+    }
+
+    const items: AnyTreeItem[] = [];
+    // Group this course's messages into threads by target id.
+    const byTarget = new Map<string, MessageList[]>();
+    for (const m of state.messages) {
+      const targetId = this.targetIdFor(scope, m) ?? '__none__';
+      if (!byTarget.has(targetId)) { byTarget.set(targetId, []); }
+      byTarget.get(targetId)!.push(m);
+    }
+    const threads: ChatThread[] = [];
+    for (const [targetId, msgs] of byTarget) {
+      const sortedMessages = msgs.slice().sort((a, b) => compareCreated(a, b));
+      const lastMessage = sortedMessages[sortedMessages.length - 1];
+      const unreadCount = msgs.filter(m => !m.is_read && m.author_id !== this.currentUserId).length;
+      if (this.unreadOnly && unreadCount === 0) { continue; }
+      const { title, subtitle } = this.threadLabels(scope, targetId === '__none__' ? null : targetId, msgs);
+      threads.push({
+        scope,
+        targetId: targetId === '__none__' ? null : targetId,
+        title,
+        subtitle,
+        lastMessage,
+        unreadCount,
+        messageCount: msgs.length,
+        messages: sortedMessages
+      });
+    }
+    threads.sort((a, b) => {
+      if ((b.unreadCount > 0 ? 1 : 0) !== (a.unreadCount > 0 ? 1 : 0)) {
+        return (b.unreadCount > 0 ? 1 : 0) - (a.unreadCount > 0 ? 1 : 0);
+      }
+      return compareThreadRecency(b, a);
+    });
+    items.push(...threads.map(t => new ChatThreadItem(t)));
+    if (state.fetched < state.total) {
+      items.push(new ChatLoadMoreItem(scope, state.fetched, state.total, courseId));
+    }
+    if (items.length === 0) {
+      items.push(new ChatEmptyItem('No messages.'));
+    }
+    return items;
   }
 
   // ----- Internals -----
@@ -525,9 +717,15 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       this.userScopes = scopes;
       this.maybeSubscribeUserChannels();
 
+      // For non-course-grouped scopes, fetch the first page in parallel.
+      // Course-grouped scopes (submission_group / course / course_content /
+      // course_group) skip the per-scope fan-out — a chat with even a few
+      // courses produces hundreds of submission_group threads, so we lazy-load
+      // per-course on tree expand instead.
+      const flatScopes = SCOPE_ORDER.filter(s => !isCourseGroupedScope(s));
       const newStates = new Map<MessageScope, ScopeFetchState>();
       const pageResults = await Promise.all(
-        SCOPE_ORDER.map(async scope => {
+        flatScopes.map(async scope => {
           try {
             const page = await this.fetchScopePage(scope, 0, ChatInboxTreeProvider.SCOPE_PAGE_SIZE);
             return { scope, page };
@@ -546,12 +744,36 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       }
       this.scopeFetchStates = newStates;
 
+      // Seed the per-(scope, course) maps from the user's accessible courses.
+      // Each entry stays empty (`fetched: 0, total: -1`) until the user expands
+      // the course node, at which point getChildren triggers the first fetch.
+      const courseIds = scopes?.course ? Object.keys(scopes.course) : [];
+      const newCourseStates = new Map<MessageScope, Map<string, ScopeFetchState>>();
+      for (const scope of SCOPE_ORDER) {
+        if (!isCourseGroupedScope(scope)) { continue; }
+        const inner = new Map<string, ScopeFetchState>();
+        // Preserve any state we already had so an in-flight Load more isn't
+        // erased by a parallel reload.
+        const previous = this.courseScopeStates.get(scope);
+        for (const courseId of courseIds) {
+          const prev = previous?.get(courseId);
+          inner.set(courseId, prev ?? { messages: [], fetched: 0, total: -1 });
+        }
+        newCourseStates.set(scope, inner);
+      }
+      this.courseScopeStates = newCourseStates;
+
+      // Resolve labels for every accessible course up front, so the
+      // ChatCourseGroupItem rows can show real titles instead of short ids.
+      await Promise.all(courseIds.map(id => this.resolveCourseLabelLazy(id).catch(() => undefined)));
+
       await this.rebuildAssembled();
     } catch (error: any) {
       this.loadError = `Failed to load messages: ${error?.message || error}`;
       this.scopeItems = [];
       this.cachedMessages = [];
       this.scopeFetchStates.clear();
+      this.courseScopeStates.clear();
     } finally {
       this.loading = false;
       this._onDidChangeTreeData.fire(undefined);
@@ -690,20 +912,42 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     const result: ChatScopeItem[] = [];
 
     for (const scope of SCOPE_ORDER) {
-      const byTarget = grouped.get(scope);
-
-      // Submission Groups stays visible when its filter is active, even if
-      // the filtered fetch returned zero messages — otherwise the user has
-      // nowhere to right-click to clear the filter.
       const filterActive = scope === 'submission_group' && this.submissionCourseFilter.size > 0;
 
-      if ((!byTarget || byTarget.size === 0) && !filterActive) { continue; }
+      // Course-grouped scopes always render — children are course nodes, not
+      // threads, so the row stays collapsible even when no messages have been
+      // pulled yet.
+      if (isCourseGroupedScope(scope)) {
+        const inner = this.courseScopeStates.get(scope);
+        if (!inner || inner.size === 0) { continue; }
+        // Filter the visible course set when the user has narrowed the
+        // submission_group scope to specific courses.
+        const courseIds = Array.from(inner.keys()).filter(id => {
+          if (scope === 'submission_group' && filterActive) {
+            return this.submissionCourseFilter.has(id);
+          }
+          return true;
+        });
+        // Aggregate unread across the loaded slices of every course bucket.
+        let totalUnread = 0;
+        for (const id of courseIds) {
+          const state = inner.get(id);
+          if (!state) { continue; }
+          for (const m of state.messages) {
+            if (!m.is_read && m.author_id !== this.currentUserId) { totalUnread += 1; }
+          }
+        }
+        if (this.unreadOnly && totalUnread === 0 && !filterActive) { continue; }
+        const expanded = this.expandedScopes.has(scope) || totalUnread > 0;
+        result.push(new ChatScopeItem(scope, [], totalUnread, expanded, filterActive, courseIds.length));
+        continue;
+      }
+
+      const byTarget = grouped.get(scope);
+      if (!byTarget || byTarget.size === 0) { continue; }
 
       const threads: ChatThread[] = [];
-      for (const [targetId, msgs] of (byTarget ?? new Map<string, MessageList[]>())) {
-        // Submission-group filters are now enforced server-side: when the
-        // filter is active, the cached payload's submission_group slice is
-        // already the result of a filtered fetch, so nothing else to do here.
+      for (const [targetId, msgs] of byTarget) {
         const sortedMessages = msgs.slice().sort((a, b) => compareCreated(a, b));
         const lastMessage = sortedMessages[sortedMessages.length - 1];
         // Exclude the user's own messages — backend doesn't auto-stamp authors
@@ -725,10 +969,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         });
       }
 
-      // Already handled the empty-and-no-filter case above; here we just
-      // need to skip non-submission-group empty scopes (which can't happen
-      // given the early continue, but keep belt-and-braces for clarity).
-      if (threads.length === 0 && !filterActive) { continue; }
+      if (threads.length === 0) { continue; }
 
       threads.sort((a, b) => {
         if ((b.unreadCount > 0 ? 1 : 0) !== (a.unreadCount > 0 ? 1 : 0)) {
@@ -739,7 +980,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
       const totalUnread = threads.reduce((acc, t) => acc + t.unreadCount, 0);
       const expanded = this.expandedScopes.has(scope) || totalUnread > 0;
-      result.push(new ChatScopeItem(scope, threads, totalUnread, expanded, filterActive));
+      result.push(new ChatScopeItem(scope, threads, totalUnread, expanded, false));
     }
 
     return result;

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -34,6 +34,8 @@ const STATE_KEY = 'computor.chat.inbox.state';
 interface PersistedState {
   expandedScopes: MessageScope[];
   unreadOnly: boolean;
+  submissionCourseFilter?: string[];
+  submissionTitleFilter?: string;
 }
 
 type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem;
@@ -74,6 +76,11 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   // Persisted UI state
   private expandedScopes: Set<MessageScope> = new Set();
   private unreadOnly = false;
+  /** Course IDs to keep when rendering the submission_group scope. Empty = all. */
+  private submissionCourseFilter: Set<string> = new Set();
+  /** Substring (case-insensitive) match against any message's title in a
+   *  submission_group thread. Empty = all. */
+  private submissionTitleFilter = '';
 
   // Label caches keyed by id
   private readonly orgLabels = new Map<string, string>();
@@ -237,6 +244,76 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     }
     this.rebuildScopeItemsFromCache();
     await this.markMessagesReadOnBackend(unread.map(m => m.id));
+  }
+
+  // ----- Submission-group filters -----
+
+  /** Returns the courses that currently have at least one submission_group
+   *  message in the cached inbox payload, with resolved labels. */
+  getSubmissionFilterCourses(): Array<{ id: string; label: string; selected: boolean }> {
+    const ids = new Set<string>();
+    for (const m of this.cachedMessages) {
+      if (m.scope !== 'submission_group') { continue; }
+      if (typeof m.course_id === 'string' && m.course_id) {
+        ids.add(m.course_id);
+      }
+    }
+    const list = Array.from(ids).map(id => ({
+      id,
+      label: this.courseLabels.get(id) || shortId(id),
+      selected: this.submissionCourseFilter.has(id)
+    }));
+    list.sort((a, b) => a.label.localeCompare(b.label));
+    return list;
+  }
+
+  setSubmissionCourseFilter(ids: string[]): void {
+    this.submissionCourseFilter = new Set(ids);
+    void this.persistState();
+    this.applySubmissionFiltersContextKey();
+    this.rebuildScopeItemsFromCache();
+  }
+
+  getSubmissionTitleFilter(): string {
+    return this.submissionTitleFilter;
+  }
+
+  setSubmissionTitleFilter(value: string): void {
+    const trimmed = (value ?? '').trim();
+    if (this.submissionTitleFilter === trimmed) { return; }
+    this.submissionTitleFilter = trimmed;
+    void this.persistState();
+    this.applySubmissionFiltersContextKey();
+    this.rebuildScopeItemsFromCache();
+  }
+
+  clearSubmissionFilters(): void {
+    if (this.submissionCourseFilter.size === 0 && this.submissionTitleFilter === '') { return; }
+    this.submissionCourseFilter = new Set();
+    this.submissionTitleFilter = '';
+    void this.persistState();
+    this.applySubmissionFiltersContextKey();
+    this.rebuildScopeItemsFromCache();
+  }
+
+  private threadMatchesSubmissionFilters(msgs: MessageList[]): boolean {
+    if (this.submissionCourseFilter.size > 0) {
+      const ok = msgs.some(m =>
+        typeof m.course_id === 'string' && this.submissionCourseFilter.has(m.course_id)
+      );
+      if (!ok) { return false; }
+    }
+    if (this.submissionTitleFilter) {
+      const needle = this.submissionTitleFilter.toLowerCase();
+      const ok = msgs.some(m => typeof m.title === 'string' && m.title.toLowerCase().includes(needle));
+      if (!ok) { return false; }
+    }
+    return true;
+  }
+
+  private applySubmissionFiltersContextKey(): void {
+    const active = this.submissionCourseFilter.size > 0 || this.submissionTitleFilter.length > 0;
+    void vscode.commands.executeCommand('setContext', 'computor.chat.submissionFiltersActive', active);
   }
 
   /**
@@ -479,6 +556,12 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
       const threads: ChatThread[] = [];
       for (const [targetId, msgs] of byTarget) {
+        // Submission-group-only filters: by parent course id, and by message
+        // title substring. Both are AND-combined; thread is kept only if at
+        // least one of its messages matches each active filter.
+        if (scope === 'submission_group' && !this.threadMatchesSubmissionFilters(msgs)) {
+          continue;
+        }
         const sortedMessages = msgs.slice().sort((a, b) => compareCreated(a, b));
         const lastMessage = sortedMessages[sortedMessages.length - 1];
         // Exclude the user's own messages — backend doesn't auto-stamp authors
@@ -500,7 +583,14 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         });
       }
 
-      if (threads.length === 0) { continue; }
+      const filterActive = scope === 'submission_group' && (
+        this.submissionCourseFilter.size > 0 || this.submissionTitleFilter.length > 0
+      );
+
+      // Hide scopes with no matching threads — except keep submission_group
+      // visible when filters are active, otherwise the user can't right-click
+      // to clear filters that strip everything.
+      if (threads.length === 0 && !filterActive) { continue; }
 
       threads.sort((a, b) => {
         if ((b.unreadCount > 0 ? 1 : 0) !== (a.unreadCount > 0 ? 1 : 0)) {
@@ -511,7 +601,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
       const totalUnread = threads.reduce((acc, t) => acc + t.unreadCount, 0);
       const expanded = this.expandedScopes.has(scope) || totalUnread > 0;
-      result.push(new ChatScopeItem(scope, threads, totalUnread, expanded));
+      result.push(new ChatScopeItem(scope, threads, totalUnread, expanded, filterActive));
     }
 
     return result;
@@ -780,17 +870,26 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         if (typeof stored.unreadOnly === 'boolean') {
           this.unreadOnly = stored.unreadOnly;
         }
+        if (Array.isArray(stored.submissionCourseFilter)) {
+          this.submissionCourseFilter = new Set(stored.submissionCourseFilter);
+        }
+        if (typeof stored.submissionTitleFilter === 'string') {
+          this.submissionTitleFilter = stored.submissionTitleFilter;
+        }
       }
     } catch (err) {
       console.warn('[ChatInbox] Failed to load persisted state:', err);
     }
     void vscode.commands.executeCommand('setContext', 'computor.chat.unreadOnly', this.unreadOnly);
+    this.applySubmissionFiltersContextKey();
   }
 
   private async persistState(): Promise<void> {
     const state: PersistedState = {
       expandedScopes: Array.from(this.expandedScopes),
-      unreadOnly: this.unreadOnly
+      unreadOnly: this.unreadOnly,
+      submissionCourseFilter: Array.from(this.submissionCourseFilter),
+      submissionTitleFilter: this.submissionTitleFilter
     };
     try {
       await this.context.globalState.update(STATE_KEY, state);

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -1057,12 +1057,13 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
     await this.ensureUserScopes();
 
+    // Always pin scope on the panel query — without it the backend matches
+    // every message that shares the target id, which leaks cross-scope
+    // messages (e.g. submission_group messages also carry course_content_id).
+    baseQuery.scope = scope;
+
     switch (scope) {
       case 'global':
-        // Global threads carry no target IDs, so /messages without a scope
-        // filter returns the user's full inbox — not just globals. Pin the
-        // scope explicitly so the panel only shows global announcements.
-        baseQuery.scope = 'global';
         readOnly = !canPostGlobal(this.userScopes);
         readOnlyReason = readOnly ? 'Only administrators can post global announcements.' : undefined;
         // wsChannel intentionally undefined — no per-target channel for global.
@@ -1093,11 +1094,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         if (!targetId) { return undefined; }
         baseQuery.course_content_id = targetId;
         basePayload.course_content_id = targetId;
-        const contentInfo = this.contentLabels.get(targetId);
-        if (contentInfo) {
-          // Course content lookup may have set the course relation; surface it for create payloads.
-          // We don't have direct course_id here unless the message carried it, so leave as is.
-        }
         wsChannel = `course_content:${targetId}`;
         break;
       }

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -64,6 +64,12 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   private readonly wsHandlerId = `chat-inbox-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   private wsReloadTimer?: ReturnType<typeof setTimeout>;
   private static readonly WS_RELOAD_DEBOUNCE_MS = 250;
+  /** Cap on concurrent mark-read API calls to avoid flooding the backend. */
+  private static readonly MARK_READ_CONCURRENCY = 4;
+  /** When we mark messages read locally, suppress WS-driven reloads for this
+   *  window — every server-side broadcast otherwise re-paginates the inbox. */
+  private static readonly MARK_READ_WS_SUPPRESS_MS = 4000;
+  private suppressWsReloadUntil = 0;
 
   // Persisted UI state
   private expandedScopes: Set<MessageScope> = new Set();
@@ -168,7 +174,8 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         m.is_read = true;
       }
       this.rebuildScopeItemsFromCache();
-      void Promise.all(unread.map(m => this.api.markMessageRead(m.id).catch(() => undefined)));
+      // Fire-and-forget but throttled — see markMessagesReadOnBackend.
+      void this.markMessagesReadOnBackend(unread.map(m => m.id));
     }
 
     await this.messagesProvider.showMessages(ctx);
@@ -217,7 +224,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       m.is_read = true;
     }
     this.rebuildScopeItemsFromCache();
-    await Promise.all(unread.map(m => this.api.markMessageRead(m.id).catch(() => undefined)));
+    await this.markMessagesReadOnBackend(unread.map(m => m.id));
   }
 
   async markScopeRead(scopeItem: ChatScopeItem): Promise<void> {
@@ -229,7 +236,49 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       m.is_read = true;
     }
     this.rebuildScopeItemsFromCache();
-    await Promise.all(unread.map(m => this.api.markMessageRead(m.id).catch(() => undefined)));
+    await this.markMessagesReadOnBackend(unread.map(m => m.id));
+  }
+
+  /**
+   * Posts mark-read for many message ids without flooding the backend.
+   * - Caps in-flight requests at MARK_READ_CONCURRENCY (workers).
+   * - Suppresses WS-driven reloads while it runs, so each backend
+   *   read:update broadcast we triggered ourselves doesn't kick off a fresh
+   *   re-paginated GET /messages of the entire inbox.
+   * - Errors per-id are swallowed (best-effort; the optimistic local state
+   *   is already applied, and the next manual refresh will re-confirm).
+   */
+  private async markMessagesReadOnBackend(ids: string[]): Promise<void> {
+    if (ids.length === 0) { return; }
+    this.suppressWsReloadUntil = Date.now() + ChatInboxTreeProvider.MARK_READ_WS_SUPPRESS_MS;
+    if (this.wsReloadTimer) {
+      clearTimeout(this.wsReloadTimer);
+      this.wsReloadTimer = undefined;
+    }
+    try {
+      let cursor = 0;
+      const workers: Promise<void>[] = [];
+      for (let w = 0; w < ChatInboxTreeProvider.MARK_READ_CONCURRENCY; w += 1) {
+        workers.push((async () => {
+          while (true) {
+            const i = cursor;
+            cursor += 1;
+            if (i >= ids.length) { return; }
+            try {
+              await this.api.markMessageRead(ids[i]!);
+            } catch {
+              // best-effort
+            }
+          }
+        })());
+      }
+      await Promise.all(workers);
+    } finally {
+      // Extend the WS suppression window slightly past now so the burst of
+      // server-side read:update broadcasts that lag behind our last request
+      // doesn't immediately trigger a re-pagination.
+      this.suppressWsReloadUntil = Date.now() + ChatInboxTreeProvider.MARK_READ_WS_SUPPRESS_MS;
+    }
   }
 
   // ----- TreeDataProvider -----
@@ -669,12 +718,19 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     // Bursts of WS events (e.g., N read:update events when opening a thread
     // with N unread messages) would otherwise produce N back-to-back reloads
     // and visible flicker as state converges. Debounce so the burst becomes
-    // a single reload once events stop arriving.
+    // a single reload once events stop arriving. Additionally, drop reloads
+    // entirely while we're applying our own mark-read mutations: every read
+    // we post triggers a server-side broadcast that would loop us back into
+    // re-paginating the whole inbox.
+    if (Date.now() < this.suppressWsReloadUntil) {
+      return;
+    }
     if (this.wsReloadTimer) {
       clearTimeout(this.wsReloadTimer);
     }
     this.wsReloadTimer = setTimeout(() => {
       this.wsReloadTimer = undefined;
+      if (Date.now() < this.suppressWsReloadUntil) { return; }
       void this.requestReload();
     }, ChatInboxTreeProvider.WS_RELOAD_DEBOUNCE_MS);
   }

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -3,7 +3,7 @@ import { ComputorApiService } from '../../../services/ComputorApiService';
 import { canPostGlobal, canPostToCourseFamily, canPostToOrganization } from '../../../services/MessagePermissions';
 import { WebSocketService } from '../../../services/WebSocketService';
 import { MessagesWebviewProvider, MessageTargetContext } from '../../webviews/MessagesWebviewProvider';
-import type { MessageList, MessageQuery } from '../../../types/generated';
+import type { MessageList } from '../../../types/generated';
 
 const GLOBAL_CHANNEL = 'global';
 import {
@@ -41,6 +41,17 @@ interface PersistedState {
 
 type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem | ChatLoadMoreItem | ChatFilterChipItem;
 
+interface ScopeFetchState {
+  /** Accumulated messages for this scope; grows on each Load more. */
+  messages: MessageList[];
+  /** How many we've fetched (sum across pages, and across courses for the
+   *  filtered submission_group case). */
+  fetched: number;
+  /** Backend's reported total for this scope under the current filter (sum
+   *  of per-course X-Total-Count when fan-out applies). */
+  total: number;
+}
+
 export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeItem> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<AnyTreeItem | undefined | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
@@ -54,22 +65,18 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   private loading = false;
   private loadError: string | undefined;
   private scopeItems: ChatScopeItem[] = [];
-  /** Last assembled inbox payload (= unfilteredBase ± submission filter
-   *  results) used by groupMessages + buildScopeItems. */
+  /** Flat union of every scope's accumulated messages, used by groupMessages
+   *  + buildScopeItems and shared by mark-read mutations. Rebuilt from
+   *  scopeFetchStates whenever they change. */
   private cachedMessages: MessageList[] = [];
-  /** Pristine accumulating page-1+ result of the unfiltered /messages query.
-   *  Grows as the user clicks "Load more". Used as the source for assembled. */
-  private unfilteredBase: MessageList[] = [];
-  /** X-Total-Count from the unfiltered /messages query — drives Load more
-   *  visibility. */
-  private unfilteredTotal: number | undefined;
-  /** How many unfiltered messages we've fetched (effectively the next skip). */
-  private unfilteredFetched = 0;
-  /** Page size for the unfiltered inbox fetch + each Load more click. */
-  private static readonly INBOX_PAGE_SIZE = 200;
-  /** Set during loadMoreInboxMessages so the user can't double-click and fan
-   *  out duplicate skip values. */
-  private loadingMore = false;
+  /** Per-scope pagination + accumulation. Each scope has its own GET window
+   *  on the backend, so Load more is rendered inside the scope it advances. */
+  private scopeFetchStates: Map<MessageScope, ScopeFetchState> = new Map();
+  /** Page size for every per-scope GET (initial + each Load more click). */
+  private static readonly SCOPE_PAGE_SIZE = 200;
+  /** Set of scopes whose Load more is in-flight, so a double-click doesn't
+   *  fan out duplicate skip values. */
+  private scopeLoadingMore: Set<MessageScope> = new Set();
   private currentUserId?: string;
   private userScopes?: import('../../../types/generated').UserScopes;
   private userScopesPromise?: Promise<void>;
@@ -254,19 +261,18 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     await this.markMessagesReadOnBackend(ids);
   }
 
-  /** Sets is_read=true on every cached copy of the given message ids — both
-   *  in cachedMessages and in unfilteredBase. They share refs for most
-   *  scopes, but diverge for submission_group when the filter is active, so
-   *  marking only cachedMessages would lose the read state next time we
-   *  re-assemble from base (e.g. when the filter is cleared). */
+  /** Sets is_read=true on every cached copy of the given message ids, across
+   *  cachedMessages and every per-scope state's messages array. */
   private markIdsReadLocally(ids: string[]): void {
     if (ids.length === 0) { return; }
     const set = new Set(ids);
     for (const m of this.cachedMessages) {
       if (set.has(m.id)) { m.is_read = true; }
     }
-    for (const m of this.unfilteredBase) {
-      if (set.has(m.id)) { m.is_read = true; }
+    for (const state of this.scopeFetchStates.values()) {
+      for (const m of state.messages) {
+        if (set.has(m.id)) { m.is_read = true; }
+      }
     }
   }
 
@@ -320,51 +326,8 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     return this.submissionCourseFilter.size > 0;
   }
 
-  /**
-   * Fetches submission-group messages matching the active backend-driven
-   * filters. Currently only the course filter goes to the backend; title is
-   * a client-side substring narrow applied during buildScopeItems, because
-   * MessageQuery doesn't support a title-substring filter (tag_scope only
-   * matches `#tag` prefixes inside the title, which is the wrong tool for
-   * arbitrary title text).
-   *
-   * Multi-course is fanned out per course because MessageQuery takes one
-   * course_id at a time. course_id_all_messages=true makes the backend walk
-   * the relations so submission_group messages with course_id=null still
-   * match the requested course.
-   */
-  private async fetchFilteredSubmissionMessages(): Promise<MessageList[]> {
-    const courseIds = Array.from(this.submissionCourseFilter);
-
-    if (courseIds.length === 0) {
-      // No course filter: pull all submission_group messages so the client-
-      // side title narrow has data to work on.
-      return await this.api.listMessages({ scope: 'submission_group' });
-    }
-
-    // course_id_all_messages tells the backend to walk the relations so
-    // submission_group messages with a null course_id column still match.
-    // The generated MessageQuery type doesn't list it (out-of-date typegen),
-    // so cast through unknown.
-    const fetches = courseIds.map(courseId =>
-      this.api.listMessages({
-        scope: 'submission_group',
-        course_id: courseId,
-        course_id_all_messages: true
-      } as unknown as MessageQuery)
-    );
-    const results = await Promise.all(fetches);
-    const seen = new Set<string>();
-    const merged: MessageList[] = [];
-    for (const list of results) {
-      for (const m of list) {
-        if (seen.has(m.id)) { continue; }
-        seen.add(m.id);
-        merged.push(m);
-      }
-    }
-    return merged;
-  }
+  // (legacy fetchFilteredSubmissionMessages removed — fetchScopePage now
+  //  handles the submission_group filter case with bounded pagination.)
 
   private applySubmissionFiltersContextKey(): void {
     void vscode.commands.executeCommand('setContext', 'computor.chat.submissionFiltersActive', this.hasSubmissionFilter());
@@ -388,58 +351,71 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   }
 
   /**
-   * Builds the assembled cachedMessages from unfilteredBase (+ filtered
-   * submission_group slice when the submission filter is on), then refreshes
-   * the scope items + tree.
+   * Fetches the first page for a single scope. For submission_group with the
+   * course filter active, fans out one request per selected course and sums
+   * the totals; otherwise a single GET /messages?scope=...&skip&limit.
    */
-  private async applyAssembledFromBase(): Promise<void> {
-    let assembled = this.unfilteredBase;
-    if (this.hasSubmissionFilter()) {
-      try {
-        const filteredSub = await this.fetchFilteredSubmissionMessages();
-        const nonSub = assembled.filter(m => m.scope !== 'submission_group');
-        assembled = [...nonSub, ...filteredSub];
-      } catch (err) {
-        console.warn('[ChatInbox] Failed to fetch filtered submission messages, falling back to unfiltered:', err);
+  private async fetchScopePage(scope: MessageScope, skip: number, limit: number): Promise<{ items: MessageList[]; total: number }> {
+    if (scope === 'submission_group' && this.hasSubmissionFilter()) {
+      const courseIds = Array.from(this.submissionCourseFilter);
+      const fetches = courseIds.map(courseId =>
+        this.api.listMessagesPage({ scope: 'submission_group', course_id: courseId, skip, limit })
+      );
+      const results = await Promise.all(fetches);
+      const seen = new Set<string>();
+      const items: MessageList[] = [];
+      let total = 0;
+      for (const r of results) {
+        total += r.total;
+        for (const m of r.items) {
+          if (!seen.has(m.id)) {
+            seen.add(m.id);
+            items.push(m);
+          }
+        }
       }
+      return { items, total };
     }
-    this.cachedMessages = assembled;
+    return await this.api.listMessagesPage({ scope, skip, limit });
+  }
+
+  /** Rebuilds cachedMessages as the flat union of every scope's accumulated
+   *  messages and refreshes the tree. */
+  private async rebuildAssembled(): Promise<void> {
+    const flat: MessageList[] = [];
+    for (const state of this.scopeFetchStates.values()) {
+      flat.push(...state.messages);
+    }
+    this.cachedMessages = flat;
     const grouped = this.groupMessages(this.cachedMessages);
     await this.resolveLabels(grouped);
     this.scopeItems = this.buildScopeItems(grouped);
   }
 
-  /** Fetches the next page of unfiltered messages and merges into the cache. */
-  async loadMoreInboxMessages(): Promise<void> {
-    if (this.loadingMore) { return; }
-    if (this.unfilteredTotal !== undefined && this.unfilteredFetched >= this.unfilteredTotal) {
-      return;
-    }
-    this.loadingMore = true;
+  /** Fetches the next page for one scope and appends to its state. */
+  async loadMoreForScope(scope: MessageScope): Promise<void> {
+    if (this.scopeLoadingMore.has(scope)) { return; }
+    const state = this.scopeFetchStates.get(scope);
+    if (!state || state.fetched >= state.total) { return; }
+    this.scopeLoadingMore.add(scope);
     try {
-      const page = await this.api.listMessagesPage({
-        skip: this.unfilteredFetched,
-        limit: ChatInboxTreeProvider.INBOX_PAGE_SIZE
-      });
-      // Dedupe in case a WS-triggered insert added a message we'd otherwise
-      // see again at this offset.
-      const seen = new Set(this.unfilteredBase.map(m => m.id));
-      for (const m of page.items) {
+      const next = await this.fetchScopePage(scope, state.fetched, ChatInboxTreeProvider.SCOPE_PAGE_SIZE);
+      const seen = new Set(state.messages.map(m => m.id));
+      for (const m of next.items) {
         if (!seen.has(m.id)) {
-          this.unfilteredBase.push(m);
+          state.messages.push(m);
           seen.add(m.id);
         }
       }
-      // Track skip on the request size, not the dedupe survivors, so we don't
-      // get stuck re-querying the same offset forever if the backend grew.
-      this.unfilteredFetched += page.items.length;
-      this.unfilteredTotal = page.total;
-
-      await this.applyAssembledFromBase();
+      // Advance by request size (not survivors) so we don't loop forever if
+      // the backend grew between pages and the same offset reappears.
+      state.fetched += next.items.length;
+      state.total = Math.max(state.total, next.total);
+      await this.rebuildAssembled();
     } catch (err: any) {
       vscode.window.showErrorMessage(`Failed to load more messages: ${err?.message || err}`);
     } finally {
-      this.loadingMore = false;
+      this.scopeLoadingMore.delete(scope);
       this._onDidChangeTreeData.fire(undefined);
       this._onDidChangeUnread.fire(this.getTotalUnread());
     }
@@ -497,16 +473,10 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     if (!element) {
       if (this.loading) { return [new ChatLoadingItem()]; }
       if (this.loadError) { return [new ChatErrorItem(this.loadError)]; }
-      const items: AnyTreeItem[] = this.scopeItems.length === 0
-        ? [new ChatEmptyItem(this.unreadOnly ? 'No unread messages.' : 'No messages.')]
-        : [...this.scopeItems];
-      // Show "Load more" when the backend reported more unfiltered messages
-      // than we've fetched. Keep it visible regardless of unread/filter state
-      // so the user can always pull the rest down.
-      if (this.unfilteredTotal !== undefined && this.unfilteredFetched < this.unfilteredTotal) {
-        items.push(new ChatLoadMoreItem(this.unfilteredFetched, this.unfilteredTotal));
+      if (this.scopeItems.length === 0) {
+        return [new ChatEmptyItem(this.unreadOnly ? 'No unread messages.' : 'No messages.')];
       }
-      return items;
+      return [...this.scopeItems];
     }
 
     if (element instanceof ChatScopeItem) {
@@ -517,6 +487,13 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         items.push(...this.buildSubmissionFilterChips());
       }
       items.push(...element.threads.map(t => new ChatThreadItem(t)));
+      // Per-scope Load more: shown as the last child when the backend
+      // reports more messages for this scope than we've pulled. Hidden when
+      // the user collapses the scope row.
+      const state = this.scopeFetchStates.get(element.scope);
+      if (state && state.fetched < state.total) {
+        items.push(new ChatLoadMoreItem(element.scope, state.fetched, state.total));
+      }
       return items;
     }
 
@@ -537,28 +514,44 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     }
 
     try {
-      // Page 1 only — Load more (rendered as a tree leaf) walks the rest.
-      const [identity, page, scopes] = await Promise.all([
+      // Identity + scopes once; per-scope inbox pages in parallel. Each scope
+      // has its own pagination, so a Load more click at the end of e.g.
+      // Submission Groups only advances *that* scope's window.
+      const [identity, scopes] = await Promise.all([
         this.api.getCurrentUser().catch(() => undefined),
-        this.api.listMessagesPage({ skip: 0, limit: ChatInboxTreeProvider.INBOX_PAGE_SIZE }),
         this.api.getUserScopes().catch(() => undefined)
       ]);
       this.currentUserId = identity?.id;
       this.userScopes = scopes;
       this.maybeSubscribeUserChannels();
 
-      this.unfilteredBase = page.items;
-      this.unfilteredTotal = page.total;
-      this.unfilteredFetched = page.items.length;
+      const newStates = new Map<MessageScope, ScopeFetchState>();
+      const pageResults = await Promise.all(
+        SCOPE_ORDER.map(async scope => {
+          try {
+            const page = await this.fetchScopePage(scope, 0, ChatInboxTreeProvider.SCOPE_PAGE_SIZE);
+            return { scope, page };
+          } catch (err) {
+            console.warn(`[ChatInbox] Failed to fetch initial page for scope ${scope}:`, err);
+            return { scope, page: { items: [] as MessageList[], total: 0 } };
+          }
+        })
+      );
+      for (const { scope, page } of pageResults) {
+        newStates.set(scope, {
+          messages: page.items,
+          fetched: page.items.length,
+          total: page.total
+        });
+      }
+      this.scopeFetchStates = newStates;
 
-      await this.applyAssembledFromBase();
+      await this.rebuildAssembled();
     } catch (error: any) {
       this.loadError = `Failed to load messages: ${error?.message || error}`;
       this.scopeItems = [];
       this.cachedMessages = [];
-      this.unfilteredBase = [];
-      this.unfilteredTotal = undefined;
-      this.unfilteredFetched = 0;
+      this.scopeFetchStates.clear();
     } finally {
       this.loading = false;
       this._onDidChangeTreeData.fire(undefined);

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -131,7 +131,10 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     this.unreadOnly = value;
     void this.persistState();
     void vscode.commands.executeCommand('setContext', 'computor.chat.unreadOnly', value);
-    this.refresh();
+    // Toggle is a pure client-side filter (buildScopeItems already excludes
+    // threads with no unread messages when unreadOnly is on). Rebuilding from
+    // the cached payload avoids re-paginating the entire inbox on every flip.
+    this.rebuildScopeItemsFromCache();
   }
 
   recordExpanded(scope: MessageScope, expanded: boolean): void {
@@ -266,7 +269,10 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     try {
       const [identity, messages, scopes] = await Promise.all([
         this.api.getCurrentUser().catch(() => undefined),
-        this.api.listMessages(this.unreadOnly ? { unread: true } : {}),
+        // Always fetch the unfiltered inbox so the unread-only toggle can flip
+        // client-side without re-paginating the backend. buildScopeItems +
+        // rebuildScopeItemsFromCache handle the filtering on the cached array.
+        this.api.listMessages({}),
         this.api.getUserScopes().catch(() => undefined)
       ]);
       this.currentUserId = identity?.id;

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -3,7 +3,7 @@ import { ComputorApiService } from '../../../services/ComputorApiService';
 import { canPostGlobal, canPostToCourseFamily, canPostToOrganization } from '../../../services/MessagePermissions';
 import { WebSocketService } from '../../../services/WebSocketService';
 import { MessagesWebviewProvider, MessageTargetContext } from '../../webviews/MessagesWebviewProvider';
-import type { MessageList } from '../../../types/generated';
+import type { MessageList, MessageQuery } from '../../../types/generated';
 
 const GLOBAL_CHANNEL = 'global';
 import {
@@ -14,6 +14,7 @@ import {
   ChatLoadingItem,
   ChatErrorItem,
   ChatLoadMoreItem,
+  ChatFilterChipItem,
   MessageScope,
   scopeLabel
 } from './ChatInboxTreeItems';
@@ -36,10 +37,9 @@ interface PersistedState {
   expandedScopes: MessageScope[];
   unreadOnly: boolean;
   submissionCourseFilter?: string[];
-  submissionTitleFilter?: string;
 }
 
-type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem | ChatLoadMoreItem;
+type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem | ChatLoadMoreItem | ChatFilterChipItem;
 
 export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeItem> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<AnyTreeItem | undefined | void>();
@@ -92,9 +92,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   private unreadOnly = false;
   /** Course IDs to keep when rendering the submission_group scope. Empty = all. */
   private submissionCourseFilter: Set<string> = new Set();
-  /** Substring (case-insensitive) match against any message's title in a
-   *  submission_group thread. Empty = all. */
-  private submissionTitleFilter = '';
 
   // Label caches keyed by id
   private readonly orgLabels = new Map<string, string>();
@@ -303,56 +300,58 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     this.refresh();
   }
 
-  getSubmissionTitleFilter(): string {
-    return this.submissionTitleFilter;
-  }
-
-  setSubmissionTitleFilter(value: string): void {
-    const trimmed = (value ?? '').trim();
-    if (this.submissionTitleFilter === trimmed) { return; }
-    this.submissionTitleFilter = trimmed;
+  removeSubmissionCourse(courseId: string): void {
+    if (!this.submissionCourseFilter.has(courseId)) { return; }
+    this.submissionCourseFilter.delete(courseId);
     void this.persistState();
     this.applySubmissionFiltersContextKey();
     this.refresh();
   }
 
   clearSubmissionFilters(): void {
-    if (this.submissionCourseFilter.size === 0 && this.submissionTitleFilter === '') { return; }
+    if (this.submissionCourseFilter.size === 0) { return; }
     this.submissionCourseFilter = new Set();
-    this.submissionTitleFilter = '';
     void this.persistState();
     this.applySubmissionFiltersContextKey();
     this.refresh();
   }
 
   private hasSubmissionFilter(): boolean {
-    return this.submissionCourseFilter.size > 0 || this.submissionTitleFilter.length > 0;
+    return this.submissionCourseFilter.size > 0;
   }
 
   /**
-   * When submission-group filters are active, fetches the matching messages
-   * via the backend (scope=submission_group +
-   * tag_scope=...). Multi-course is fanned out per course because the backend
-   * takes one course_id at a time. Returns deduped results.
+   * Fetches submission-group messages matching the active backend-driven
+   * filters. Currently only the course filter goes to the backend; title is
+   * a client-side substring narrow applied during buildScopeItems, because
+   * MessageQuery doesn't support a title-substring filter (tag_scope only
+   * matches `#tag` prefixes inside the title, which is the wrong tool for
+   * arbitrary title text).
+   *
+   * Multi-course is fanned out per course because MessageQuery takes one
+   * course_id at a time. course_id_all_messages=true makes the backend walk
+   * the relations so submission_group messages with course_id=null still
+   * match the requested course.
    */
   private async fetchFilteredSubmissionMessages(): Promise<MessageList[]> {
-    const tagScope = this.submissionTitleFilter || undefined;
     const courseIds = Array.from(this.submissionCourseFilter);
 
     if (courseIds.length === 0) {
-      // Title-only filter
-      return await this.api.listMessages({
-        scope: 'submission_group',
-        ...(tagScope ? { tag_scope: tagScope } : {})
-      });
+      // No course filter: pull all submission_group messages so the client-
+      // side title narrow has data to work on.
+      return await this.api.listMessages({ scope: 'submission_group' });
     }
 
+    // course_id_all_messages tells the backend to walk the relations so
+    // submission_group messages with a null course_id column still match.
+    // The generated MessageQuery type doesn't list it (out-of-date typegen),
+    // so cast through unknown.
     const fetches = courseIds.map(courseId =>
       this.api.listMessages({
         scope: 'submission_group',
         course_id: courseId,
-        ...(tagScope ? { tag_scope: tagScope } : {})
-      })
+        course_id_all_messages: true
+      } as unknown as MessageQuery)
     );
     const results = await Promise.all(fetches);
     const seen = new Set<string>();
@@ -368,8 +367,24 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   }
 
   private applySubmissionFiltersContextKey(): void {
-    const active = this.submissionCourseFilter.size > 0 || this.submissionTitleFilter.length > 0;
-    void vscode.commands.executeCommand('setContext', 'computor.chat.submissionFiltersActive', active);
+    void vscode.commands.executeCommand('setContext', 'computor.chat.submissionFiltersActive', this.hasSubmissionFilter());
+  }
+
+  /** One chip per active course filter; clicking a chip removes that course
+   *  from the filter set (and triggers a refresh of the submission_group
+   *  slice). Empty array when no filter is active. */
+  private buildSubmissionFilterChips(): ChatFilterChipItem[] {
+    const chips: ChatFilterChipItem[] = [];
+    for (const courseId of this.submissionCourseFilter) {
+      const label = this.courseLabels.get(courseId) || shortId(courseId);
+      chips.push(new ChatFilterChipItem(
+        `Course: ${label}`,
+        `Click to remove "${label}" from the Submission Groups filter.`,
+        'computor.chat.removeSubmissionCourse',
+        [courseId]
+      ));
+    }
+    return chips;
   }
 
   /**
@@ -495,7 +510,14 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     }
 
     if (element instanceof ChatScopeItem) {
-      return element.threads.map(t => new ChatThreadItem(t));
+      const items: AnyTreeItem[] = [];
+      // Submission Groups gets per-active-filter chips up top — click a chip
+      // to remove that one filter, mirroring the examples-tree pattern.
+      if (element.scope === 'submission_group') {
+        items.push(...this.buildSubmissionFilterChips());
+      }
+      items.push(...element.threads.map(t => new ChatThreadItem(t)));
+      return items;
     }
 
     return [];
@@ -680,9 +702,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       // Submission Groups stays visible when its filter is active, even if
       // the filtered fetch returned zero messages — otherwise the user has
       // nowhere to right-click to clear the filter.
-      const filterActive = scope === 'submission_group' && (
-        this.submissionCourseFilter.size > 0 || this.submissionTitleFilter.length > 0
-      );
+      const filterActive = scope === 'submission_group' && this.submissionCourseFilter.size > 0;
 
       if ((!byTarget || byTarget.size === 0) && !filterActive) { continue; }
 
@@ -998,9 +1018,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         if (Array.isArray(stored.submissionCourseFilter)) {
           this.submissionCourseFilter = new Set(stored.submissionCourseFilter);
         }
-        if (typeof stored.submissionTitleFilter === 'string') {
-          this.submissionTitleFilter = stored.submissionTitleFilter;
-        }
       }
     } catch (err) {
       console.warn('[ChatInbox] Failed to load persisted state:', err);
@@ -1013,8 +1030,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     const state: PersistedState = {
       expandedScopes: Array.from(this.expandedScopes),
       unreadOnly: this.unreadOnly,
-      submissionCourseFilter: Array.from(this.submissionCourseFilter),
-      submissionTitleFilter: this.submissionTitleFilter
+      submissionCourseFilter: Array.from(this.submissionCourseFilter)
     };
     try {
       await this.context.globalState.update(STATE_KEY, state);


### PR DESCRIPTION
## Why

The chat inbox subscribes to \`read:update\` events on the per-user WS channel, but the backend only broadcasts \`read:update\` on \`submission_group:*\` channels (see \`computor-backend/src/computor_backend/api/messages.py\`). For every other scope the chat inbox never gets notified that messages were marked read, and badges hung around until the user manually hit Refresh.

## What

Make the inbox self-sufficient about read state instead of leaning on the WS event:

- Cache the raw \`MessageList\` payload from the last load on the provider.
- In \`openThread\`, mutate \`is_read = true\` in place on the cached message objects (filtered to "from others, currently unread"), rebuild scope items from the cache without refetching, then fire \`markMessageRead\` for those ids. Mark-read is idempotent on the backend, so \`MessagesWebviewProvider\`'s parallel marking is harmless.
- Same flow applied to \`markThreadRead\` / \`markScopeRead\` (the manual context-menu commands) — they no longer trigger a full \`refresh()\`, which used to refetch the entire inbox just to clear a single thread's badge.

## Test plan

- [ ] Open a course-content / course / course-group thread from the chat inbox → badge clears immediately, no manual refresh required
- [ ] Open a submission-group thread (the one path that already worked via WS) → still clears immediately, no double flash
- [ ] Right-click → "Mark Thread as Read" on an unread thread → badge clears instantly
- [ ] Right-click → "Mark All as Read" on a scope row → all of that scope's badges clear instantly
- [ ] After clearing, hit "Refresh" → state stays consistent (backend confirms the mark-read)
- [ ] Receive a new message via WS while inbox is open → unread badge appears (the WS path for new messages was already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)