### PR TITLE
fix(messages): toast suppression + submission-group titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,6 +371,30 @@
         "category": "Computor Chat"
       },
       {
+        "command": "computor.chat.notifications.mute",
+        "title": "Mute Chat Notifications",
+        "icon": "$(bell)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.notifications.unmute",
+        "title": "Unmute Chat Notifications",
+        "icon": "$(bell-slash)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.scope.mute",
+        "title": "Mute This Scope",
+        "icon": "$(bell)",
+        "category": "Computor Chat"
+      },
+      {
+        "command": "computor.chat.scope.unmute",
+        "title": "Unmute This Scope",
+        "icon": "$(bell-slash)",
+        "category": "Computor Chat"
+      },
+      {
         "command": "computor.chat.markThreadRead",
         "title": "Mark Thread as Read",
         "icon": "$(check)",
@@ -1086,6 +1110,16 @@
           "group": "navigation@2"
         },
         {
+          "command": "computor.chat.notifications.mute",
+          "when": "view == computor.chat.inbox && computor.chat.notificationsEnabled",
+          "group": "navigation@3"
+        },
+        {
+          "command": "computor.chat.notifications.unmute",
+          "when": "view == computor.chat.inbox && !computor.chat.notificationsEnabled",
+          "group": "navigation@3"
+        },
+        {
           "command": "computor.user.profile",
           "when": "view == computor.lecturer.courses",
           "group": "navigation@0"
@@ -1234,8 +1268,28 @@
       "view/item/context": [
         {
           "command": "computor.chat.markScopeRead",
-          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\..+\\.unread$/",
+          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\..+\\.unread/",
           "group": "1_actions@1"
+        },
+        {
+          "command": "computor.chat.scope.mute",
+          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\.[^.]+(\\.unread)?$/",
+          "group": "inline@5"
+        },
+        {
+          "command": "computor.chat.scope.unmute",
+          "when": "view == computor.chat.inbox && viewItem =~ /\\.muted$/",
+          "group": "inline@5"
+        },
+        {
+          "command": "computor.chat.scope.mute",
+          "when": "view == computor.chat.inbox && viewItem =~ /^chatScope\\.[^.]+(\\.unread)?$/",
+          "group": "1_actions@2"
+        },
+        {
+          "command": "computor.chat.scope.unmute",
+          "when": "view == computor.chat.inbox && viewItem =~ /\\.muted$/",
+          "group": "1_actions@2"
         },
         {
           "command": "computor.chat.markThreadRead",

--- a/package.json
+++ b/package.json
@@ -1111,12 +1111,12 @@
         },
         {
           "command": "computor.chat.notifications.mute",
-          "when": "view == computor.chat.inbox && computor.chat.notificationsEnabled",
+          "when": "view == computor.chat.inbox && computor.chat.anyScopeUnmuted",
           "group": "navigation@3"
         },
         {
           "command": "computor.chat.notifications.unmute",
-          "when": "view == computor.chat.inbox && !computor.chat.notificationsEnabled",
+          "when": "view == computor.chat.inbox && !computor.chat.anyScopeUnmuted",
           "group": "navigation@3"
         },
         {

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -79,7 +79,7 @@ export class LecturerCommands {
     this.courseGroupWebviewProvider = new CourseGroupWebviewProvider(context, this.apiService, this.treeDataProvider);
     this.courseMemberWebviewProvider = new CourseMemberWebviewProvider(context, this.apiService, this.treeDataProvider);
     this.courseMemberImportWebviewProvider = new CourseMemberImportWebviewProvider(context, this.apiService, this.treeDataProvider);
-    this.messagesWebviewProvider = new MessagesWebviewProvider(context, this.apiService);
+    this.messagesWebviewProvider = MessagesWebviewProvider.getShared(context, this.apiService);
     if (messagesInputPanel) {
       this.messagesWebviewProvider.setInputPanel(messagesInputPanel);
     }

--- a/src/commands/StudentCommands.ts
+++ b/src/commands/StudentCommands.ts
@@ -48,7 +48,7 @@ export class StudentCommands {
     this.testResultService = TestResultService.getInstance();
     // Make sure TestResultService has the API service
     this.testResultService.setApiService(this.apiService);
-    this.messagesWebviewProvider = new MessagesWebviewProvider(context, this.apiService);
+    this.messagesWebviewProvider = MessagesWebviewProvider.getShared(context, this.apiService);
     if (messagesInputPanel) {
       this.messagesWebviewProvider.setInputPanel(messagesInputPanel);
     }

--- a/src/commands/TutorCommands.ts
+++ b/src/commands/TutorCommands.ts
@@ -51,7 +51,7 @@ export class TutorCommands {
     if (commentsInputPanel) {
       this.commentsWebviewProvider.setInputPanel(commentsInputPanel);
     }
-    this.messagesWebviewProvider = new MessagesWebviewProvider(context, this.apiService);
+    this.messagesWebviewProvider = MessagesWebviewProvider.getShared(context, this.apiService);
     if (messagesInputPanel) {
       this.messagesWebviewProvider.setInputPanel(messagesInputPanel);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1186,7 +1186,7 @@ class UnifiedController {
 
     // The chat view drives the existing MessagesWebviewProvider + bottom Compose
     // panel, so reuse the input panel + WebSocket service we already instantiated.
-    const messagesWebview = new (await import('./ui/webviews/MessagesWebviewProvider')).MessagesWebviewProvider(this.context, api);
+    const messagesWebview = (await import('./ui/webviews/MessagesWebviewProvider')).MessagesWebviewProvider.getShared(this.context, api);
     if (this.messagesInputPanel) {
       messagesWebview.setInputPanel(this.messagesInputPanel);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1258,10 +1258,10 @@ class UnifiedController {
         }
       }),
       vscode.commands.registerCommand('computor.chat.notifications.mute', () => {
-        tree.toggleNotificationsEnabled();
+        tree.toggleAllNotifications();
       }),
       vscode.commands.registerCommand('computor.chat.notifications.unmute', () => {
-        tree.toggleNotificationsEnabled();
+        tree.toggleAllNotifications();
       }),
       vscode.commands.registerCommand('computor.chat.scope.mute', (item: any) => {
         if (item instanceof ChatScopeItem) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1256,6 +1256,22 @@ class UnifiedController {
         } else {
           void tree.loadMoreForScope(scope as any);
         }
+      }),
+      vscode.commands.registerCommand('computor.chat.notifications.mute', () => {
+        tree.toggleNotificationsEnabled();
+      }),
+      vscode.commands.registerCommand('computor.chat.notifications.unmute', () => {
+        tree.toggleNotificationsEnabled();
+      }),
+      vscode.commands.registerCommand('computor.chat.scope.mute', (item: any) => {
+        if (item instanceof ChatScopeItem) {
+          tree.toggleScopeMuted(item.scope);
+        }
+      }),
+      vscode.commands.registerCommand('computor.chat.scope.unmute', (item: any) => {
+        if (item instanceof ChatScopeItem) {
+          tree.toggleScopeMuted(item.scope);
+        }
       })
     );
 

--- a/src/ui/tree/chat/ChatInboxTreeItems.ts
+++ b/src/ui/tree/chat/ChatInboxTreeItems.ts
@@ -81,8 +81,12 @@ export class ChatScopeItem extends vscode.TreeItem {
     const isCourseGrouped = courseChildCount !== undefined;
     const childCount = isCourseGrouped ? courseChildCount! : threads.length;
     const childKind = isCourseGrouped ? 'course' : 'thread';
+    // Prefix the label (not the description) with the muted bell so the
+    // glyph sits at the same column on every muted row, vertically aligned.
+    const baseLabel = SCOPE_LABELS[scope];
+    const label = muted ? `🔕 ${baseLabel}` : baseLabel;
     super(
-      SCOPE_LABELS[scope],
+      label,
       childCount === 0
         ? vscode.TreeItemCollapsibleState.None
         : expanded
@@ -98,11 +102,10 @@ export class ChatScopeItem extends vscode.TreeItem {
     if (muted) { suffixes.push('muted'); }
     this.contextValue = ['chatScope', scope, ...suffixes].join('.');
     this.iconPath = new vscode.ThemeIcon(SCOPE_ICONS[scope]);
-    const baseDescription = unreadCount > 0 ? `${unreadCount} unread · ${childCount}` : `${childCount}`;
-    this.description = muted ? `🔕 ${baseDescription}` : baseDescription;
+    this.description = unreadCount > 0 ? `${unreadCount} unread · ${childCount}` : `${childCount}`;
     const baseTooltip = unreadCount > 0
-      ? `${SCOPE_LABELS[scope]}: ${unreadCount} unread of ${childCount} ${childKind}(s)`
-      : `${SCOPE_LABELS[scope]}: ${childCount} ${childKind}(s)`;
+      ? `${baseLabel}: ${unreadCount} unread of ${childCount} ${childKind}(s)`
+      : `${baseLabel}: ${childCount} ${childKind}(s)`;
     this.tooltip = muted ? `${baseTooltip}\nNotifications muted for this scope.` : baseTooltip;
   }
 }

--- a/src/ui/tree/chat/ChatInboxTreeItems.ts
+++ b/src/ui/tree/chat/ChatInboxTreeItems.ts
@@ -64,12 +64,20 @@ export class ChatScopeItem extends vscode.TreeItem {
     public readonly threads: ChatThread[],
     public readonly unreadCount: number,
     expanded: boolean,
-    /** When set, the scope renders course nodes as children instead of
-     *  threads — used for the four course-grouped scopes (submission_group /
-     *  course / course_content / course_group). The number is shown in the
-     *  description and the row stays collapsible even with zero threads. */
-    public readonly courseChildCount?: number
+    options?: {
+      /** When set, the scope renders course nodes as children instead of
+       *  threads — used for the four course-grouped scopes (submission_group /
+       *  course / course_content / course_group). The number is shown in the
+       *  description and the row stays collapsible even with zero threads. */
+      courseChildCount?: number;
+      /** When true, this scope's notifications are muted. Reflected in the
+       *  description, tooltip, and contextValue (so menus can swap between
+       *  mute/unmute commands). */
+      muted?: boolean;
+    }
   ) {
+    const courseChildCount = options?.courseChildCount;
+    const muted = options?.muted === true;
     const isCourseGrouped = courseChildCount !== undefined;
     const childCount = isCourseGrouped ? courseChildCount! : threads.length;
     const childKind = isCourseGrouped ? 'course' : 'thread';
@@ -82,19 +90,20 @@ export class ChatScopeItem extends vscode.TreeItem {
           : vscode.TreeItemCollapsibleState.Collapsed
     );
     this.id = `chat-scope-${scope}`;
-    // contextValue carries the scope name and an unread suffix, so menus
-    // can target either every scope (e.g. /\.unread$/), or a single scope
-    // (e.g. /^chatScope\.submission_group/) without ambiguity.
-    this.contextValue = unreadCount > 0
-      ? `chatScope.${scope}.unread`
-      : `chatScope.${scope}`;
+    // contextValue carries the scope name plus optional ".unread" / ".muted"
+    // suffixes so menus can target either every scope (e.g. /\.unread$/) or a
+    // single scope (e.g. /^chatScope\.submission_group/) without ambiguity.
+    const suffixes: string[] = [];
+    if (unreadCount > 0) { suffixes.push('unread'); }
+    if (muted) { suffixes.push('muted'); }
+    this.contextValue = ['chatScope', scope, ...suffixes].join('.');
     this.iconPath = new vscode.ThemeIcon(SCOPE_ICONS[scope]);
-    this.description = unreadCount > 0
-      ? `${unreadCount} unread · ${childCount}`
-      : `${childCount}`;
-    this.tooltip = unreadCount > 0
+    const baseDescription = unreadCount > 0 ? `${unreadCount} unread · ${childCount}` : `${childCount}`;
+    this.description = muted ? `🔕 ${baseDescription}` : baseDescription;
+    const baseTooltip = unreadCount > 0
       ? `${SCOPE_LABELS[scope]}: ${unreadCount} unread of ${childCount} ${childKind}(s)`
       : `${SCOPE_LABELS[scope]}: ${childCount} ${childKind}(s)`;
+    this.tooltip = muted ? `${baseTooltip}\nNotifications muted for this scope.` : baseTooltip;
   }
 }
 

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -950,13 +950,14 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         return { title: info?.title || (targetId ? `Member ${shortId(targetId)}` : 'Course Member'), subtitle: info?.subtitle };
       }
       case 'submission_group': {
-        // Try to find a useful subtitle from any message that carries course_content_id (sibling field).
+        // Title comes from the linked course_content; the scope label
+        // ("Submission Groups") is already shown by the panel chrome, so we
+        // skip the subtitle to avoid the redundant "Submission group / X".
         const sample = msgs[0];
         const contentId = sample?.course_content_id;
         const contentLabel = contentId ? this.contentLabels.get(contentId)?.title : undefined;
         return {
-          title: contentLabel || (targetId ? `Submission Group ${shortId(targetId)}` : 'Submission Group'),
-          subtitle: contentLabel ? 'Submission group' : undefined
+          title: contentLabel || (targetId ? `Submission Group ${shortId(targetId)}` : 'Submission Group')
         };
       }
       case 'user': {

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -728,9 +728,23 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     const tasks: Promise<unknown>[] = [];
 
     for (const [scope, byTarget] of grouped) {
-      for (const [targetId] of byTarget) {
-        if (targetId === '__none__') { continue; }
-        tasks.push(this.ensureLabel(scope, targetId).catch(() => undefined));
+      for (const [targetId, msgs] of byTarget) {
+        if (targetId !== '__none__') {
+          tasks.push(this.ensureLabel(scope, targetId).catch(() => undefined));
+        }
+        // Submission-group threads label themselves from the linked
+        // course_content (see threadLabels). Pre-resolve those content
+        // labels so the title isn't a raw "Submission Group <shortId>".
+        if (scope === 'submission_group') {
+          const seen = new Set<string>();
+          for (const m of msgs) {
+            const contentId = m.course_content_id;
+            if (typeof contentId === 'string' && contentId && !seen.has(contentId)) {
+              seen.add(contentId);
+              tasks.push(this.ensureLabel('course_content', contentId).catch(() => undefined));
+            }
+          }
+        }
       }
     }
     await Promise.all(tasks);
@@ -964,6 +978,21 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
   private async buildTargetContext(thread: ChatThread): Promise<MessageTargetContext | undefined> {
     const { scope, targetId } = thread;
+
+    // Submission-group titles read from the linked course_content. Lazy-fetch
+    // it now if the label cache hasn't seen it yet (e.g. when opening from a
+    // brand-new WS toast where resolveLabels hasn't run for this content id).
+    if (scope === 'submission_group') {
+      const seen = new Set<string>();
+      for (const m of thread.messages) {
+        const contentId = m.course_content_id;
+        if (typeof contentId === 'string' && contentId && !seen.has(contentId) && !this.contentLabels.has(contentId)) {
+          seen.add(contentId);
+          await this.ensureLabel('course_content', contentId).catch(() => undefined);
+        }
+      }
+    }
+
     const labels = this.threadLabels(scope, targetId, thread.messages);
     const titleSegments: string[] = [];
     if (labels.subtitle) { titleSegments.push(labels.subtitle); }

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -1126,6 +1126,11 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       // Don't notify the user about their own posts.
       return;
     }
+    if (this.messagesProvider.isShowingMessage(inner)) {
+      // Panel is open on this exact thread — the panel itself will render the
+      // new message, so the toast would be redundant.
+      return;
+    }
     void this.showNewMessageToast(inner);
   }
 

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -49,6 +49,8 @@ const STATE_KEY = 'computor.chat.inbox.state';
 interface PersistedState {
   expandedScopes: MessageScope[];
   unreadOnly: boolean;
+  notificationsEnabled?: boolean;
+  mutedScopes?: MessageScope[];
 }
 
 type AnyTreeItem = ChatScopeItem | ChatThreadItem | ChatEmptyItem | ChatLoadingItem | ChatErrorItem | ChatLoadMoreItem | ChatCourseGroupItem;
@@ -122,6 +124,8 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   // Persisted UI state
   private expandedScopes: Set<MessageScope> = new Set();
   private unreadOnly = false;
+  private notificationsEnabled = true;
+  private mutedScopes: Set<MessageScope> = new Set();
 
   // Label caches keyed by id
   private readonly orgLabels = new Map<string, string>();
@@ -189,6 +193,34 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     // threads with no unread messages when unreadOnly is on). Rebuilding from
     // the cached payload avoids re-paginating the entire inbox on every flip.
     this.rebuildScopeItemsFromCache();
+  }
+
+  isNotificationsEnabled(): boolean {
+    return this.notificationsEnabled;
+  }
+
+  toggleNotificationsEnabled(): void {
+    this.notificationsEnabled = !this.notificationsEnabled;
+    void this.persistState();
+    void this.applyNotificationContextKeys();
+    // Refresh just the visible scope items so their bell icons reflect the
+    // new global state immediately.
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  isScopeMuted(scope: MessageScope): boolean {
+    return this.mutedScopes.has(scope);
+  }
+
+  toggleScopeMuted(scope: MessageScope): void {
+    if (this.mutedScopes.has(scope)) {
+      this.mutedScopes.delete(scope);
+    } else {
+      this.mutedScopes.add(scope);
+    }
+    void this.persistState();
+    void this.applyNotificationContextKeys();
+    this._onDidChangeTreeData.fire(undefined);
   }
 
   recordExpanded(scope: MessageScope, expanded: boolean): void {
@@ -855,7 +887,10 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         }
         if (this.unreadOnly && totalUnread === 0) { continue; }
         const expanded = this.expandedScopes.has(scope) || totalUnread > 0;
-        result.push(new ChatScopeItem(scope, [], totalUnread, expanded, inner.size));
+        result.push(new ChatScopeItem(scope, [], totalUnread, expanded, {
+          courseChildCount: inner.size,
+          muted: this.mutedScopes.has(scope)
+        }));
         continue;
       }
 
@@ -915,7 +950,9 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
 
       const totalUnread = threads.reduce((acc, t) => acc + t.unreadCount, 0);
       const expanded = this.expandedScopes.has(scope) || totalUnread > 0;
-      result.push(new ChatScopeItem(scope, threads, totalUnread, expanded));
+      result.push(new ChatScopeItem(scope, threads, totalUnread, expanded, {
+        muted: this.mutedScopes.has(scope)
+      }));
     }
 
     return result;
@@ -1132,6 +1169,13 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       // new message, so the toast would be redundant.
       return;
     }
+    if (!this.notificationsEnabled) {
+      return;
+    }
+    const scope = (typeof inner.scope === 'string' ? inner.scope : 'global') as MessageScope;
+    if (this.mutedScopes.has(scope)) {
+      return;
+    }
     void this.showNewMessageToast(inner);
   }
 
@@ -1201,23 +1245,43 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         if (typeof stored.unreadOnly === 'boolean') {
           this.unreadOnly = stored.unreadOnly;
         }
+        if (typeof stored.notificationsEnabled === 'boolean') {
+          this.notificationsEnabled = stored.notificationsEnabled;
+        }
+        if (Array.isArray(stored.mutedScopes)) {
+          this.mutedScopes = new Set(stored.mutedScopes);
+        }
       }
     } catch (err) {
       console.warn('[ChatInbox] Failed to load persisted state:', err);
     }
     void vscode.commands.executeCommand('setContext', 'computor.chat.unreadOnly', this.unreadOnly);
