### PR TITLE
feat(lecturer): Manage Members webview on the course node (roster, add, import)

### DIFF
--- a/package.json
+++ b/package.json
@@ -878,6 +878,12 @@
         "category": "Computor Lecturer"
       },
       {
+        "command": "computor.lecturer.manageCourseMembers",
+        "title": "Manage Members",
+        "icon": "$(organization)",
+        "category": "Computor Lecturer"
+      },
+      {
         "command": "computor.lecturer.showCourseGroupDetails",
         "title": "Show Details",
         "icon": "$(info)",
@@ -1665,6 +1671,11 @@
           "command": "computor.lecturer.configureCourseGit",
           "when": "view == computor.lecturer.courses && viewItem == course",
           "group": "2_config@1"
+        },
+        {
+          "command": "computor.lecturer.manageCourseMembers",
+          "when": "view == computor.lecturer.courses && viewItem == course",
+          "group": "2_discussion@2"
         },
         {
           "command": "computor.lecturer.showCourseDetails",

--- a/src/commands/LecturerCommands.ts
+++ b/src/commands/LecturerCommands.ts
@@ -14,6 +14,7 @@ import { CourseContentTypeWebviewProvider } from '../ui/webviews/CourseContentTy
 import { CourseGroupWebviewProvider } from '../ui/webviews/CourseGroupWebviewProvider';
 import { CourseMemberWebviewProvider } from '../ui/webviews/CourseMemberWebviewProvider';
 import { CourseMemberImportWebviewProvider } from '../ui/webviews/CourseMemberImportWebviewProvider';
+import { ManageCourseMembersWebviewProvider } from '../ui/webviews/ManageCourseMembersWebviewProvider';
 import { MessagesWebviewProvider, MessageTargetContext } from '../ui/webviews/MessagesWebviewProvider';
 import { CourseMemberCommentsWebviewProvider } from '../ui/webviews/CourseMemberCommentsWebviewProvider';
 import { CourseMemberCommentsInputPanelProvider } from '../ui/panels/CourseMemberCommentsInputPanel';
@@ -53,6 +54,7 @@ export class LecturerCommands {
   private courseGroupWebviewProvider: CourseGroupWebviewProvider;
   private courseMemberWebviewProvider: CourseMemberWebviewProvider;
   private courseMemberImportWebviewProvider: CourseMemberImportWebviewProvider;
+  private manageCourseMembersWebviewProvider: ManageCourseMembersWebviewProvider;
   private courseGroupCommands: CourseGroupCommands;
   private messagesWebviewProvider: MessagesWebviewProvider;
   private commentsWebviewProvider: CourseMemberCommentsWebviewProvider;
@@ -79,6 +81,7 @@ export class LecturerCommands {
     this.courseGroupWebviewProvider = new CourseGroupWebviewProvider(context, this.apiService, this.treeDataProvider);
     this.courseMemberWebviewProvider = new CourseMemberWebviewProvider(context, this.apiService, this.treeDataProvider);
     this.courseMemberImportWebviewProvider = new CourseMemberImportWebviewProvider(context, this.apiService, this.treeDataProvider);
+    this.manageCourseMembersWebviewProvider = new ManageCourseMembersWebviewProvider(context, this.apiService, this.treeDataProvider);
     this.messagesWebviewProvider = MessagesWebviewProvider.getShared(context, this.apiService);
     if (messagesInputPanel) {
       this.messagesWebviewProvider.setInputPanel(messagesInputPanel);
@@ -193,6 +196,11 @@ export class LecturerCommands {
     // Course member import with preview
     register('computor.lecturer.importCourseMembersPreview', async (item: CourseTreeItem | CourseFolderTreeItem) => {
       await this.importCourseMembersWithPreview(item);
+    });
+
+    // Manage members (roster + add) — on the course node
+    register('computor.lecturer.manageCourseMembers', async (item: CourseTreeItem) => {
+      await this.manageCourseMembers(item);
     });
 
     register('computor.lecturer.editCourseContentType', async (item: CourseContentTypeTreeItem) => {
@@ -2440,6 +2448,24 @@ export class LecturerCommands {
       console.error('Failed to show course members:', error);
       vscode.window.showErrorMessage(
         `Failed to show course members: ${error?.message || error}`
+      );
+    }
+  }
+
+  async manageCourseMembers(item: CourseTreeItem): Promise<void> {
+    try {
+      if (!(item instanceof CourseTreeItem) || !item.course?.id) {
+        vscode.window.showErrorMessage('Please select a course to manage its members.');
+        return;
+      }
+      await this.manageCourseMembersWebviewProvider.open(
+        item.course.id,
+        item.course.title || item.course.path
+      );
+    } catch (error: any) {
+      console.error('Failed to open course member management:', error);
+      vscode.window.showErrorMessage(
+        `Failed to open course member management: ${error?.message || error}`
       );
     }
   }

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -53,6 +53,7 @@ import {
   CourseRoleList,
   CourseMemberList,
   CourseMemberGet,
+  CourseMemberCreate,
   CourseMemberUpdate,
   CourseMemberReadinessStatus,
   CourseMemberImportResponse,
@@ -1306,6 +1307,24 @@ export class ComputorApiService {
     return response.data;
   }
 
+  async createCourseMember(member: CourseMemberCreate): Promise<CourseMemberGet> {
+    const client = await this.getHttpClient();
+    const response = await client.post<CourseMemberGet>('/course-members', member);
+
+    // Invalidate related caches so the roster reflects the new member.
+    this.invalidateCachePattern('courseMembers-');
+
+    return response.data;
+  }
+
+  async deleteCourseMember(memberId: string): Promise<void> {
+    const client = await this.getHttpClient();
+    await client.delete(`/course-members/${memberId}`);
+
+    // Invalidate related caches so the roster reflects the removal.
+    this.invalidateCachePattern('courseMembers-');
+  }
+
   /**
    * Lecturer: Sync GitLab permissions for a course member
    */
@@ -2265,6 +2284,23 @@ export class ComputorApiService {
       console.error('[getUsers] Failed to fetch users:', error);
       throw error;
     }
+  }
+
+  /**
+   * Search/paginate users via the backend's permission-scoped /users list.
+   * `search` is a substring match over name + email; the backend still filters
+   * to users the caller may see, so this never widens visibility. Not cached —
+   * the result set depends on the (search, skip) cursor.
+   */
+  async searchUsers(params?: { search?: string; skip?: number; limit?: number }): Promise<UserList[]> {
+    const client = await this.getHttpClient();
+    return (
+      await client.get<UserList[]>('/users', {
+        search: params?.search || undefined,
+        skip: params?.skip,
+        limit: params?.limit,
+      })
+    ).data;
   }
 
   // User Management: Get a specific user by ID

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -1326,6 +1326,24 @@ export class ComputorApiService {
   }
 
   /**
+   * Parse an uploaded member file (CSV/JSON/XLSX/Excel-XML) into preview rows.
+   * Read-only on the backend — no members are imported. `contentBase64` is the
+   * raw file bytes base64-encoded (handles binary xlsx over plain JSON).
+   */
+  async parseCourseMemberFile(
+    courseId: string,
+    filename: string,
+    contentBase64: string
+  ): Promise<{ rows: any[]; detected_format?: string; warnings?: string[] }> {
+    const client = await this.getHttpClient();
+    const response = await client.post<{ rows: any[]; detected_format?: string; warnings?: string[] }>(
+      `/course-member-import/parse/${courseId}`,
+      { filename, content_base64: contentBase64 }
+    );
+    return response.data;
+  }
+
+  /**
    * Lecturer: Sync GitLab permissions for a course member
    */
   async syncMemberGitlabPermissions(

--- a/src/ui/webviews/ManageCourseMembersWebviewProvider.ts
+++ b/src/ui/webviews/ManageCourseMembersWebviewProvider.ts
@@ -172,6 +172,10 @@ export class ManageCourseMembersWebviewProvider extends BaseWebviewProvider {
         return this.handleRemoveMember(message.data);
       case 'importByEmail':
         return this.handleImportByEmail(message.data);
+      case 'pickImportFile':
+        return this.handlePickImportFile();
+      case 'importFileRow':
+        return this.handleImportFileRow(message.data);
       case 'refresh':
         return this.refreshAndPostMembers();
       case 'showError':
@@ -288,6 +292,59 @@ export class ManageCourseMembersWebviewProvider extends BaseWebviewProvider {
       await this.panel?.webview.postMessage({
         command: 'importResult',
         data: { ok: false, message: errMessage(e) },
+      });
+    }
+  }
+
+  private async handlePickImportFile(): Promise<void> {
+    if (!this.courseId) return;
+    const picked = await vscode.window.showOpenDialog({
+      canSelectMany: false,
+      openLabel: 'Select member file',
+      filters: { 'Member lists': ['csv', 'tsv', 'txt', 'json', 'xlsx', 'xls', 'xml'] },
+    });
+    const uri = picked && picked[0];
+    if (!uri) return;
+    const filename = uri.path.split('/').pop() || 'members';
+    try {
+      const bytes = await vscode.workspace.fs.readFile(uri);
+      const contentBase64 = Buffer.from(bytes).toString('base64');
+      const res = await this.apiService.parseCourseMemberFile(this.courseId, filename, contentBase64);
+      await this.panel?.webview.postMessage({
+        command: 'parsedRows',
+        data: { filename, rows: res.rows || [] },
+      });
+    } catch (e) {
+      await this.panel?.webview.postMessage({
+        command: 'parsedRows',
+        data: { filename, rows: [], error: errMessage(e) },
+      });
+    }
+  }
+
+  private async handleImportFileRow(data: any): Promise<void> {
+    const member = data?.member;
+    if (!this.courseId || !member?.email) return;
+    try {
+      const res = await this.apiService.importSingleCourseMember(
+        this.courseId,
+        {
+          email: String(member.email).trim(),
+          given_name: member.given_name?.trim() || null,
+          family_name: member.family_name?.trim() || null,
+          course_group_title: member.course_group_title?.trim() || null,
+          course_role_id: member.course_role_id,
+        },
+        { createMissingGroup: true, updateIfExists: true }
+      );
+      await this.panel?.webview.postMessage({
+        command: 'fileRowResult',
+        data: { index: data.index, ok: !!res.success, message: res.message },
+      });
+    } catch (e) {
+      await this.panel?.webview.postMessage({
+        command: 'fileRowResult',
+        data: { index: data.index, ok: false, message: errMessage(e) },
       });
     }
   }

--- a/src/ui/webviews/ManageCourseMembersWebviewProvider.ts
+++ b/src/ui/webviews/ManageCourseMembersWebviewProvider.ts
@@ -1,0 +1,324 @@
+import * as vscode from 'vscode';
+import { BaseWebviewProvider } from './BaseWebviewProvider';
+import { CourseMemberList, CourseGroupList } from '../../types/generated';
+import { ComputorApiService } from '../../services/ComputorApiService';
+import { LecturerTreeDataProvider } from '../tree/lecturer/LecturerTreeDataProvider';
+
+// Course role hierarchy mirrored from the backend (permissions/roles.py +
+// principal.py). Used for UI gating only — the backend still enforces the
+// assignment ceiling on every create/update/delete.
+const COURSE_ROLES = ['_student', '_tutor', '_lecturer', '_maintainer', '_owner'];
+const ROLE_RANK: Record<string, number> = {
+  _student: 1,
+  _tutor: 2,
+  _lecturer: 3,
+  _maintainer: 4,
+  _owner: 5,
+};
+const ROLE_LABEL: Record<string, string> = {
+  _student: 'Student',
+  _tutor: 'Tutor',
+  _lecturer: 'Lecturer',
+  _maintainer: 'Maintainer',
+  _owner: 'Owner',
+};
+
+const USERS_PAGE_SIZE = 10;
+
+function rank(roleId?: string | null): number {
+  return roleId ? ROLE_RANK[roleId] ?? 0 : 0;
+}
+
+function highestRole(roleIds: string[]): string | null {
+  let best: string | null = null;
+  for (const r of roleIds) {
+    if (rank(r) > rank(best)) best = r;
+  }
+  return best;
+}
+
+function errMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+interface MemberRow {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+  roleId: string;
+  group: string;
+  isSelf: boolean;
+  manageable: boolean;
+}
+
+/**
+ * "Manage Members" panel for a course (lecturer tree → course node). Shows the
+ * roster with inline role change + remove, plus an add section (searchable,
+ * paged user table and an add-by-email form). Distinct from the Groups-folder
+ * "Show Members" bulk importer, which is left untouched.
+ */
+export class ManageCourseMembersWebviewProvider extends BaseWebviewProvider {
+  private apiService: ComputorApiService;
+  private treeDataProvider?: LecturerTreeDataProvider;
+  private courseId?: string;
+  private groups: CourseGroupList[] = [];
+  private ceiling: string | null = null;
+  private assignableRoles: string[] = [];
+  private canManage = false;
+  private currentUserId?: string;
+
+  constructor(
+    context: vscode.ExtensionContext,
+    apiService: ComputorApiService,
+    treeDataProvider?: LecturerTreeDataProvider
+  ) {
+    super(context, 'computor.manageCourseMembers');
+    this.apiService = apiService;
+    this.treeDataProvider = treeDataProvider;
+  }
+
+  async open(courseId: string, courseName?: string): Promise<void> {
+    this.courseId = courseId;
+
+    // Compute the caller's assignment ceiling for this course (admin and
+    // organization managers are uncapped → _owner; otherwise their highest
+    // course role). Mirrors the backend rule; used only for UI gating.
+    try {
+      const [scopes, account] = await Promise.all([
+        this.apiService.getUserScopes(),
+        this.apiService.getUserAccount(),
+      ]);
+      const userRoleIds = (account?.user_roles ?? []).map((r) => r.role_id);
+      const isAdmin = !!scopes?.is_admin || userRoleIds.includes('_admin');
+      const isOrgManager = userRoleIds.includes('_organization_manager');
+      const courseRoleIds = scopes?.course?.[courseId] ?? [];
+      this.ceiling = isAdmin || isOrgManager ? '_owner' : highestRole(courseRoleIds);
+      this.currentUserId = account?.id || this.apiService.getCurrentUserId();
+    } catch {
+      this.ceiling = null;
+      this.currentUserId = this.apiService.getCurrentUserId();
+    }
+    this.canManage = rank(this.ceiling) >= rank('_lecturer');
+    this.assignableRoles = this.canManage
+      ? COURSE_ROLES.filter((r) => rank(r) <= rank(this.ceiling))
+      : [];
+
+    const members = await this.loadMembers();
+
+    await this.show(`Members: ${courseName || 'Course'}`, {
+      courseId,
+      courseName: courseName || 'Course',
+      members,
+      canManage: this.canManage,
+      assignableRoles: this.assignableRoles,
+      roleLabels: ROLE_LABEL,
+      usersPageSize: USERS_PAGE_SIZE,
+    });
+  }
+
+  private async loadMembers(): Promise<MemberRow[]> {
+    if (!this.courseId) return [];
+    const [membersRes, groupsRes] = await Promise.allSettled([
+      this.apiService.getCourseMembers(this.courseId),
+      this.apiService.getCourseGroups(this.courseId),
+    ]);
+    const raw: CourseMemberList[] = membersRes.status === 'fulfilled' ? membersRes.value : [];
+    this.groups = groupsRes.status === 'fulfilled' ? groupsRes.value : [];
+    return raw
+      .map((m) => this.toRow(m))
+      .sort((a, b) => rank(b.roleId) - rank(a.roleId) || a.name.localeCompare(b.name));
+  }
+
+  private toRow(m: CourseMemberList): MemberRow {
+    const name =
+      `${m.user?.given_name ?? ''} ${m.user?.family_name ?? ''}`.trim() ||
+      m.user?.email ||
+      m.user_id;
+    let group = '';
+    if (m.course_group_id) {
+      group = this.groups.find((g) => g.id === m.course_group_id)?.title || '';
+    }
+    const isSelf = !!this.currentUserId && this.currentUserId === m.user_id;
+    // Mirror the backend: you can only manage members strictly below your ceiling.
+    const manageable = this.canManage && !isSelf && rank(m.course_role_id) < rank(this.ceiling);
+    return {
+      id: m.id,
+      userId: m.user_id,
+      name,
+      email: m.user?.email || '',
+      roleId: m.course_role_id,
+      group,
+      isSelf,
+      manageable,
+    };
+  }
+
+  private async refreshAndPostMembers(): Promise<void> {
+    const members = await this.loadMembers();
+    await this.panel?.webview.postMessage({ command: 'membersUpdated', data: { members } });
+    this.treeDataProvider?.refresh();
+  }
+
+  protected async handleMessage(message: any): Promise<void> {
+    switch (message?.command) {
+      case 'searchUsers':
+        return this.handleSearchUsers(message.data);
+      case 'addMember':
+        return this.handleAddMember(message.data);
+      case 'changeRole':
+        return this.handleChangeRole(message.data);
+      case 'removeMember':
+        return this.handleRemoveMember(message.data);
+      case 'importByEmail':
+        return this.handleImportByEmail(message.data);
+      case 'refresh':
+        return this.refreshAndPostMembers();
+      case 'showError':
+        vscode.window.showErrorMessage(message.data?.message || 'Error');
+        return;
+      default:
+        return;
+    }
+  }
+
+  private async handleSearchUsers(data: any): Promise<void> {
+    const page = Math.max(0, Number(data?.page) || 0);
+    const search = (data?.search || '').trim();
+    try {
+      const users = await this.apiService.searchUsers({
+        search: search || undefined,
+        skip: page * USERS_PAGE_SIZE,
+        limit: USERS_PAGE_SIZE,
+      });
+      await this.panel?.webview.postMessage({
+        command: 'usersResult',
+        data: {
+          search,
+          page,
+          hasNext: users.length === USERS_PAGE_SIZE,
+          users: users.map((u) => ({
+            id: u.id,
+            name: `${u.given_name ?? ''} ${u.family_name ?? ''}`.trim() || u.email || u.id,
+            email: u.email || '',
+          })),
+        },
+      });
+    } catch (e) {
+      await this.panel?.webview.postMessage({
+        command: 'usersResult',
+        data: { search, page, hasNext: false, users: [], error: errMessage(e) },
+      });
+    }
+  }
+
+  private async handleAddMember(data: any): Promise<void> {
+    if (!this.courseId || !data?.userId || !data?.roleId) return;
+    try {
+      await this.apiService.createCourseMember({
+        user_id: data.userId,
+        course_id: this.courseId,
+        course_role_id: data.roleId,
+      });
+      await this.panel?.webview.postMessage({
+        command: 'addResult',
+        data: { userId: data.userId, ok: true },
+      });
+      await this.refreshAndPostMembers();
+    } catch (e) {
+      await this.panel?.webview.postMessage({
+        command: 'addResult',
+        data: { userId: data.userId, ok: false, message: errMessage(e) },
+      });
+    }
+  }
+
+  private async handleChangeRole(data: any): Promise<void> {
+    if (!data?.memberId || !data?.roleId) return;
+    try {
+      await this.apiService.updateCourseMember(data.memberId, { course_role_id: data.roleId });
+      await this.refreshAndPostMembers();
+    } catch (e) {
+      vscode.window.showErrorMessage(`Failed to change role: ${errMessage(e)}`);
+      // Re-sync the UI to the server's truth.
+      await this.refreshAndPostMembers();
+    }
+  }
+
+  private async handleRemoveMember(data: any): Promise<void> {
+    if (!data?.memberId) return;
+    const confirm = await vscode.window.showWarningMessage(
+      `Remove ${data.name || 'this member'} from the course? Their account is not affected.`,
+      { modal: true },
+      'Remove'
+    );
+    if (confirm !== 'Remove') return;
+    try {
+      await this.apiService.deleteCourseMember(data.memberId);
+      await this.refreshAndPostMembers();
+    } catch (e) {
+      vscode.window.showErrorMessage(`Failed to remove member: ${errMessage(e)}`);
+    }
+  }
+
+  private async handleImportByEmail(data: any): Promise<void> {
+    if (!this.courseId || !data?.email) return;
+    try {
+      const res = await this.apiService.importSingleCourseMember(
+        this.courseId,
+        {
+          email: String(data.email).trim(),
+          given_name: data.given_name?.trim() || null,
+          family_name: data.family_name?.trim() || null,
+          course_group_title: data.course_group_title?.trim() || null,
+          course_role_id: data.course_role_id,
+        },
+        { createMissingGroup: true, updateIfExists: true }
+      );
+      await this.panel?.webview.postMessage({
+        command: 'importResult',
+        data: {
+          ok: !!res.success,
+          message: res.message || (res.success ? 'Member added.' : 'Import failed.'),
+          workflowId: res.workflow_id,
+        },
+      });
+      if (res.success) await this.refreshAndPostMembers();
+    } catch (e) {
+      await this.panel?.webview.postMessage({
+        command: 'importResult',
+        data: { ok: false, message: errMessage(e) },
+      });
+    }
+  }
+
+  protected async getWebviewContent(data?: any): Promise<string> {
+    if (!this.panel) return '';
+    const webview = this.panel.webview;
+    const nonce = this.getNonce();
+    const initialState = JSON.stringify(data ?? {});
+    const stylesUri = this.getWebviewUri(webview, 'webview-ui', 'manage-course-members.css');
+    const scriptUri = this.getWebviewUri(webview, 'webview-ui', 'manage-course-members.js');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <title>Manage Members</title>
+  <link rel="stylesheet" href="${stylesUri}">
+</head>
+<body>
+  <div id="app" class="members-container">
+    <div class="loading">Loading members…</div>
+  </div>
+  <script nonce="${nonce}">
+    window.vscodeApi = window.vscodeApi || acquireVsCodeApi();
+    window.__INITIAL_STATE__ = ${initialState};
+  </script>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+  }
+}

--- a/webview-ui/manage-course-members.css
+++ b/webview-ui/manage-course-members.css
@@ -203,26 +203,43 @@ button.secondary:hover:not(:disabled) {
   margin-left: 6px;
 }
 
-/* Add section layout */
-.add-grid {
+/* Tabs */
+.tabs {
   display: flex;
-  flex-wrap: wrap;
-  gap: 24px;
+  gap: 4px;
+  border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+  margin-bottom: 16px;
 }
 
-.users-pane {
-  flex: 1 1 480px;
-  min-width: 0;
+.tab {
+  background: none;
+  color: var(--vscode-descriptionForeground);
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  padding: 8px 12px;
+  margin-bottom: -1px;
 }
 
-.email-pane {
-  flex: 0 0 300px;
+.tab:hover {
+  color: var(--vscode-foreground);
 }
 
+.tab.active {
+  color: var(--vscode-foreground);
+  border-bottom-color: var(--vscode-focusBorder, var(--vscode-button-background));
+}
+
+.tab-panel.hidden {
+  display: none;
+}
+
+/* Add-by-email form */
 #email-form {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  max-width: 420px;
 }
 
 #email-form label {

--- a/webview-ui/manage-course-members.css
+++ b/webview-ui/manage-course-members.css
@@ -1,0 +1,243 @@
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-foreground);
+  background: var(--vscode-editor-background);
+  margin: 0;
+  padding: 16px;
+}
+
+.members-container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.loading,
+.empty {
+  color: var(--vscode-descriptionForeground);
+  padding: 16px 8px;
+  text-align: center;
+}
+
+header {
+  margin-bottom: 20px;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.5em;
+}
+
+h2 {
+  font-size: 1.05em;
+  margin: 0 0 8px;
+}
+
+.muted {
+  color: var(--vscode-descriptionForeground);
+}
+
+.small {
+  font-size: 0.9em;
+}
+
+.hint {
+  color: var(--vscode-descriptionForeground);
+  margin: 0 0 10px;
+}
+
+.strong {
+  font-weight: 600;
+}
+
+section {
+  margin-bottom: 24px;
+}
+
+/* Tables */
+table.grid {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+table.grid th,
+table.grid td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.25));
+  vertical-align: top;
+}
+
+table.grid th {
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--vscode-descriptionForeground);
+}
+
+td.right,
+th:last-child {
+  text-align: right;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.85em;
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+/* Inputs */
+input,
+select {
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--vscode-input-foreground);
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, var(--vscode-dropdown-border, transparent));
+  border-radius: 4px;
+  padding: 5px 8px;
+  box-sizing: border-box;
+}
+
+input:focus,
+select:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+#user-search {
+  width: 100%;
+  max-width: 420px;
+  margin-bottom: 10px;
+}
+
+/* Buttons */
+button {
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 12px;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+button.primary {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+button.primary:hover:not(:disabled) {
+  background: var(--vscode-button-hoverBackground);
+}
+
+button.secondary {
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+}
+
+button.secondary:hover:not(:disabled) {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.link-danger {
+  background: none;
+  color: var(--vscode-errorForeground);
+  padding: 4px 0;
+}
+
+.link-danger:hover {
+  text-decoration: underline;
+}
+
+.ok {
+  color: var(--vscode-testing-iconPassed, var(--vscode-charts-green, #3fb950));
+}
+
+.error {
+  color: var(--vscode-errorForeground);
+}
+
+.status {
+  min-height: 1.2em;
+  margin: 8px 0;
+  font-size: 0.95em;
+}
+
+.status.ok {
+  color: var(--vscode-testing-iconPassed, var(--vscode-charts-green, #3fb950));
+}
+
+.status.error {
+  color: var(--vscode-errorForeground);
+}
+
+.notice {
+  padding: 12px 14px;
+  border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+  border-radius: 6px;
+  color: var(--vscode-descriptionForeground);
+  background: var(--vscode-editorWidget-background, transparent);
+}
+
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 10px;
+  gap: 8px;
+}
+
+.pager button {
+  margin-left: 6px;
+}
+
+/* Add section layout */
+.add-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+
+.users-pane {
+  flex: 1 1 480px;
+  min-width: 0;
+}
+
+.email-pane {
+  flex: 0 0 300px;
+}
+
+#email-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#email-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.85em;
+  color: var(--vscode-descriptionForeground);
+}
+
+#email-form input,
+#email-form select {
+  width: 100%;
+}
+
+#email-submit {
+  align-self: flex-start;
+}

--- a/webview-ui/manage-course-members.js
+++ b/webview-ui/manage-course-members.js
@@ -7,9 +7,12 @@
   const roleLabels = state.roleLabels || {};
   const assignableRoles = state.assignableRoles || [];
   const canManage = !!state.canManage;
-  const usersPageSize = state.usersPageSize || 10;
 
   let members = state.members || [];
+  let memberIds = new Set(members.map((m) => m.userId));
+
+  let currentTab = 'roster';
+  let usersLoaded = false;
 
   // Users-table local state.
   let userSearch = '';
@@ -47,44 +50,54 @@
       .join('');
   }
 
+  // Members already in the course don't belong in the add picker (they're on the
+  // roster tab). Keep users added this session visible so their "Added ✓" shows.
+  function visibleUserList() {
+    return userList.filter((u) => addedUsers.has(u.id) || !memberIds.has(u.id));
+  }
+
   // ---- shell (built once) -------------------------------------------------
   function buildShell() {
-    const addSection = canManage
+    const tabs = canManage
+      ? `<button class="tab" data-tab="roster">Members (<span id="member-count">${members.length}</span>)</button>
+         <button class="tab" data-tab="add">Add from list</button>
+         <button class="tab" data-tab="email">By email</button>`
+      : `<button class="tab" data-tab="roster">Members (<span id="member-count">${members.length}</span>)</button>`;
+
+    const addPanels = canManage
       ? `
-      <section class="add">
-        <div class="add-grid">
-          <div class="pane users-pane">
-            <h2>Add from the user list</h2>
-            <p class="hint">You can only see users your permissions allow. Pick a role and add them.</p>
-            <input id="user-search" type="text" placeholder="Search by name or email…" autocomplete="off" />
-            <div id="users-status" class="status"></div>
-            <table class="grid">
-              <thead><tr><th>User</th><th>Role</th><th></th></tr></thead>
-              <tbody id="users-body"></tbody>
-            </table>
-            <div class="pager">
-              <span id="users-page-label" class="muted"></span>
-              <span>
-                <button id="users-prev" class="secondary">Previous</button>
-                <button id="users-next" class="secondary">Next</button>
-              </span>
-            </div>
-          </div>
-          <div class="pane email-pane">
-            <h2>By email</h2>
-            <p class="hint">Adds the user with this email, creating the account if it does not exist yet.</p>
-            <form id="email-form">
-              <label>Email *<input id="email-input" type="email" placeholder="person@example.org" required /></label>
-              <label>Given name<input id="email-given" type="text" /></label>
-              <label>Family name<input id="email-family" type="text" /></label>
-              <label>Role *<select id="email-role">${roleOptions(assignableRoles[0])}</select></label>
-              <label>Group<input id="email-group" type="text" placeholder="Optional — created if missing" /></label>
-              <button id="email-submit" type="submit" class="primary">Add by email</button>
-            </form>
-            <div id="email-status" class="status"></div>
-          </div>
+      <section id="tab-add" class="tab-panel">
+        <p class="hint">You can only see users your permissions allow. Members already in the course are hidden — pick a role and add them.</p>
+        <input id="user-search" type="text" placeholder="Search by name or email…" autocomplete="off" />
+        <div id="users-status" class="status"></div>
+        <table class="grid">
+          <thead><tr><th>User</th><th>Role</th><th></th></tr></thead>
+          <tbody id="users-body"></tbody>
+        </table>
+        <div class="pager">
+          <span id="users-page-label" class="muted"></span>
+          <span>
+            <button id="users-prev" class="secondary">Previous</button>
+            <button id="users-next" class="secondary">Next</button>
+          </span>
         </div>
+      </section>
+      <section id="tab-email" class="tab-panel">
+        <p class="hint">Adds the user with this email, creating the account if it does not exist yet. Use this for people not yet in the system.</p>
+        <form id="email-form">
+          <label>Email *<input id="email-input" type="email" placeholder="person@example.org" required /></label>
+          <label>Given name<input id="email-given" type="text" /></label>
+          <label>Family name<input id="email-family" type="text" /></label>
+          <label>Role *<select id="email-role">${roleOptions(assignableRoles[0])}</select></label>
+          <label>Group<input id="email-group" type="text" placeholder="Optional — created if missing" /></label>
+          <button id="email-submit" type="submit" class="primary">Add by email</button>
+        </form>
+        <div id="email-status" class="status"></div>
       </section>`
+      : '';
+
+    const readonlyNotice = canManage
+      ? ''
       : `<div class="notice">You have read-only access to this roster. A lecturer role (or higher) on this course is required to add or change members.</div>`;
 
     app.innerHTML = `
@@ -92,26 +105,44 @@
         <h1>Members</h1>
         <div class="muted">${esc(state.courseName || 'Course')}</div>
       </header>
-      <section class="roster">
-        <h2>Roster (<span id="member-count">${members.length}</span>)</h2>
+      <nav class="tabs">${tabs}</nav>
+      <section id="tab-roster" class="tab-panel">
+        ${readonlyNotice}
         <table class="grid">
           <thead><tr><th>Member</th><th>Role</th><th>Group</th><th></th></tr></thead>
           <tbody id="roster-body"></tbody>
         </table>
       </section>
-      ${addSection}`;
+      ${addPanels}`;
 
     attachShellEvents();
+    showTab('roster');
     renderRoster();
-    if (canManage) requestUsers();
+  }
+
+  function showTab(name) {
+    currentTab = name;
+    ['roster', 'add', 'email'].forEach((t) => {
+      const panel = document.getElementById('tab-' + t);
+      if (panel) panel.classList.toggle('hidden', t !== name);
+    });
+    app.querySelectorAll('.tab').forEach((b) => {
+      b.classList.toggle('active', b.getAttribute('data-tab') === name);
+    });
+    // Load the user list lazily the first time the Add tab is opened.
+    if (name === 'add' && canManage && !usersLoaded) {
+      usersLoaded = true;
+      requestUsers();
+    }
   }
 
   // ---- roster -------------------------------------------------------------
   function renderRoster() {
-    const body = document.getElementById('roster-body');
-    if (!body) return;
     const count = document.getElementById('member-count');
     if (count) count.textContent = String(members.length);
+
+    const body = document.getElementById('roster-body');
+    if (!body) return;
 
     if (!members.length) {
       body.innerHTML = `<tr><td colspan="4" class="empty">No members yet.</td></tr>`;
@@ -150,15 +181,18 @@
     const body = document.getElementById('users-body');
     if (!body) return;
     const status = document.getElementById('users-status');
-    if (status) status.textContent = usersError ? usersError : '';
-    if (status) status.className = 'status' + (usersError ? ' error' : '');
+    if (status) {
+      status.textContent = usersError || '';
+      status.className = 'status' + (usersError ? ' error' : '');
+    }
 
+    const visible = visibleUserList();
     if (usersLoading) {
       body.innerHTML = `<tr><td colspan="3" class="empty">Loading users…</td></tr>`;
-    } else if (!userList.length) {
-      body.innerHTML = `<tr><td colspan="3" class="empty">No users found.</td></tr>`;
+    } else if (!visible.length) {
+      body.innerHTML = `<tr><td colspan="3" class="empty">No users to add.</td></tr>`;
     } else {
-      body.innerHTML = userList
+      body.innerHTML = visible
         .map((u) => {
           const isAdded = addedUsers.has(u.id);
           const err = rowError[u.id];
@@ -194,6 +228,10 @@
   let searchTimer = null;
 
   function attachShellEvents() {
+    app.querySelectorAll('.tab').forEach((b) => {
+      b.addEventListener('click', () => showTab(b.getAttribute('data-tab')));
+    });
+
     // Roster delegation.
     const rosterBody = document.getElementById('roster-body');
     if (rosterBody) {
@@ -297,7 +335,9 @@
     switch (msg.command) {
       case 'membersUpdated':
         members = (msg.data && msg.data.members) || [];
+        memberIds = new Set(members.map((m) => m.userId));
         renderRoster();
+        renderUsers(); // drop any freshly-added members from the picker
         break;
       case 'usersResult': {
         const d = msg.data || {};

--- a/webview-ui/manage-course-members.js
+++ b/webview-ui/manage-course-members.js
@@ -1,0 +1,347 @@
+(function () {
+  'use strict';
+
+  const vscode = window.vscodeApi || acquireVsCodeApi();
+  const state = window.__INITIAL_STATE__ || {};
+
+  const roleLabels = state.roleLabels || {};
+  const assignableRoles = state.assignableRoles || [];
+  const canManage = !!state.canManage;
+  const usersPageSize = state.usersPageSize || 10;
+
+  let members = state.members || [];
+
+  // Users-table local state.
+  let userSearch = '';
+  let userPage = 0;
+  let userList = [];
+  let userHasNext = false;
+  let usersLoading = false;
+  let usersError = '';
+  const rowRole = {}; // userId -> selected role for the add action
+  const addedUsers = new Set(); // userIds added this session
+  const rowError = {}; // userId -> error message
+
+  const app = document.getElementById('app');
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function roleLabel(id) {
+    return roleLabels[id] || (id ? id.replace(/^_/, '') : '—');
+  }
+
+  function roleOptions(selected) {
+    const opts = assignableRoles.slice();
+    if (selected && opts.indexOf(selected) === -1) opts.unshift(selected);
+    return opts
+      .map(
+        (r) =>
+          `<option value="${esc(r)}"${r === selected ? ' selected' : ''}>${esc(roleLabel(r))}</option>`
+      )
+      .join('');
+  }
+
+  // ---- shell (built once) -------------------------------------------------
+  function buildShell() {
+    const addSection = canManage
+      ? `
+      <section class="add">
+        <div class="add-grid">
+          <div class="pane users-pane">
+            <h2>Add from the user list</h2>
+            <p class="hint">You can only see users your permissions allow. Pick a role and add them.</p>
+            <input id="user-search" type="text" placeholder="Search by name or email…" autocomplete="off" />
+            <div id="users-status" class="status"></div>
+            <table class="grid">
+              <thead><tr><th>User</th><th>Role</th><th></th></tr></thead>
+              <tbody id="users-body"></tbody>
+            </table>
+            <div class="pager">
+              <span id="users-page-label" class="muted"></span>
+              <span>
+                <button id="users-prev" class="secondary">Previous</button>
+                <button id="users-next" class="secondary">Next</button>
+              </span>
+            </div>
+          </div>
+          <div class="pane email-pane">
+            <h2>By email</h2>
+            <p class="hint">Adds the user with this email, creating the account if it does not exist yet.</p>
+            <form id="email-form">
+              <label>Email *<input id="email-input" type="email" placeholder="person@example.org" required /></label>
+              <label>Given name<input id="email-given" type="text" /></label>
+              <label>Family name<input id="email-family" type="text" /></label>
+              <label>Role *<select id="email-role">${roleOptions(assignableRoles[0])}</select></label>
+              <label>Group<input id="email-group" type="text" placeholder="Optional — created if missing" /></label>
+              <button id="email-submit" type="submit" class="primary">Add by email</button>
+            </form>
+            <div id="email-status" class="status"></div>
+          </div>
+        </div>
+      </section>`
+      : `<div class="notice">You have read-only access to this roster. A lecturer role (or higher) on this course is required to add or change members.</div>`;
+
+    app.innerHTML = `
+      <header>
+        <h1>Members</h1>
+        <div class="muted">${esc(state.courseName || 'Course')}</div>
+      </header>
+      <section class="roster">
+        <h2>Roster (<span id="member-count">${members.length}</span>)</h2>
+        <table class="grid">
+          <thead><tr><th>Member</th><th>Role</th><th>Group</th><th></th></tr></thead>
+          <tbody id="roster-body"></tbody>
+        </table>
+      </section>
+      ${addSection}`;
+
+    attachShellEvents();
+    renderRoster();
+    if (canManage) requestUsers();
+  }
+
+  // ---- roster -------------------------------------------------------------
+  function renderRoster() {
+    const body = document.getElementById('roster-body');
+    if (!body) return;
+    const count = document.getElementById('member-count');
+    if (count) count.textContent = String(members.length);
+
+    if (!members.length) {
+      body.innerHTML = `<tr><td colspan="4" class="empty">No members yet.</td></tr>`;
+      return;
+    }
+    body.innerHTML = members
+      .map((m) => {
+        const roleCell = m.manageable
+          ? `<select class="member-role" data-id="${esc(m.id)}">${roleOptions(m.roleId)}</select>`
+          : `<span class="badge">${esc(roleLabel(m.roleId))}</span>`;
+        const actionCell = m.manageable
+          ? `<button class="link-danger remove-member" data-id="${esc(m.id)}" data-name="${esc(m.name)}">Remove</button>`
+          : '';
+        return `<tr>
+          <td>
+            <div class="strong">${esc(m.name)}${m.isSelf ? ' <span class="muted">(you)</span>' : ''}</div>
+            <div class="muted">${esc(m.email || '—')}</div>
+          </td>
+          <td>${roleCell}</td>
+          <td>${esc(m.group || '—')}</td>
+          <td class="right">${actionCell}</td>
+        </tr>`;
+      })
+      .join('');
+  }
+
+  // ---- users table --------------------------------------------------------
+  function requestUsers() {
+    usersLoading = true;
+    usersError = '';
+    renderUsers();
+    vscode.postMessage({ command: 'searchUsers', data: { search: userSearch, page: userPage } });
+  }
+
+  function renderUsers() {
+    const body = document.getElementById('users-body');
+    if (!body) return;
+    const status = document.getElementById('users-status');
+    if (status) status.textContent = usersError ? usersError : '';
+    if (status) status.className = 'status' + (usersError ? ' error' : '');
+
+    if (usersLoading) {
+      body.innerHTML = `<tr><td colspan="3" class="empty">Loading users…</td></tr>`;
+    } else if (!userList.length) {
+      body.innerHTML = `<tr><td colspan="3" class="empty">No users found.</td></tr>`;
+    } else {
+      body.innerHTML = userList
+        .map((u) => {
+          const isAdded = addedUsers.has(u.id);
+          const err = rowError[u.id];
+          const action = isAdded
+            ? `<span class="ok">Added ✓</span>`
+            : `<button class="primary add-user" data-id="${esc(u.id)}">Add</button>`;
+          return `<tr>
+            <td>
+              <div class="strong">${esc(u.name)}</div>
+              <div class="muted">${esc(u.email || '—')}</div>
+              ${err ? `<div class="error small">${esc(err)}</div>` : ''}
+            </td>
+            <td>
+              <select class="row-role" data-id="${esc(u.id)}"${isAdded ? ' disabled' : ''}>
+                ${roleOptions(rowRole[u.id] || assignableRoles[0])}
+              </select>
+            </td>
+            <td class="right">${action}</td>
+          </tr>`;
+        })
+        .join('');
+    }
+
+    const label = document.getElementById('users-page-label');
+    if (label) label.textContent = `Page ${userPage + 1}`;
+    const prev = document.getElementById('users-prev');
+    const next = document.getElementById('users-next');
+    if (prev) prev.disabled = userPage === 0 || usersLoading;
+    if (next) next.disabled = !userHasNext || usersLoading;
+  }
+
+  // ---- events -------------------------------------------------------------
+  let searchTimer = null;
+
+  function attachShellEvents() {
+    // Roster delegation.
+    const rosterBody = document.getElementById('roster-body');
+    if (rosterBody) {
+      rosterBody.addEventListener('change', (e) => {
+        const sel = e.target.closest('select.member-role');
+        if (sel) {
+          vscode.postMessage({
+            command: 'changeRole',
+            data: { memberId: sel.getAttribute('data-id'), roleId: sel.value },
+          });
+        }
+      });
+      rosterBody.addEventListener('click', (e) => {
+        const btn = e.target.closest('button.remove-member');
+        if (btn) {
+          vscode.postMessage({
+            command: 'removeMember',
+            data: { memberId: btn.getAttribute('data-id'), name: btn.getAttribute('data-name') },
+          });
+        }
+      });
+    }
+
+    if (!canManage) return;
+
+    const search = document.getElementById('user-search');
+    if (search) {
+      search.addEventListener('input', () => {
+        if (searchTimer) clearTimeout(searchTimer);
+        searchTimer = setTimeout(() => {
+          userSearch = search.value.trim();
+          userPage = 0;
+          requestUsers();
+        }, 300);
+      });
+    }
+    const prev = document.getElementById('users-prev');
+    if (prev) prev.addEventListener('click', () => {
+      if (userPage > 0) {
+        userPage -= 1;
+        requestUsers();
+      }
+    });
+    const next = document.getElementById('users-next');
+    if (next) next.addEventListener('click', () => {
+      if (userHasNext) {
+        userPage += 1;
+        requestUsers();
+      }
+    });
+
+    const usersBody = document.getElementById('users-body');
+    if (usersBody) {
+      usersBody.addEventListener('change', (e) => {
+        const sel = e.target.closest('select.row-role');
+        if (sel) rowRole[sel.getAttribute('data-id')] = sel.value;
+      });
+      usersBody.addEventListener('click', (e) => {
+        const btn = e.target.closest('button.add-user');
+        if (btn) {
+          const id = btn.getAttribute('data-id');
+          btn.disabled = true;
+          btn.textContent = 'Adding…';
+          delete rowError[id];
+          vscode.postMessage({
+            command: 'addMember',
+            data: { userId: id, roleId: rowRole[id] || assignableRoles[0] },
+          });
+        }
+      });
+    }
+
+    const form = document.getElementById('email-form');
+    if (form) {
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const email = document.getElementById('email-input').value.trim();
+        if (!email) return;
+        const status = document.getElementById('email-status');
+        if (status) {
+          status.textContent = 'Adding…';
+          status.className = 'status';
+        }
+        vscode.postMessage({
+          command: 'importByEmail',
+          data: {
+            email,
+            given_name: document.getElementById('email-given').value,
+            family_name: document.getElementById('email-family').value,
+            course_role_id: document.getElementById('email-role').value,
+            course_group_title: document.getElementById('email-group').value,
+          },
+        });
+      });
+    }
+  }
+
+  // ---- inbound messages ---------------------------------------------------
+  window.addEventListener('message', (event) => {
+    const msg = event.data || {};
+    switch (msg.command) {
+      case 'membersUpdated':
+        members = (msg.data && msg.data.members) || [];
+        renderRoster();
+        break;
+      case 'usersResult': {
+        const d = msg.data || {};
+        // Ignore stale responses from an earlier query/page.
+        if ((d.search || '') !== userSearch || d.page !== userPage) break;
+        userList = d.users || [];
+        userHasNext = !!d.hasNext;
+        usersError = d.error || '';
+        usersLoading = false;
+        renderUsers();
+        break;
+      }
+      case 'addResult': {
+        const d = msg.data || {};
+        if (d.ok) {
+          addedUsers.add(d.userId);
+          delete rowError[d.userId];
+        } else {
+          rowError[d.userId] = d.message || 'Failed to add';
+        }
+        renderUsers();
+        break;
+      }
+      case 'importResult': {
+        const d = msg.data || {};
+        const status = document.getElementById('email-status');
+        if (status) {
+          status.textContent = d.ok
+            ? (d.workflowId ? `${d.message} (repository provisioning started)` : d.message)
+            : d.message;
+          status.className = 'status ' + (d.ok ? 'ok' : 'error');
+        }
+        if (d.ok) {
+          ['email-input', 'email-given', 'email-family', 'email-group'].forEach((id) => {
+            const el = document.getElementById(id);
+            if (el) el.value = '';
+          });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  });
+
+  buildShell();
+})();

--- a/webview-ui/manage-course-members.js
+++ b/webview-ui/manage-course-members.js
@@ -25,6 +25,15 @@
   const addedUsers = new Set(); // userIds added this session
   const rowError = {}; // userId -> error message
 
+  // Import-from-file local state (index-keyed).
+  let fileRows = [];
+  const fileSel = {};
+  const fileRole = {};
+  const fileGroup = {};
+  const fileResults = {};
+  let fileImporting = false;
+  let fileQueue = [];
+
   const app = document.getElementById('app');
 
   function esc(s) {
@@ -61,7 +70,8 @@
     const tabs = canManage
       ? `<button class="tab" data-tab="roster">Members (<span id="member-count">${members.length}</span>)</button>
          <button class="tab" data-tab="add">Add from list</button>
-         <button class="tab" data-tab="email">By email</button>`
+         <button class="tab" data-tab="email">By email</button>
+         <button class="tab" data-tab="file">Import file</button>`
       : `<button class="tab" data-tab="roster">Members (<span id="member-count">${members.length}</span>)</button>`;
 
     const addPanels = canManage
@@ -93,6 +103,12 @@
           <button id="email-submit" type="submit" class="primary">Add by email</button>
         </form>
         <div id="email-status" class="status"></div>
+      </section>
+      <section id="tab-file" class="tab-panel">
+        <p class="hint">Upload a CSV, JSON, Excel (.xlsx) or Excel-XML student list. Review and adjust the rows, then import the ones you want.</p>
+        <button id="file-pick" class="secondary">Choose file…</button>
+        <div id="file-status" class="status"></div>
+        <div id="file-preview"></div>
       </section>`
       : '';
 
@@ -122,7 +138,7 @@
 
   function showTab(name) {
     currentTab = name;
-    ['roster', 'add', 'email'].forEach((t) => {
+    ['roster', 'add', 'email', 'file'].forEach((t) => {
       const panel = document.getElementById('tab-' + t);
       if (panel) panel.classList.toggle('hidden', t !== name);
     });
@@ -222,6 +238,87 @@
     const next = document.getElementById('users-next');
     if (prev) prev.disabled = userPage === 0 || usersLoading;
     if (next) next.disabled = !userHasNext || usersLoading;
+  }
+
+  // ---- import from file ---------------------------------------------------
+  function renderFile() {
+    const preview = document.getElementById('file-preview');
+    if (!preview) return;
+    if (!fileRows.length) {
+      preview.innerHTML = '';
+      return;
+    }
+    const selCount = fileRows.reduce((n, _, i) => n + (fileSel[i] ? 1 : 0), 0);
+    const body = fileRows
+      .map((r, i) => {
+        const res = fileResults[i];
+        const name = `${r.given_name || ''} ${r.family_name || ''}`.trim() || r.email;
+        const status = res
+          ? res.ok
+            ? '<span class="ok">Added ✓</span>'
+            : `<span class="error" title="${esc(res.message || '')}">Failed</span>`
+          : '<span class="muted">—</span>';
+        const dis = fileImporting ? ' disabled' : '';
+        return `<tr>
+          <td><input type="checkbox" class="file-sel" data-i="${i}"${fileSel[i] ? ' checked' : ''}${dis} /></td>
+          <td><div class="strong">${esc(name)}</div><div class="muted">${esc(r.email)}</div></td>
+          <td><select class="file-role" data-i="${i}"${dis}>${roleOptions(fileRole[i] || assignableRoles[0])}</select></td>
+          <td><input class="file-group" data-i="${i}" value="${esc(fileGroup[i] || '')}" placeholder="—"${dis} /></td>
+          <td class="right">${status}</td>
+        </tr>`;
+      })
+      .join('');
+    preview.innerHTML = `
+      <table class="grid">
+        <thead><tr><th></th><th>User</th><th>Role</th><th>Group</th><th>Status</th></tr></thead>
+        <tbody>${body}</tbody>
+      </table>
+      <div class="pager">
+        <span class="muted">${selCount} selected</span>
+        <button id="file-import" class="primary"${fileImporting || selCount === 0 ? ' disabled' : ''}>${fileImporting ? 'Importing…' : 'Import selected'}</button>
+      </div>`;
+  }
+
+  function startFileImport() {
+    if (fileImporting) return;
+    fileQueue = fileRows
+      .map((_, i) => i)
+      .filter((i) => fileSel[i] && !(fileResults[i] && fileResults[i].ok));
+    if (!fileQueue.length) return;
+    fileImporting = true;
+    renderFile();
+    processNextFileImport();
+  }
+
+  // Import one row at a time (serialised) so concurrent create-missing-group
+  // calls can't race on the same new group.
+  function processNextFileImport() {
+    if (!fileQueue.length) {
+      fileImporting = false;
+      renderFile();
+      vscode.postMessage({ command: 'refresh' });
+      const st = document.getElementById('file-status');
+      if (st) {
+        st.textContent = 'Import finished.';
+        st.className = 'status ok';
+      }
+      return;
+    }
+    const i = fileQueue[0];
+    const r = fileRows[i];
+    vscode.postMessage({
+      command: 'importFileRow',
+      data: {
+        index: i,
+        member: {
+          email: r.email,
+          given_name: r.given_name,
+          family_name: r.family_name,
+          course_role_id: fileRole[i] || assignableRoles[0],
+          course_group_title: fileGroup[i],
+        },
+      },
+    });
   }
 
   // ---- events -------------------------------------------------------------
@@ -327,6 +424,36 @@
         });
       });
     }
+
+    const filePick = document.getElementById('file-pick');
+    if (filePick) {
+      filePick.addEventListener('click', () => vscode.postMessage({ command: 'pickImportFile' }));
+    }
+    const fileSection = document.getElementById('tab-file');
+    if (fileSection) {
+      fileSection.addEventListener('change', (e) => {
+        const cb = e.target.closest('input.file-sel');
+        if (cb) {
+          fileSel[Number(cb.getAttribute('data-i'))] = cb.checked;
+          renderFile();
+          return;
+        }
+        const role = e.target.closest('select.file-role');
+        if (role) {
+          fileRole[Number(role.getAttribute('data-i'))] = role.value;
+          return;
+        }
+        const group = e.target.closest('input.file-group');
+        if (group) fileGroup[Number(group.getAttribute('data-i'))] = group.value;
+      });
+      fileSection.addEventListener('input', (e) => {
+        const group = e.target.closest('input.file-group');
+        if (group) fileGroup[Number(group.getAttribute('data-i'))] = group.value;
+      });
+      fileSection.addEventListener('click', (e) => {
+        if (e.target.closest('#file-import')) startFileImport();
+      });
+    }
   }
 
   // ---- inbound messages ---------------------------------------------------
@@ -376,6 +503,44 @@
             if (el) el.value = '';
           });
         }
+        break;
+      }
+      case 'parsedRows': {
+        const d = msg.data || {};
+        fileRows = d.rows || [];
+        [fileSel, fileRole, fileGroup, fileResults].forEach((m) => {
+          Object.keys(m).forEach((k) => delete m[k]);
+        });
+        fileRows.forEach((r, i) => {
+          fileSel[i] = true;
+          fileRole[i] =
+            r.course_role_id && assignableRoles.indexOf(r.course_role_id) !== -1
+              ? r.course_role_id
+              : assignableRoles[0];
+          fileGroup[i] = r.course_group_title || '';
+        });
+        const st = document.getElementById('file-status');
+        if (st) {
+          if (d.error) {
+            st.textContent = d.error;
+            st.className = 'status error';
+          } else if (!fileRows.length) {
+            st.textContent = 'No members with an email address were found in the file.';
+            st.className = 'status';
+          } else {
+            st.textContent = `Parsed ${fileRows.length} member(s) from ${d.filename || 'the file'}.`;
+            st.className = 'status';
+          }
+        }
+        renderFile();
+        break;
+      }
+      case 'fileRowResult': {
+        const d = msg.data || {};
+        fileResults[d.index] = { ok: d.ok, message: d.message };
+        fileQueue = fileQueue.filter((x) => x !== d.index);
+        renderFile();
+        processNextFileImport();
         break;
       }
       default:


### PR DESCRIPTION
Adds a **Manage Members** webview on the lecturer tree's **course** node, mirroring the new web member-management UI. The existing "Show Members" bulk importer on the Groups-folder node is left untouched.

## What's new
- **Command** `computor.lecturer.manageCourseMembers` ("Manage Members") on `viewItem == course` → opens `ManageCourseMembersWebviewProvider`.
- **Tabbed webview**:
  - **Members** — roster with inline role change + remove (gated by the caller's assignment ceiling; backend enforces).
  - **Add from list** — searchable, paged user picker; members already in the course are hidden.
  - **By email** — invite/add a single user by email.
  - **Import file** — pick a CSV/JSON/XLSX/Excel-XML student list; the backend parses it (`POST /course-member-import/parse/{id}`), then an editable preview (select / role / group) imports selected rows one at a time.
- The assignment ceiling is computed client-side from `/user/scopes` + the caller's roles (admins/org-managers uncapped).

## API service
- Added `createCourseMember`, `deleteCourseMember`, `searchUsers({search,skip,limit})`, and `parseCourseMemberFile(courseId, filename, base64)`.

Requires the matching computor-fullstack changes (backend endpoints) on `release/2026.10`.
