### PR TITLE
Student submission curve + gate grading/progress to lecturers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1302,12 +1302,12 @@
         },
         {
           "command": "computor.tutor.showCourseProgress",
-          "when": "view == computor.tutor.filters",
+          "when": "view == computor.tutor.filters && computor.lecturer.show",
           "group": "navigation@1"
         },
         {
           "command": "computor.tutor.showMemberProgress",
-          "when": "view == computor.tutor.filters",
+          "when": "view == computor.tutor.filters && computor.lecturer.show",
           "group": "navigation@2"
         },
         {

--- a/src/commands/TutorCommands.ts
+++ b/src/commands/TutorCommands.ts
@@ -119,6 +119,10 @@ export class TutorCommands {
 
     // Show Course Progress (uses current selected course from filters)
     register('computor.tutor.showCourseProgress', async () => {
+      if (!(await this.hasLecturerView())) {
+        vscode.window.showInformationMessage('Grading and progress views are available to lecturers only.');
+        return;
+      }
       const sel = TutorSelectionService.getInstance();
       const courseId = sel.getCurrentCourseId();
       if (!courseId) {
@@ -130,6 +134,10 @@ export class TutorCommands {
 
     // Show Member Progress (uses current selected member from filters)
     register('computor.tutor.showMemberProgress', async () => {
+      if (!(await this.hasLecturerView())) {
+        vscode.window.showInformationMessage('Grading and progress views are available to lecturers only.');
+        return;
+      }
       const sel = TutorSelectionService.getInstance();
       const memberId = sel.getCurrentMemberId();
       const memberName = sel.getCurrentMemberLabel();
@@ -447,6 +455,16 @@ export class TutorCommands {
     register('computor.tutor.runTest', async (item: any) => {
       await this.runTestOnSubmission(item);
     });
+  }
+
+  // Grading/progress views are lecturer+ only (the backend enforces this too).
+  // getUserViews() is cached, so this is cheap on repeated invocations.
+  private async hasLecturerView(): Promise<boolean> {
+    try {
+      return (await this.apiService.getUserViews()).includes('lecturer');
+    } catch {
+      return false;
+    }
   }
 
   private async queueCheckout(item: unknown, confirmRedownload: boolean): Promise<void> {

--- a/webview-ui/charts.js
+++ b/webview-ui/charts.js
@@ -431,7 +431,8 @@
       backgroundColor: (ds.color || DEFAULT_PALETTE[i % DEFAULT_PALETTE.length]) + '20',
       borderWidth: 2,
       fill: options.fill !== false,
-      tension: options.tension || 0.3,
+      stepped: options.stepped || false,
+      tension: options.stepped ? 0 : (options.tension || 0.3),
       pointRadius: options.showPoints !== false ? 4 : 0,
       pointHoverRadius: 6,
       pointBackgroundColor: ds.color || DEFAULT_PALETTE[i % DEFAULT_PALETTE.length],
@@ -470,7 +471,8 @@
           ...config.scales,
           y: {
             ...config.scales.y,
-            beginAtZero: options.beginAtZero !== false
+            beginAtZero: options.beginAtZero !== false,
+            max: options.yMax
           }
         },
         onClick: options.onClick

--- a/webview-ui/course-member-progress.css
+++ b/webview-ui/course-member-progress.css
@@ -181,6 +181,10 @@
 }
 
 /* Charts row */
+.submission-timeline-section {
+  margin-bottom: var(--sp-6);
+}
+
 .member-charts-row {
   display: grid;
   grid-template-columns: 300px 1fr;

--- a/webview-ui/course-member-progress.js
+++ b/webview-ui/course-member-progress.js
@@ -11,6 +11,7 @@
   const state = window.__INITIAL_STATE__ || { memberGradings: null };
 
   let donutChart = null;
+  let submissionChart = null;
 
   function init() {
     render();
@@ -70,6 +71,7 @@
       <div class="course-member-progress">
         ${renderHeader(gradings, state.fallbackName)}
         ${renderOverallProgress(gradings)}
+        ${renderSubmissionSection(gradings)}
         ${renderChartsRow(gradings)}
         ${renderContentTree(gradings)}
         <div class="loading-overlay loading-overlay--hidden" id="loadingOverlay">
@@ -79,6 +81,7 @@
     `;
 
     initDonutChart(gradings);
+    initSubmissionChart(gradings);
     attachCopyButtonListeners();
     attachButtonListeners();
   }
@@ -497,6 +500,75 @@
         </div>
       `;
     }).join('');
+  }
+
+  // One point per submittable assignment that has an official submission, using
+  // its latest official submission time — the same source the web UI uses (the
+  // grading payload carries no per-submission timeseries).
+  function computeSubmissionSeries(gradings) {
+    const nodes = (gradings && gradings.nodes) || [];
+    return nodes
+      .filter(n => n && n.submittable === true && n.latest_submission_at)
+      .map(n => {
+        const t = new Date(n.latest_submission_at).getTime();
+        return Number.isFinite(t) ? { t } : null;
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.t - b.t);
+  }
+
+  function renderSubmissionSection(gradings) {
+    const series = computeSubmissionSeries(gradings);
+    const total = toNonNegativeInt(gradings.total_max_assignments);
+    const body = series.length === 0
+      ? '<p style="color: var(--vscode-descriptionForeground); font-size: 13px;">No official submissions to plot yet.</p>'
+      : `
+          <div class="chart-card__canvas">
+            <canvas id="submissionCurve"></canvas>
+          </div>
+          <p style="margin: 8px 0 0; text-align: center; font-size: 12px; color: var(--vscode-descriptionForeground);">
+            Cumulative assignments submitted (${series.length}/${total})
+          </p>
+        `;
+    return `
+      <section class="submission-timeline-section">
+        <div class="chart-card">
+          <h3 class="chart-card__title">Submission timeline</h3>
+          ${body}
+        </div>
+      </section>
+    `;
+  }
+
+  function initSubmissionChart(gradings) {
+    const canvas = document.getElementById('submissionCurve');
+    if (!canvas) return;
+    const series = computeSubmissionSeries(gradings);
+    if (series.length === 0) return;
+
+    // Guard against Chart.js "canvas already in use" across re-renders.
+    if (submissionChart) { submissionChart.destroy(); submissionChart = null; }
+    if (window.Chart && typeof Chart.getChart === 'function') {
+      const existing = Chart.getChart(canvas);
+      if (existing) { existing.destroy(); }
+    }
+
+    const total = Math.max(toNonNegativeInt(gradings.total_max_assignments), series.length);
+    const labels = series.map(p =>
+      new Date(p.t).toLocaleDateString(undefined, { month: 'short', day: '2-digit' })
+    );
+    const values = series.map((_, i) => i + 1);
+
+    submissionChart = ComputorCharts.createLineChart('submissionCurve', {
+      labels,
+      datasets: [{ label: 'Submitted', values, color: ComputorCharts.ThemeColors.info }]
+    }, {
+      stepped: true,
+      fill: false,
+      showPoints: series.length <= 40,
+      beginAtZero: true,
+      yMax: total
+    });
   }
 
   function initDonutChart(gradings) {


### PR DESCRIPTION
Mirrors the web-ui/backend changes in the VS Code extension.

## Grading/progress → lecturer+ only
The backend now 403s tutors on `/course-member-gradings`. Align the extension:
- Hide the tutor **Course/Member Progress** toolbar buttons unless the user has the lecturer view (`when` += `computor.lecturer.show`).
- Runtime guard on `computor.tutor.showCourseProgress` / `showMemberProgress` via a cached `getUserViews()` lecturer check (covers the command palette).
- Lecturer tree entry points were already lecturer-gated; backend stays authoritative.

## Submission curve (per-student progress webview)
- New **"Submission timeline"** section in `course-member-progress.js`: a cumulative **step curve** of official submissions over time, derived from each submittable node's `latest_submission_at` — the same source the web-ui uses (the grading payload has no per-submission timeseries), so **no backend change**.
- Rendered with the existing `ComputorCharts` (Chart.js); extended the shared `createLineChart` with `stepped` + `yMax`. Reuses `.chart-card` styling.

## Notes / deferred
- The curve uses a Chart.js category (date-label) x-axis rather than the web-ui's proportional-time SVG — same story, idiomatic to the extension's chart lib.
- The web-ui's due-date/start-date controls are **not** ported (need webview config + persistence + a vertical-line annotation) — easy follow-up.

## Verification
`tsc --noEmit` exit 0; `node --check` on both webview JS files OK; `package.json` valid. `dist/` not rebuilt (source is tsc-clean; CI/release rebuilds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)