+    void this.applyNotificationContextKeys();
   }
 
   private async persistState(): Promise<void> {
     const state: PersistedState = {
       expandedScopes: Array.from(this.expandedScopes),
-      unreadOnly: this.unreadOnly
+      unreadOnly: this.unreadOnly,
+      notificationsEnabled: this.notificationsEnabled,
+      mutedScopes: Array.from(this.mutedScopes)
     };
     try {
       await this.context.globalState.update(STATE_KEY, state);
     } catch (err) {
       console.warn('[ChatInbox] Failed to persist state:', err);
     }
+  }
+
+  /** Mirrors the notification settings into VS Code context keys so the menu
+   *  `when` clauses can swap between mute/unmute commands. We expose:
+   *    - `computor.chat.notificationsEnabled` — global on/off
+   *    - `computor.chat.mutedScopes` — space-separated list of scope ids the
+   *      user has muted; menu `when` clauses can use `=~ /\bsubmission_group\b/`
+   *      to test membership. */
+  private async applyNotificationContextKeys(): Promise<void> {
+    await vscode.commands.executeCommand('setContext', 'computor.chat.notificationsEnabled', this.notificationsEnabled);
+    await vscode.commands.executeCommand('setContext', 'computor.chat.mutedScopes', Array.from(this.mutedScopes).join(' '));
   }
 }
 

