### PR TITLE
feat(student): inline Show Messages icon on assignment items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1738,6 +1738,11 @@
           "group": "inline@5"
         },
         {
+          "command": "computor.student.showMessages",
+          "when": "view == computor.student.courses && viewItem =~ /^studentCourseContent\\.assignment/",
+          "group": "inline@6"
+        },
+        {
           "command": "computor.student.viewSubmissionGroup",
           "when": "view == computor.student.courses && viewItem =~ /^studentCourseContent/",
           "group": "2_details@1"

--- a/src/commands/StudentCommands.ts
+++ b/src/commands/StudentCommands.ts
@@ -1171,8 +1171,11 @@ export class StudentCommands {
         let wsChannel: string | undefined;
 
         if (submissionGroup?.id) {
-          // Assignment with submission group - students only need submission_group messages
+          // Assignment with submission group - students only need submission_group messages.
+          // Pin scope so the panel doesn't pull in messages from broader scopes that
+          // happen to share the same submission_group_id.
           query = {
+            scope: 'submission_group',
             submission_group_id: submissionGroup.id
           };
           createPayload = {
@@ -1181,8 +1184,9 @@ export class StudentCommands {
           wsChannel = `submission_group:${submissionGroup.id}`;
         } else {
           // Unit content without submission group - show course_content messages
-          // Students can only read (lecturer+ for writing)
+          // Students can only read (lecturer+ for writing).
           query = {
+            scope: 'course_content',
             course_content_id: content.id
           };
           createPayload = {


### PR DESCRIPTION
## Summary
- Adds the `$(comment-discussion)` icon next to the upload action on assignment tree items in the Student view.
- Pins `scope` on the panel query in `StudentCommands.showMessages` so opening messages for a submission_group / course_content target doesn't surface messages from broader scopes that share the same id (mirrors the chat-inbox fix from PR #88).

## Test plan
- [ ] Open the Student courses tree, verify the comment icon appears on assignment rows after the upload icon.
- [ ] Click the icon on an assignment with a submission group; the panel only lists `submission_group` messages.
- [ ] Click the icon on a unit/content row (right-click menu); panel only lists `course_content` messages.