### PR TITLE
Student: export course examples as ZIP (flat or tree)

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,12 @@
         "category": "Computor Student"
       },
       {
+        "command": "computor.student.exportCourseExamples",
+        "title": "Export Course Examples…",
+        "icon": "$(file-zip)",
+        "category": "Computor Student"
+      },
+      {
         "command": "computor.student.offline.addCourse",
         "title": "Add Course",
         "icon": "$(add)",
@@ -1800,6 +1806,11 @@
           "command": "computor.student.viewSubmissionGroup",
           "when": "view == computor.student.courses && viewItem =~ /^studentCourseContent/",
           "group": "2_details@1"
+        },
+        {
+          "command": "computor.student.exportCourseExamples",
+          "when": "view == computor.student.courses && viewItem == studentCourseRoot",
+          "group": "2_actions@1"
         },
         {
           "command": "computor.student.help",

--- a/src/commands/StudentCommands.ts
+++ b/src/commands/StudentCommands.ts
@@ -16,6 +16,8 @@ import type { WebSocketService } from '../services/WebSocketService';
 import { getExampleVersionId } from '../utils/deploymentHelpers';
 import JSZip from 'jszip';
 import { commandRegistrar } from './commandHelpers';
+import { buildCourseExportZip, sanitizeContentDirName, type CourseExportFormat } from '../utils/courseExportZip';
+import { runLockedWithProgress } from '../utils/progressLock';
 
 // (Deprecated legacy types removed)
 
@@ -226,6 +228,10 @@ export class StudentCommands {
 
     register('computor.student.showMessages', async (item?: any) => {
       await this.showMessages(item);
+    });
+
+    register('computor.student.exportCourseExamples', async (item?: any) => {
+      await this.exportCourseExamples(item);
     });
 
     register('computor.showTestResults', async (item?: any) => {
@@ -1125,6 +1131,88 @@ export class StudentCommands {
       console.error('[showHelp] Failed to show help:', error);
       vscode.window.showErrorMessage('Failed to open help documentation');
     }
+  }
+
+  private async exportCourseExamples(item?: any): Promise<void> {
+    const courseId: string | undefined = typeof item?.courseId === 'string' ? item.courseId : undefined;
+    const courseTitle: string = typeof item?.title === 'string' && item.title.trim().length > 0
+      ? item.title
+      : 'Course';
+    if (!courseId) {
+      vscode.window.showWarningMessage('No course selected for export.');
+      return;
+    }
+
+    const formatPick = await vscode.window.showQuickPick(
+      [
+        { label: 'Tree (default)', description: 'Mirror the course content tree, named by content titles', value: 'tree' as CourseExportFormat },
+        { label: 'Flat', description: 'One folder per assignment, named by example identifier', value: 'flat' as CourseExportFormat }
+      ],
+      {
+        title: `Export ${courseTitle}: choose archive layout`,
+        placeHolder: 'Tree (recommended)',
+        ignoreFocusOut: true
+      }
+    );
+    if (!formatPick) { return; }
+
+    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!workspaceRoot) {
+      vscode.window.showWarningMessage('Open a workspace folder before exporting.');
+      return;
+    }
+
+    const defaultFile = `${sanitizeContentDirName(courseTitle)}.${formatPick.value}.zip`;
+    const dest = await vscode.window.showSaveDialog({
+      defaultUri: vscode.Uri.file(path.join(workspaceRoot, defaultFile)),
+      filters: { 'ZIP Archives': ['zip'] },
+      saveLabel: 'Export'
+    });
+    if (!dest) { return; }
+
+    await runLockedWithProgress(
+      {
+        key: `student-export:${courseId}`,
+        title: `Exporting ${courseTitle}…`,
+        duplicateMessage: 'Export already in progress for this course.',
+        timeoutMs: 300_000
+      },
+      async () => {
+        const contents = (await this.apiService.getStudentCourseContents(courseId)) ?? [];
+        if (contents.length === 0) {
+          vscode.window.showInformationMessage('No course contents found to export.');
+          return;
+        }
+
+        const result = await buildCourseExportZip({
+          contents,
+          workspaceRoot,
+          format: formatPick.value
+        });
+
+        if (result.packaged === 0) {
+          vscode.window.showWarningMessage(
+            'Nothing was exported — clone or check out the assignments first.'
+          );
+          return;
+        }
+
+        const buffer = await result.zip.generateAsync({
+          type: 'nodebuffer',
+          compression: 'DEFLATE',
+          compressionOptions: { level: 6 }
+        });
+        await fs.promises.writeFile(dest.fsPath, buffer);
+
+        const summary = result.missing.length > 0
+          ? `Exported ${result.packaged} assignment(s); skipped ${result.missing.length} not on disk.`
+          : `Exported ${result.packaged} assignment(s).`;
+        const choice = await vscode.window.showInformationMessage(summary, 'Reveal');
+        if (choice === 'Reveal') {
+          void vscode.commands.executeCommand('revealFileInOS', dest);
+        }
+      }
+    );
   }
 
   private async showMessages(item?: any): Promise<void> {

--- a/src/commands/StudentCommands.ts
+++ b/src/commands/StudentCommands.ts
@@ -1191,9 +1191,15 @@ export class StudentCommands {
         });
 
         if (result.packaged === 0) {
-          vscode.window.showWarningMessage(
-            'Nothing was exported — clone or check out the assignments first.'
+          console.warn('[exportCourseExamples] Nothing packaged. Probed paths:', result.probedPaths);
+          const sample = result.probedPaths.slice(0, 3).join('\n');
+          const choice = await vscode.window.showWarningMessage(
+            `Nothing was exported. Probed ${result.probedPaths.length} path(s).${sample ? `\nFirst: ${sample}` : ''}`,
+            'Open Console'
           );
+          if (choice === 'Open Console') {
+            void vscode.commands.executeCommand('workbench.action.toggleDevTools');
+          }
           return;
         }
 

--- a/src/commands/StudentCommands.ts
+++ b/src/commands/StudentCommands.ts
@@ -1213,10 +1213,13 @@ export class StudentCommands {
         const summary = result.missing.length > 0
           ? `Exported ${result.packaged} assignment(s); skipped ${result.missing.length} not on disk.`
           : `Exported ${result.packaged} assignment(s).`;
-        const choice = await vscode.window.showInformationMessage(summary, 'Reveal');
-        if (choice === 'Reveal') {
-          void vscode.commands.executeCommand('revealFileInOS', dest);
-        }
+        // Fire-and-forget: awaiting this would keep the "Exporting…" progress
+        // popup open until the user dismisses the success toast.
+        void vscode.window.showInformationMessage(summary, 'Reveal').then(choice => {
+          if (choice === 'Reveal') {
+            void vscode.commands.executeCommand('revealFileInOS', dest);
+          }
+        });
       }
     );
   }

--- a/src/utils/courseExportZip.ts
+++ b/src/utils/courseExportZip.ts
@@ -3,10 +3,7 @@ import * as path from 'path';
 import JSZip from 'jszip';
 import { shouldExcludeExampleEntry } from './exampleExcludePatterns';
 import { buildStudentRepoRoot } from './repositoryNaming';
-import type {
-  CourseContentStudentList,
-  SubmissionGroupStudentList
-} from '../types/generated';
+import type { CourseContentStudentList } from '../types/generated';
 
 export type CourseExportFormat = 'flat' | 'tree';
 
@@ -18,15 +15,15 @@ export interface CourseExportInput {
 
 export interface CourseExportResult {
   zip: JSZip;
-  /** Number of assignment directories actually packaged. */
   packaged: number;
-  /** Assignments whose local directory is missing on disk. */
+  /** Title list for assignments whose source folder didn't exist on disk. */
   missing: string[];
+  /** Probed paths — surfaced when packaged == 0 to help debug. */
+  probedPaths: string[];
 }
 
-/** Replaces whitespace with `_`, strips filesystem-unsafe and control
- *  characters, collapses repeats. Returns `'untitled'` for inputs that boil
- *  down to nothing usable. Used for tree-format folder names. */
+/** Replaces whitespace with `_`, strips filesystem-unsafe and control chars,
+ *  collapses repeats. Returns `'untitled'` for blank inputs. */
 export function sanitizeContentDirName(raw: string | null | undefined): string {
   const source = (raw ?? '').toString().normalize('NFKD');
   const cleaned = source
@@ -40,38 +37,34 @@ export function sanitizeContentDirName(raw: string | null | undefined): string {
   return cleaned || 'untitled';
 }
 
-/** Mirrors the convention from the tutor / student trees: the assignment
- *  files live in the repository at `directory` (or fall back to the example
- *  identifier / last path segment). */
-function deriveAssignmentSubdirectory(content: CourseContentStudentList): string | undefined {
-  const raw = (content as any)?.directory as string | undefined
-    ?? content.submission_group?.example_identifier
-    ?? content.path?.split('.').pop();
-  if (!raw) { return undefined; }
-  const normalized = path.normalize(raw).replace(/^([\\/]+)/, '');
-  if (!normalized || normalized === '.' || normalized === '..') {
-    return undefined;
-  }
-  const segments = normalized.split(/[\\/]+/).filter(seg => seg && seg !== '..');
-  return segments.length > 0 ? segments.join(path.sep) : undefined;
-}
-
-function getRepoRoot(workspaceRoot: string, submissionGroup: SubmissionGroupStudentList | undefined | null): string | undefined {
-  const fullPath = submissionGroup?.repository?.full_path;
+/** Mirrors StudentCourseContentTreeProvider.getStudentRepoRoot — turns
+ *  `submission_group.repository.full_path` into the local repo directory. */
+function repoRootFor(
+  content: CourseContentStudentList,
+  workspaceRoot: string
+): string | undefined {
+  const fullPath = content.submission_group?.repository?.full_path;
   if (!fullPath) { return undefined; }
   const dirName = fullPath.replace(/\//g, '.');
   return buildStudentRepoRoot(workspaceRoot, dirName);
 }
 
-/** A content node is exportable if it has a submission_group (which is the
- *  practical signal that it's an assignment with cloneable files) regardless
- *  of how the kind / slug are spelled. Pure units don't get a submission_group. */
-function isExportable(content: CourseContentStudentList): boolean {
-  return content.submission_group != null && !!content.submission_group.repository?.full_path;
+/** Mirrors StudentCourseContentTreeProvider's `resolvePath` helper used to
+ *  locate the assignment folder: absolute `directory` is taken verbatim;
+ *  relative `directory` is joined onto repoRoot. When `directory` is missing
+ *  we fall back to repoRoot itself. */
+function localAssignmentPath(
+  content: CourseContentStudentList,
+  workspaceRoot: string
+): string | undefined {
+  const repoRoot = repoRootFor(content, workspaceRoot);
+  if (!repoRoot) { return undefined; }
+  const directory = (content as any)?.directory as string | undefined;
+  if (!directory) { return repoRoot; }
+  if (path.isAbsolute(directory)) { return directory; }
+  return path.join(repoRoot, directory);
 }
 
-/** Builds the zip-internal path for a content node in tree format by walking
- *  its dotted `path` ancestors and joining sanitized titles. */
 function buildTreePath(
   content: CourseContentStudentList,
   byPath: Map<string, CourseContentStudentList>
@@ -82,16 +75,18 @@ function buildTreePath(
     const ancestorPath = parts.slice(0, i).join('.');
     const ancestor = byPath.get(ancestorPath);
     const fallback = parts[i - 1] ?? '';
-    const candidate = ancestor?.title ?? fallback;
-    segments.push(sanitizeContentDirName(candidate));
+    segments.push(sanitizeContentDirName(ancestor?.title ?? fallback));
   }
   return segments.join('/');
 }
 
-/** Recursively packages a directory into the zip under `zipBasePath`,
- *  skipping git / IDE / OS metadata files via `shouldExcludeExampleEntry` and
- *  also any entry whose name starts with `.` (catches things the shared
- *  exclude list misses, e.g. `.envrc`). */
+function flatNameFor(content: CourseContentStudentList): string {
+  const exampleId = content.submission_group?.example_identifier;
+  const directory = (content as any)?.directory as string | undefined;
+  const fallback = content.path?.split('.').pop();
+  return sanitizeContentDirName(exampleId || (directory ? path.basename(directory) : '') || fallback || content.id);
+}
+
 function addDirectoryToZip(zip: JSZip, sourceDir: string, zipBasePath: string): void {
   const walk = (current: string, baseInZip: string): void => {
     let entries: fs.Dirent[];
@@ -131,15 +126,16 @@ export async function buildCourseExportZip(input: CourseExportInput): Promise<Co
 
   let packaged = 0;
   const missing: string[] = [];
+  const probedPaths: string[] = [];
 
   for (const content of input.contents) {
-    if (!isExportable(content)) { continue; }
-    const submissionGroup = content.submission_group;
-    const repoRoot = getRepoRoot(input.workspaceRoot, submissionGroup);
-    if (!repoRoot) { continue; }
+    // The student tree only renders files for nodes with a submission_group;
+    // mirror that — pure unit folders aren't exportable.
+    if (!content.submission_group) { continue; }
 
-    const subdir = deriveAssignmentSubdirectory(content);
-    const sourcePath = subdir ? path.join(repoRoot, subdir) : repoRoot;
+    const sourcePath = localAssignmentPath(content, input.workspaceRoot);
+    if (!sourcePath) { continue; }
+    probedPaths.push(sourcePath);
 
     let exists = false;
     try {
@@ -153,14 +149,13 @@ export async function buildCourseExportZip(input: CourseExportInput): Promise<Co
     }
 
     const zipBasePath = input.format === 'flat'
-      ? sanitizeContentDirName(submissionGroup?.example_identifier || subdir || content.title || content.path)
+      ? flatNameFor(content)
       : buildTreePath(content, byPath);
 
     if (!zipBasePath) { continue; }
-
     addDirectoryToZip(zip, sourcePath, zipBasePath);
     packaged += 1;
   }
 
-  return { zip, packaged, missing };
+  return { zip, packaged, missing, probedPaths };
 }

--- a/src/utils/courseExportZip.ts
+++ b/src/utils/courseExportZip.ts
@@ -1,0 +1,165 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import JSZip from 'jszip';
+import { shouldExcludeExampleEntry } from './exampleExcludePatterns';
+import { buildStudentRepoRoot } from './repositoryNaming';
+import type {
+  CourseContentStudentList,
+  SubmissionGroupStudentList
+} from '../types/generated';
+
+export type CourseExportFormat = 'flat' | 'tree';
+
+export interface CourseExportInput {
+  contents: CourseContentStudentList[];
+  workspaceRoot: string;
+  format: CourseExportFormat;
+}
+
+export interface CourseExportResult {
+  zip: JSZip;
+  /** Number of assignment directories actually packaged. */
+  packaged: number;
+  /** Assignments whose local directory is missing on disk. */
+  missing: string[];
+}
+
+/** Replaces whitespace with `_`, strips filesystem-unsafe and control
+ *  characters, collapses repeats. Returns `'untitled'` for inputs that boil
+ *  down to nothing usable. Used for tree-format folder names. */
+export function sanitizeContentDirName(raw: string | null | undefined): string {
+  const source = (raw ?? '').toString().normalize('NFKD');
+  const cleaned = source
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f<>:"/\\|?*]+/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/-+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '')
+    .trim();
+  return cleaned || 'untitled';
+}
+
+/** Mirrors the convention from the tutor / student trees: the assignment
+ *  files live in the repository at `directory` (or fall back to the example
+ *  identifier / last path segment). */
+function deriveAssignmentSubdirectory(content: CourseContentStudentList): string | undefined {
+  const raw = (content as any)?.directory as string | undefined
+    ?? content.submission_group?.example_identifier
+    ?? content.path?.split('.').pop();
+  if (!raw) { return undefined; }
+  const normalized = path.normalize(raw).replace(/^([\\/]+)/, '');
+  if (!normalized || normalized === '.' || normalized === '..') {
+    return undefined;
+  }
+  const segments = normalized.split(/[\\/]+/).filter(seg => seg && seg !== '..');
+  return segments.length > 0 ? segments.join(path.sep) : undefined;
+}
+
+function getRepoRoot(workspaceRoot: string, submissionGroup: SubmissionGroupStudentList | undefined | null): string | undefined {
+  const fullPath = submissionGroup?.repository?.full_path;
+  if (!fullPath) { return undefined; }
+  const dirName = fullPath.replace(/\//g, '.');
+  return buildStudentRepoRoot(workspaceRoot, dirName);
+}
+
+function isAssignment(content: CourseContentStudentList): boolean {
+  const ct = (content as any)?.course_content_type ?? (content as any)?.course_content_types;
+  const kindId = (Array.isArray(ct) ? ct[0] : ct)?.course_content_kind_id;
+  return typeof kindId === 'string' && kindId === 'assignment';
+}
+
+/** Builds the zip-internal path for a content node in tree format by walking
+ *  its dotted `path` ancestors and joining sanitized titles. */
+function buildTreePath(
+  content: CourseContentStudentList,
+  byPath: Map<string, CourseContentStudentList>
+): string {
+  const parts = (content.path || '').split('.').filter(Boolean);
+  const segments: string[] = [];
+  for (let i = 1; i <= parts.length; i++) {
+    const ancestorPath = parts.slice(0, i).join('.');
+    const ancestor = byPath.get(ancestorPath);
+    const fallback = parts[i - 1] ?? '';
+    const candidate = ancestor?.title ?? fallback;
+    segments.push(sanitizeContentDirName(candidate));
+  }
+  return segments.join('/');
+}
+
+/** Recursively packages a directory into the zip under `zipBasePath`,
+ *  skipping git / IDE / OS metadata files via `shouldExcludeExampleEntry` and
+ *  also any entry whose name starts with `.` (catches things the shared
+ *  exclude list misses, e.g. `.envrc`). */
+function addDirectoryToZip(zip: JSZip, sourceDir: string, zipBasePath: string): void {
+  const walk = (current: string, baseInZip: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch (err) {
+      console.warn('[courseExportZip] Failed to read directory:', current, err);
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) { continue; }
+      if (shouldExcludeExampleEntry(entry.name)) { continue; }
+      const abs = path.join(current, entry.name);
+      const inZipPath = baseInZip ? `${baseInZip}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(abs, inZipPath);
+      } else if (entry.isFile()) {
+        try {
+          zip.file(inZipPath, fs.readFileSync(abs));
+        } catch (err) {
+          console.warn('[courseExportZip] Failed to read file:', abs, err);
+        }
+      }
+    }
+  };
+  walk(sourceDir, zipBasePath);
+}
+
+export async function buildCourseExportZip(input: CourseExportInput): Promise<CourseExportResult> {
+  const zip = new JSZip();
+  const byPath = new Map<string, CourseContentStudentList>();
+  for (const c of input.contents) {
+    if (typeof c.path === 'string' && c.path.length > 0) {
+      byPath.set(c.path, c);
+    }
+  }
+
+  let packaged = 0;
+  const missing: string[] = [];
+
+  for (const content of input.contents) {
+    if (!isAssignment(content)) { continue; }
+    const submissionGroup = content.submission_group;
+    const repoRoot = getRepoRoot(input.workspaceRoot, submissionGroup);
+    if (!repoRoot) { continue; }
+
+    const subdir = deriveAssignmentSubdirectory(content);
+    const sourcePath = subdir ? path.join(repoRoot, subdir) : repoRoot;
+
+    let exists = false;
+    try {
+      exists = fs.existsSync(sourcePath) && fs.statSync(sourcePath).isDirectory();
+    } catch {
+      exists = false;
+    }
+    if (!exists) {
+      missing.push(content.title || content.path || content.id);
+      continue;
+    }
+
+    const zipBasePath = input.format === 'flat'
+      ? sanitizeContentDirName(submissionGroup?.example_identifier || subdir || content.title || content.path)
+      : buildTreePath(content, byPath);
+
+    if (!zipBasePath) { continue; }
+
+    addDirectoryToZip(zip, sourcePath, zipBasePath);
+    packaged += 1;
+  }
+
+  return { zip, packaged, missing };
+}

--- a/src/utils/courseExportZip.ts
+++ b/src/utils/courseExportZip.ts
@@ -63,10 +63,11 @@ function getRepoRoot(workspaceRoot: string, submissionGroup: SubmissionGroupStud
   return buildStudentRepoRoot(workspaceRoot, dirName);
 }
 
-function isAssignment(content: CourseContentStudentList): boolean {
-  const ct = (content as any)?.course_content_type ?? (content as any)?.course_content_types;
-  const kindId = (Array.isArray(ct) ? ct[0] : ct)?.course_content_kind_id;
-  return typeof kindId === 'string' && kindId === 'assignment';
+/** A content node is exportable if it has a submission_group (which is the
+ *  practical signal that it's an assignment with cloneable files) regardless
+ *  of how the kind / slug are spelled. Pure units don't get a submission_group. */
+function isExportable(content: CourseContentStudentList): boolean {
+  return content.submission_group != null && !!content.submission_group.repository?.full_path;
 }
 
 /** Builds the zip-internal path for a content node in tree format by walking
@@ -132,7 +133,7 @@ export async function buildCourseExportZip(input: CourseExportInput): Promise<Co
   const missing: string[] = [];
 
   for (const content of input.contents) {
-    if (!isAssignment(content)) { continue; }
+    if (!isExportable(content)) { continue; }
     const submissionGroup = content.submission_group;
     const repoRoot = getRepoRoot(input.workspaceRoot, submissionGroup);
     if (!repoRoot) { continue; }


### PR DESCRIPTION
## Summary

Adds an **Export Course Examples…** command on the student course root tree item. Packages every assignment for that course into a ZIP in one of two layouts.

4 commits:
- \`4701d89\` feat: export course examples as zip in flat or tree layout
- \`117ec26\` fix: export by submission_group presence instead of strict kind id
- \`a75377f\` fix: mirror tree's resolvePath logic for absolute/relative directory
- \`182b27e\` fix: close export progress popup as soon as zip is written

## Behaviour

Right-click the course root → **Export Course Examples…**

1. Quick-pick layout: **Tree** (default) or **Flat**.
2. Save dialog defaults to \`<course-title>.tree.zip\` / \`.flat.zip\` in the workspace.
3. Non-cancellable progress notification while building (5-min safety timeout, key per courseId so a duplicate click is rejected).

**Layouts:**
- **Flat** — one folder at the root per assignment, named by \`example_identifier\` (falls back to the on-disk directory or content title).
- **Tree** — folder hierarchy mirrors the student course-content tree, named by **sanitized content titles** (whitespace → \`_\`, filesystem-unsafe characters stripped, repeats collapsed).

**Source resolution** mirrors \`StudentCourseContentTreeProvider.getStudentRepoRoot\` and its \`resolvePath\` helper exactly: \`\${workspaceRoot}/student/\${repository.full_path.replace('/', '.')}\`, plus \`directory\` (absolute → as-is, relative → joined onto the repo root).

**Skip rules** during the file walk:
- Anything starting with \`.\` (kills \`.git\`, \`.DS_Store\`, \`.env\`, all hidden files)
- The shared \`shouldExcludeExampleEntry\` list (\`node_modules\`, \`__pycache__\`, \`*.pyc\`, \`.vscode\`, \`.idea\`, etc.)

**Edge cases:**
- No course contents → "No course contents found".
- Nothing on disk → diagnostic message listing the first probed paths + an "Open Console" affordance.
- Some assignments missing on disk → counted in the success summary.

## Test plan

- [ ] Course with mixed assignment kinds (\`assignment\`, \`exercise\`, etc.) — all package into the ZIP.
- [ ] Tree layout — opening the ZIP shows the same hierarchy as the student tree, with sanitized folder names.
- [ ] Flat layout — top-level folders named after \`example_identifier\`.
- [ ] Course with un-cloned assignments — message reports the count skipped.
- [ ] Progress notification closes as soon as the ZIP is written; the success toast appears separately.
- [ ] Duplicate click while exporting — second click rejected with a friendly message.
- [ ] Resulting ZIP contains no \`.git\`, \`.DS_Store\`, or \`__pycache__\` directories.