--- a/src/ui/tree/chat/ChatInboxTreeProvider.ts
+++ b/src/ui/tree/chat/ChatInboxTreeProvider.ts
@@ -49,7 +49,6 @@ const STATE_KEY = 'computor.chat.inbox.state';
 interface PersistedState {
   expandedScopes: MessageScope[];
   unreadOnly: boolean;
-  notificationsEnabled?: boolean;
   mutedScopes?: MessageScope[];
 }
 
@@ -124,7 +123,9 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
   // Persisted UI state
   private expandedScopes: Set<MessageScope> = new Set();
   private unreadOnly = false;
-  private notificationsEnabled = true;
+  /** Scopes whose new-message toasts are suppressed. Per-scope only — there
+   *  is no separate global flag; the global title-bar toggle simply flips
+   *  this set between empty (all on) and full (all muted). */
   private mutedScopes: Set<MessageScope> = new Set();
 
   // Label caches keyed by id
@@ -195,21 +196,28 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     this.rebuildScopeItemsFromCache();
   }
 
-  isNotificationsEnabled(): boolean {
-    return this.notificationsEnabled;
-  }
-
-  toggleNotificationsEnabled(): void {
-    this.notificationsEnabled = !this.notificationsEnabled;
-    void this.persistState();
-    void this.applyNotificationContextKeys();
-    // Refresh just the visible scope items so their bell icons reflect the
-    // new global state immediately.
-    this._onDidChangeTreeData.fire(undefined);
+  /** True when at least one scope is currently un-muted. The title-bar action
+   *  uses this to pick between "mute all" (bell) and "unmute all" (bell-slash). */
+  isAnyScopeUnmuted(): boolean {
+    return SCOPE_ORDER.some(scope => !this.mutedScopes.has(scope));
   }
 
   isScopeMuted(scope: MessageScope): boolean {
     return this.mutedScopes.has(scope);
+  }
+
+  /** Flip every scope at once. If any scope is currently un-muted, mute all;
+   *  otherwise unmute all. */
+  toggleAllNotifications(): void {
+    const allMuted = !this.isAnyScopeUnmuted();
+    if (allMuted) {
+      this.mutedScopes.clear();
+    } else {
+      this.mutedScopes = new Set(SCOPE_ORDER);
+    }
+    void this.persistState();
+    void this.applyNotificationContextKeys();
+    this.rebuildScopeItemsFromCache();
   }
 
   toggleScopeMuted(scope: MessageScope): void {
@@ -220,7 +228,7 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     }
     void this.persistState();
     void this.applyNotificationContextKeys();
-    this._onDidChangeTreeData.fire(undefined);
+    this.rebuildScopeItemsFromCache();
   }
 
   recordExpanded(scope: MessageScope, expanded: boolean): void {
@@ -1169,9 +1177,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
       // new message, so the toast would be redundant.
       return;
     }
-    if (!this.notificationsEnabled) {
-      return;
-    }
     const scope = (typeof inner.scope === 'string' ? inner.scope : 'global') as MessageScope;
     if (this.mutedScopes.has(scope)) {
       return;
@@ -1245,9 +1250,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
         if (typeof stored.unreadOnly === 'boolean') {
           this.unreadOnly = stored.unreadOnly;
         }
-        if (typeof stored.notificationsEnabled === 'boolean') {
-          this.notificationsEnabled = stored.notificationsEnabled;
-        }
         if (Array.isArray(stored.mutedScopes)) {
           this.mutedScopes = new Set(stored.mutedScopes);
         }
@@ -1263,7 +1265,6 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     const state: PersistedState = {
       expandedScopes: Array.from(this.expandedScopes),
       unreadOnly: this.unreadOnly,
-      notificationsEnabled: this.notificationsEnabled,
       mutedScopes: Array.from(this.mutedScopes)
     };
     try {
@@ -1273,14 +1274,17 @@ export class ChatInboxTreeProvider implements vscode.TreeDataProvider<AnyTreeIte
     }
   }
 
-  /** Mirrors the notification settings into VS Code context keys so the menu
-   *  `when` clauses can swap between mute/unmute commands. We expose:
-   *    - `computor.chat.notificationsEnabled` — global on/off
-   *    - `computor.chat.mutedScopes` — space-separated list of scope ids the
-   *      user has muted; menu `when` clauses can use `=~ /\bsubmission_group\b/`
-   *      to test membership. */
+  /** Mirrors the mute set into VS Code context keys so menu `when` clauses
+   *  can pick the right icon variant.
+   *    - `computor.chat.anyScopeUnmuted` — true if at least one scope's
+   *      notifications are still on. The title-bar action shows the bell
+   *      (mute-all) variant when this is true and the bell-slash
+   *      (unmute-all) variant when it is false.
+   *    - `computor.chat.mutedScopes` — space-separated list of muted scope
+   *      ids. Per-scope inline icons swap on the contextValue suffix
+   *      (`.muted`) instead, but this stays available for future use. */
   private async applyNotificationContextKeys(): Promise<void> {
-    await vscode.commands.executeCommand('setContext', 'computor.chat.notificationsEnabled', this.notificationsEnabled);
+    await vscode.commands.executeCommand('setContext', 'computor.chat.anyScopeUnmuted', this.isAnyScopeUnmuted());
     await vscode.commands.executeCommand('setContext', 'computor.chat.mutedScopes', Array.from(this.mutedScopes).join(' '));
   }
 }

--- a/src/ui/webviews/MessagesWebviewProvider.ts
+++ b/src/ui/webviews/MessagesWebviewProvider.ts
@@ -102,6 +102,50 @@ export class MessagesWebviewProvider extends BaseWebviewProvider {
     }
   }
 
+  /**
+   * Returns true when the messages panel is currently visible AND its target
+   * matches the channel of the given message. Lets callers (e.g. the chat
+   * inbox toast) suppress notifications the user is already looking at.
+   */
+  public isShowingMessage(message: Record<string, unknown>): boolean {
+    if (!this.isPanelVisible || !this.panel) { return false; }
+    const target = this.getCurrentTarget();
+    if (!target) { return false; }
+
+    // If the panel pinned a scope, the message must share it.
+    const pinnedScope = (target.query as Record<string, unknown>).scope;
+    if (typeof pinnedScope === 'string' && pinnedScope !== message.scope) {
+      return false;
+    }
+
+    // Match every id-shaped query key that's set on the panel against the
+    // same key on the incoming message. If none are set the panel is the
+    // global list, so accept any global message.
+    const idKeys = [
+      'submission_group_id',
+      'course_content_id',
+      'course_group_id',
+      'course_id',
+      'course_family_id',
+      'organization_id',
+      'course_member_id',
+      'user_id'
+    ];
+    let anyIdMatched = false;
+    for (const key of idKeys) {
+      const targetVal = (target.query as Record<string, unknown>)[key];
+      if (targetVal === undefined) { continue; }
+      anyIdMatched = true;
+      if ((message as Record<string, unknown>)[key] !== targetVal) {
+        return false;
+      }
+    }
+    if (!anyIdMatched) {
+      return pinnedScope === 'global' && message.scope === 'global';
+    }
+    return true;
+  }
+
   private subscribeToChannel(target: MessageTargetContext): void {
     if (!this.wsService || !target.wsChannel) {
       return;

--- a/src/ui/webviews/MessagesWebviewProvider.ts
+++ b/src/ui/webviews/MessagesWebviewProvider.ts
@@ -53,6 +53,19 @@ export class MessagesWebviewProvider extends BaseWebviewProvider {
   private readonly wsHandlerId: string;
   private pendingUnreadMessageIds: Set<string> = new Set();
 
+  /** Shared instance reused across the chat, student, tutor and lecturer
+   *  views — every caller routes through the same provider so that opening
+   *  the same thread from two different trees focuses one panel rather than
+   *  spawning a second copy. */
+  private static shared: MessagesWebviewProvider | undefined;
+
+  static getShared(context: vscode.ExtensionContext, apiService: ComputorApiService): MessagesWebviewProvider {
+    if (!this.shared) {
+      this.shared = new MessagesWebviewProvider(context, apiService);
+    }
+    return this.shared;
+  }
+
   constructor(context: vscode.ExtensionContext, apiService: ComputorApiService) {
     super(context, 'computor.messagesView');
     this.apiService = apiService;


### PR DESCRIPTION
## Summary

7 commits cleaning up the messages experience plus per-scope notification controls.

### Toast / title polish
- `a5dff06` Resolve linked course_content title for submission-group threads
- `c8fe1f9` Suppress new-message toast for the thread already on screen
- `282190f` Drop redundant "Submission group" prefix from the title

### Webview reuse
- `3b7ba8a` Share one MessagesWebviewProvider across chat / student / tutor / lecturer

### Per-scope notification mute (new)
- `f162622` Per-scope and global notification mute toggles
- `ef9e8a3` Rebuild scope items on mute toggle; global action toggles all scopes
- `647d4bc` Prefix muted scope label with 🔕 so it aligns vertically

## Behaviour

- **Per-scope mute**: each scope row in the chat tree gets an inline bell / bell-slash button (also in the right-click menu). Click toggles. Muted rows show 🔕 prefix, persists across restart via `globalState`.
- **Global toggle**: title-bar bell action mutes / unmutes all 9 scopes at once. The icon picks bell vs bell-slash based on whether any scope is currently un-muted (`computor.chat.anyScopeUnmuted` context key).
- **Toast suppression**: new-message toasts skip muted scopes. Already-open thread = no toast (existing behaviour, kept).
- **Persistence**: `mutedScopes: MessageScope[]` rides alongside `expandedScopes` / `unreadOnly` in the existing chat state blob. Optional field, fully backward-compatible.

## Verification

- [x] Mute one scope from the inline bell — popup for that scope is suppressed; other scopes still notify.
- [x] Mute via right-click menu — same.
- [x] Title-bar bell mutes all; bell-slash unmutes all; both reflect via the inline icons immediately (no view-switch needed).
- [x] Restart VS Code — mute set is preserved.
- [x] Submission-group thread titles show the linked content name; no redundant "Submission group" prefix.
- [x] Toast does not fire for the thread currently visible in the panel.