### PR TITLE
feat(consent): actionable consent prompt + fix user-manager retry loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,11 @@
         "category": "Computor"
       },
       {
+        "command": "computor.acceptPrivacyPolicy",
+        "title": "Accept Privacy Policy",
+        "category": "Computor"
+      },
+      {
         "command": "computor.loginOffline",
         "title": "Login (Offline Mode)",
         "category": "Computor"

--- a/src/exceptions/error-catalog.vscode.json
+++ b/src/exceptions/error-catalog.vscode.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "generated_at": "2026-03-11T16:21:57.157306",
-  "error_count": 66,
+  "error_count": 67,
   "errors": {
     "AUTH_001": {
       "code": "AUTH_001",
@@ -117,6 +117,19 @@
         "plain": "You cannot assign a role higher than your own.",
         "markdown": "**Role Escalation Denied**\n\nYou cannot assign the role '{target_role}'. Your role '{user_role}' can only assign roles at or below your privilege level.",
         "html": "<strong>Role Escalation Denied</strong><p>You cannot assign the role <code>{target_role}</code>. Your role <code>{user_role}</code> can only assign roles at or below your privilege level.</p>"
+      },
+      "retry_after": null
+    },
+    "AUTHZ_006": {
+      "code": "AUTHZ_006",
+      "http_status": 403,
+      "category": "authorization",
+      "severity": "warning",
+      "title": "Privacy Policy Consent Required",
+      "message": {
+        "plain": "You must accept the current privacy policy before you can continue.",
+        "markdown": "**Privacy Policy Consent Required**\n\nYou must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.",
+        "html": "<strong>Privacy Policy Consent Required</strong><p>You must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.</p>"
       },
       "retry_after": null
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1606,6 +1606,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Advanced: sign in with a Computor API token (non-SSO escape hatch)
   context.subscriptions.push(vscode.commands.registerCommand('computor.loginWithApiToken', async () => apiTokenLoginFlow(context)));
 
+  // Privacy-policy consent: open the web app's consent page. Shared by the
+  // consent-gate notification button and the "accept the privacy policy" tree
+  // node (see utils/consentGate.ts).
+  context.subscriptions.push(vscode.commands.registerCommand('computor.acceptPrivacyPolicy', async () => {
+    const { openConsentPage } = await import('./utils/consentGate');
+    await openConsentPage();
+  }));
+
   // Logout / clear-data commands — registered for ALL roles (not just lecturers),
   // and available even when signed out. SSO sessions expire, so every role needs
   // to be able to sign out and back in.

--- a/src/services/ComputorApiService.ts
+++ b/src/services/ComputorApiService.ts
@@ -6,7 +6,7 @@ import { errorRecoveryService, RetryOptions } from './ErrorRecoveryService';
 import { requestBatchingService } from './RequestBatchingService';
 import { multiTierCache } from './CacheService';
 import { performanceMonitor } from './PerformanceMonitoringService';
-import type { CourseDeploymentGet, VersionUpgradeGet, CourseDeployRequest, CourseDeployResult } from '../types/generated';
+import type { CourseDeploymentGet, VersionUpgradeGet, CourseDeployRequest, CourseDeployResult, InstanceInfoGet } from '../types/generated';
 import type { CourseTaskRequest } from '../types/generated/courses';
 import type { TaskInfo } from '../types/generated/tasks';
 import type {
@@ -298,6 +298,29 @@ export class ComputorApiService {
       });
     } catch (error) {
       console.error('Failed to get course:', error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Instance navigation URLs (web app + managed Forgejo). The backend endpoint
+   * is consent-gate-exempt, so this succeeds even when the user is otherwise
+   * consent-blocked — which is exactly when we need web_url to point them at the
+   * consent page. Cached: instance URLs are effectively static per deployment.
+   */
+  async getInstanceInfo(): Promise<InstanceInfoGet | undefined> {
+    try {
+      return await this.cachedRequest({
+        cacheKey: 'instance-info',
+        tier: 'warm',
+        fetch: async () => {
+          const client = await this.getHttpClient();
+          return (await client.get<InstanceInfoGet>('/instance-info')).data;
+        },
+        retry: { maxRetries: 1 }
+      });
+    } catch (error) {
+      console.error('Failed to get instance info:', error);
       return undefined;
     }
   }

--- a/src/types/generated/common.ts
+++ b/src/types/generated/common.ts
@@ -602,6 +602,43 @@ export interface CourseContentConfig {
 }
 
 /**
+ * Portable per-course git configuration for a deployment file.
+ * 
+ * Resolved server-side into a ``CourseGitBinding`` when the course is deployed
+ * (CLI, web upload, or VSCode). A git server is referenced by ``provider``
+ * (+ ``base_url`` for external instances) instead of a machine-specific
+ * ``git_server_id`` UUID, so the file stays portable across systems.
+ * 
+ * - In-system managed **Forgejo**: ``provider: forgejo`` (no ``base_url``);
+ * credentials are the system server's — nothing lives here.
+ * - External **GitLab**: ``provider: gitlab`` + ``base_url``; the course brings
+ * its own ``parent_group_id`` (its GitLab group is created under it) and
+ * ``token`` (a group access token, stored encrypted ON THE BINDING).
+ * - Pure **download**: ``delivery: download`` (with a ``provider`` to host the
+ * template archive, or none for an unbound course).
+ */
+export interface CourseGitConfig {
+  /** Assignment delivery: 'git' (fork/clone) or 'download' (archive) */
+  delivery?: "git" | "download";
+  /** Git provider. 'forgejo' with no base_url = the in-system managed Forgejo. */
+  provider?: "forgejo" | "gitlab" | null;
+  /** Git server base URL. Required for external GitLab; omit for the in-system managed Forgejo. */
+  base_url?: string | null;
+  /** GitLab parent group id/path the course group is created under (GitLab only). */
+  parent_group_id?: string | null;
+  /** GitLab group access token bound to this course (GitLab only; stored encrypted). Supports ${ENV_VAR} interpolation at deploy time. */
+  token?: string | null;
+  /** Explicit template repo/project ref (optional; auto-derived for managed servers). */
+  template_repo?: string | null;
+  /** Explicit template clone/web URL (optional). */
+  template_url?: string | null;
+  /** Default branch of the template (defaults to 'main'). */
+  default_branch?: string | null;
+  /** Allowed student-repo hosting modes: subset of ['managed', 'external', 'download']. */
+  student_repo_modes?: string[];
+}
+
+/**
  * Course configuration.
  */
 export interface CourseConfig {
@@ -621,6 +658,8 @@ export interface CourseConfig {
   content_types?: CourseContentTypeConfig[] | null;
   /** Course contents hierarchy (assignments, units, etc.) */
   contents?: CourseContentConfig[] | null;
+  /** Optional git configuration, bound to the course at deploy time. Omit to create an unbound course (configure git later in the UI). */
+  git?: CourseGitConfig | null;
   /** Course-specific settings */
   settings?: Record<string, unknown> | null;
 }
@@ -645,6 +684,8 @@ export interface HierarchicalCourseConfig {
   content_types?: CourseContentTypeConfig[] | null;
   /** Course contents hierarchy (assignments, units, etc.) */
   contents?: CourseContentConfig[] | null;
+  /** Optional git configuration, bound to the course at deploy time. Omit to create an unbound course (configure git later in the UI). */
+  git?: CourseGitConfig | null;
   /** Course-specific settings */
   settings?: Record<string, unknown> | null;
 }
@@ -1085,6 +1126,55 @@ export interface ComputorMeta {
 }
 
 /**
+ * Answer to 'may this user pass the consent gate right now?'.
+ */
+export interface ConsentStatusGet {
+  /** Current policy version; null if no policy is configured (gate inactive) */
+  required_version?: string | null;
+  has_consented: boolean;
+  granted_at?: string | null;
+}
+
+export interface ConsentCreate {
+  /** Must match the current policy version */
+  policy_version: string;
+  /** Granular opt-in purposes, if the policy defines any */
+  purposes?: Record<string, boolean> | null;
+}
+
+export interface PolicyTextGet {
+  version: string;
+  /** Language actually served (after fallback) */
+  lang: string;
+  /** Languages available for this version */
+  languages?: string[];
+  effective_from?: string | null;
+  /** Markdown text of the privacy notice */
+  content: string;
+}
+
+/**
+ * Admin: publish a new policy version (append-only; texts are write-once).
+ */
+export interface PolicyVersionCreate {
+  /** e.g. 2026-07-04 */
+  version: string;
+  /** When this version becomes current; defaults to now. May be in the future (scheduled). */
+  effective_from?: string | null;
+  /** Mapping of language code -> Markdown notice text, e.g. {'de': ..., 'en': ...} */
+  texts: Record<string, string>;
+}
+
+export interface PolicyVersionGet {
+  id: string;
+  version: string;
+  languages?: string[];
+  effective_from: string;
+  content_hashes?: Record<string, string> | null;
+  created_at?: string | null;
+}
+
+/**
  * Test count statistics.
  */
 export interface ComputorReportSummary {
@@ -1220,35 +1310,6 @@ export interface BaseEntityGet {
   updated_at?: string | null;
   created_by?: string | null;
   updated_by?: string | null;
-}
-
-/**
- * Self-service migration: set a Keycloak password, gated by a GitLab PAT.
- * 
- * The PAT proves the caller controls a GitLab account whose email matches an
- * existing computor user (by User.email or the org-scoped StudentProfile email).
- * No password is read from our database (local auth is gone); the PAT is only
- * used for verification and is never stored.
- */
-export interface GitLabRegisterRequest {
-  /** GitLab instance URL the PAT was issued on */
-  gitlab_url: string;
-  /** GitLab Personal Access Token (verification only, not stored) */
-  gitlab_pat: string;
-  /** Password to set for Keycloak login */
-  new_password: string;
-}
-
-/**
- * Response after provisioning/resetting a Keycloak login via GitLab PAT.
- */
-export interface GitLabRegisterResponse {
-  /** User ID in Computor */
-  user_id: string;
-  /** Email address (Keycloak username) */
-  email: string;
-  /** True if the Keycloak user was created, False if its password was reset */
-  created: boolean;
 }
 
 /**
@@ -2109,6 +2170,16 @@ export interface TestCreate {
   project?: string | null;
   provider_url?: string | null;
   submit?: boolean | null;
+}
+
+/**
+ * Public navigation URLs for this Computor instance.
+ */
+export interface InstanceInfoGet {
+  /** Public base URL of the Computor web app (e.g. https://computor.example.org); null if not configured. */
+  web_url?: string | null;
+  /** Public base URL of the managed Forgejo git server; null if no managed Forgejo is configured. */
+  forgejo_url?: string | null;
 }
 
 /**
@@ -4228,4 +4299,4 @@ export type ErrorCategory = "authentication" | "authorization" | "validation" | 
 
 export type GradingStatus = 0 | 1 | 2 | 3;
 
-export type ErrorCode = "AUTH_001" | "AUTH_002" | "AUTH_003" | "AUTH_004" | "AUTH_005" | "AUTHZ_001" | "AUTHZ_002" | "AUTHZ_003" | "AUTHZ_004" | "AUTHZ_005" | "AUTHZ_010" | "VAL_001" | "VAL_002" | "VAL_003" | "VAL_004" | "NF_001" | "NF_002" | "NF_003" | "NF_004" | "NF_010" | "CONFLICT_001" | "CONFLICT_002" | "RATE_001" | "RATE_002" | "RATE_003" | "CONTENT_001" | "CONTENT_002" | "CONTENT_003" | "CONTENT_004" | "CONTENT_005" | "CONTENT_006" | "CONTENT_007" | "VERSION_001" | "DEPLOY_001" | "DEPLOY_002" | "DEPLOY_003" | "DEPLOY_004" | "DEPLOY_005" | "SUBMIT_001" | "SUBMIT_002" | "SUBMIT_003" | "SUBMIT_004" | "SUBMIT_005" | "SUBMIT_006" | "SUBMIT_007" | "SUBMIT_008" | "TASK_001" | "TASK_002" | "TASK_003" | "TASK_004" | "GITLAB_001" | "GITLAB_002" | "GITLAB_003" | "GITLAB_004" | "GITLAB_005" | "GITLAB_006" | "GITLAB_007" | "GITLAB_008" | "EXT_001" | "EXT_002" | "EXT_003" | "EXT_004" | "EXT_005" | "EXT_006" | "DB_001" | "DB_002" | "DB_003" | "INT_001" | "INT_002" | "NIMPL_001";
+export type ErrorCode = "AUTH_001" | "AUTH_002" | "AUTH_003" | "AUTH_004" | "AUTH_005" | "AUTHZ_001" | "AUTHZ_002" | "AUTHZ_003" | "AUTHZ_004" | "AUTHZ_005" | "AUTHZ_006" | "AUTHZ_010" | "VAL_001" | "VAL_002" | "VAL_003" | "VAL_004" | "NF_001" | "NF_002" | "NF_003" | "NF_004" | "NF_010" | "CONFLICT_001" | "CONFLICT_002" | "RATE_001" | "RATE_002" | "RATE_003" | "CONTENT_001" | "CONTENT_002" | "CONTENT_003" | "CONTENT_004" | "CONTENT_005" | "CONTENT_006" | "CONTENT_007" | "VERSION_001" | "DEPLOY_001" | "DEPLOY_002" | "DEPLOY_003" | "DEPLOY_004" | "DEPLOY_005" | "SUBMIT_001" | "SUBMIT_002" | "SUBMIT_003" | "SUBMIT_004" | "SUBMIT_005" | "SUBMIT_006" | "SUBMIT_007" | "SUBMIT_008" | "TASK_001" | "TASK_002" | "TASK_003" | "TASK_004" | "GITLAB_001" | "GITLAB_002" | "GITLAB_003" | "GITLAB_004" | "GITLAB_005" | "GITLAB_006" | "GITLAB_007" | "GITLAB_008" | "EXT_001" | "EXT_002" | "EXT_003" | "EXT_004" | "EXT_005" | "EXT_006" | "DB_001" | "DB_002" | "DB_003" | "INT_001" | "INT_002" | "NIMPL_001";

--- a/src/types/generated/courses.ts
+++ b/src/types/generated/courses.ts
@@ -1046,6 +1046,10 @@ export interface CourseGitBindingUpsert {
   delivery?: "git" | "download";
   /** Registry server hosting the student-template */
   git_server_id?: string | null;
+  /** GitLab parent group id/path the course group is created under (GitLab only) */
+  parent_group_id?: string | null;
+  /** GitLab group access token bound to this course (GitLab only; stored encrypted, never returned) */
+  token?: string | null;
   /** Repo/project reference of the student-template */
   template_repo?: string | null;
   /** Clone/web URL of the student-template */
@@ -1064,6 +1068,10 @@ export interface CourseGitBindingGet {
   course_id: string;
   delivery: string;
   git_server_id?: string | null;
+  /** GitLab parent group id/path (GitLab only) */
+  parent_group_id?: string | null;
+  /** Whether a per-course git token is stored on the binding (the token itself is never returned) */
+  has_token?: boolean;
   template_repo?: string | null;
   template_url?: string | null;
   default_branch?: string | null;

--- a/src/types/generated/error-codes.ts
+++ b/src/types/generated/error-codes.ts
@@ -70,6 +70,7 @@ export const ErrorCodes = {
   AUTHZ_003: "AUTHZ_003", // Course Access Denied
   AUTHZ_004: "AUTHZ_004", // Insufficient Course Role
   AUTHZ_005: "AUTHZ_005", // Role Escalation Denied
+  AUTHZ_006: "AUTHZ_006", // Privacy Policy Consent Required
   AUTHZ_010: "AUTHZ_010", // Service Account Required
   VAL_001: "VAL_001", // Invalid Request Data
   VAL_002: "VAL_002", // Missing Required Field
@@ -293,6 +294,20 @@ export const ERROR_DEFINITIONS: Record<string, ErrorDefinition> = {
     },
     retryAfter: undefined,
     documentationUrl: "/docs/permissions#role-assignment",
+  },
+  AUTHZ_006: {
+    code: "AUTHZ_006",
+    httpStatus: 403,
+    category: ErrorCategory.AUTHORIZATION,
+    severity: ErrorSeverity.WARNING,
+    title: "Privacy Policy Consent Required",
+    message: {
+      plain: "You must accept the current privacy policy before you can continue.",
+      markdown: "**Privacy Policy Consent Required**\n\nYou must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.",
+      html: "<strong>Privacy Policy Consent Required</strong><p>You must review and accept the current privacy policy before you can continue. Open the Computor web app to give your consent.</p>",
+    },
+    retryAfter: undefined,
+    documentationUrl: "/docs/consent",
   },
   AUTHZ_010: {
     code: "AUTHZ_010",

--- a/src/ui/tree/lecturer/LecturerTreeDataProvider.ts
+++ b/src/ui/tree/lecturer/LecturerTreeDataProvider.ts
@@ -8,6 +8,7 @@ import { ComputorSettingsManager } from '../../../settings/ComputorSettingsManag
 import type { WebSocketService } from '../../../services/WebSocketService';
 import { CourseChannelSubscription } from '../courseChannelSubscription';
 import { errorRecoveryService } from '../../../services/ErrorRecoveryService';
+import { isConsentRequiredError, handleConsentError } from '../../../utils/consentGate';
 import { performanceMonitor } from '../../../services/PerformanceMonitoringService';
 import { VirtualScrollingService } from '../../../services/VirtualScrollingService';
 import { DragDropManager } from '../../../services/DragDropManager';
@@ -648,6 +649,17 @@ export class LecturerTreeDataProvider extends BaseTreeDataProvider<TreeItem> imp
 
       return [];
     } catch (error) {
+      // Consent gate: show a clear, clickable node (and one throttled prompt)
+      // instead of dumping an opaque "HTTP 403: Forbidden".
+      if (isConsentRequiredError(error)) {
+        void handleConsentError(error);
+        const item = new InfoItem('Accept the privacy policy to continue', 'warning');
+        item.command = {
+          command: 'computor.acceptPrivacyPolicy',
+          title: 'Open Web App to accept the privacy policy',
+        };
+        return [item];
+      }
       vscode.window.showErrorMessage(`Failed to load tree data: ${error}`);
       return [];
     }

--- a/src/ui/tree/user-manager/UserManagerTreeProvider.ts
+++ b/src/ui/tree/user-manager/UserManagerTreeProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ComputorApiService } from '../../../services/ComputorApiService';
 import { UserList } from '../../../types/generated/users';
 import { BaseTreeDataProvider } from '../BaseTreeDataProvider';
+import { isConsentRequiredError, handleConsentError } from '../../../utils/consentGate';
 
 const STATE_KEY = 'computor.userManager.filterState';
 
@@ -118,6 +119,7 @@ export class UserManagerTreeProvider extends BaseTreeDataProvider<TreeItem> {
   private filterState: FilterState;
   private loading = false;
   private loadError: string | undefined;
+  private loadErrorIsConsent = false;
   private hasLoaded = false;
 
   constructor(
@@ -173,6 +175,7 @@ export class UserManagerTreeProvider extends BaseTreeDataProvider<TreeItem> {
     this.users = [];
     this.hasLoaded = false;
     this.loadError = undefined;
+    this.loadErrorIsConsent = false;
     super.refresh();
   }
 
@@ -195,8 +198,17 @@ export class UserManagerTreeProvider extends BaseTreeDataProvider<TreeItem> {
 
     if (this.loadError) {
       const errorItem = new vscode.TreeItem(this.loadError, vscode.TreeItemCollapsibleState.None);
-      errorItem.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground'));
-      errorItem.contextValue = 'userManagerError';
+      if (this.loadErrorIsConsent) {
+        errorItem.iconPath = new vscode.ThemeIcon('warning');
+        errorItem.contextValue = 'userManagerConsentRequired';
+        errorItem.command = {
+          command: 'computor.acceptPrivacyPolicy',
+          title: 'Open Web App to accept the privacy policy',
+        };
+      } else {
+        errorItem.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground'));
+        errorItem.contextValue = 'userManagerError';
+      }
       return [errorItem];
     }
 
@@ -236,6 +248,7 @@ export class UserManagerTreeProvider extends BaseTreeDataProvider<TreeItem> {
   private async loadUsers(): Promise<void> {
     this.loading = true;
     this.loadError = undefined;
+    this.loadErrorIsConsent = false;
     this.fireChange();
     try {
       const all = await this.apiService.getUsers({ force: true });
@@ -249,12 +262,24 @@ export class UserManagerTreeProvider extends BaseTreeDataProvider<TreeItem> {
         const bGiven = (b.given_name || '').toLowerCase();
         return aGiven.localeCompare(bGiven);
       });
-      this.hasLoaded = true;
     } catch (error: any) {
       console.error('[UserManagerTreeProvider] Failed to load users:', error);
-      this.loadError = `Failed to load users: ${error?.message || error}`;
       this.users = [];
+      // Consent gate: surface the actionable prompt (throttled) + a clickable
+      // node instead of a raw 403.
+      if (isConsentRequiredError(error)) {
+        this.loadErrorIsConsent = true;
+        this.loadError = 'Accept the privacy policy to continue, then refresh.';
+        void handleConsentError(error);
+      } else {
+        this.loadError = `Failed to load users: ${error?.message || error}`;
+      }
     } finally {
+      // Mark loaded even on failure so the fireChange() below does not make
+      // getChildren() re-trigger loadUsers() — that guard (!hasLoaded) caused an
+      // API-hammering retry loop while consent-blocked. refresh() resets
+      // hasLoaded to false so an explicit refresh retries.
+      this.hasLoaded = true;
       this.loading = false;
       this.fireChange();
     }

--- a/src/utils/consentGate.ts
+++ b/src/utils/consentGate.ts
@@ -1,0 +1,95 @@
+import * as vscode from 'vscode';
+import { HttpError } from '../http/errors/HttpError';
+
+/**
+ * GDPR consent gate handling.
+ *
+ * When the backend consent gate is active, EVERY gated API call is blocked with
+ * the same 403 until the user accepts the current privacy policy in the web app.
+ * The backend body is stable: `{ error: "consent_required", required_version,
+ * error_code: "AUTHZ_006", message }`. Without special handling the extension
+ * only shows an opaque "HTTP 403: Forbidden"; this module detects that 403 and
+ * surfaces an actionable, throttled prompt that deep-links to the web app's
+ * consent page instead.
+ */
+
+const CONSENT_ERROR = 'consent_required';
+
+/** True iff `error` is the backend consent gate's 403 (keyed on the stable `error` field). */
+export function isConsentRequiredError(error: unknown): error is HttpError {
+  return (
+    error instanceof HttpError &&
+    error.status === 403 &&
+    (error.response as any)?.error === CONSENT_ERROR
+  );
+}
+
+/** The policy version the caller must accept, if the error carries it. */
+export function requiredConsentVersion(error: unknown): string | undefined {
+  if (!isConsentRequiredError(error)) {
+    return undefined;
+  }
+  const v = (error.response as any)?.required_version;
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Resolve the web app URL via GET /instance-info. That endpoint is whitelisted
+ * in the consent gate, so it still succeeds while the caller is consent-blocked.
+ * Uses a dynamic import to avoid a static dependency cycle with the API service.
+ */
+async function resolveWebUrl(): Promise<string | undefined> {
+  try {
+    const { ComputorApiService } = await import('../services/ComputorApiService');
+    const info = await ComputorApiService.getInstance()?.getInstanceInfo();
+    return info?.web_url ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Open the web app's consent page, or explain where to go if the URL is unknown. */
+export async function openConsentPage(): Promise<void> {
+  const webUrl = await resolveWebUrl();
+  if (webUrl) {
+    const consentUrl = `${webUrl.replace(/\/+$/, '')}/consent`;
+    await vscode.env.openExternal(vscode.Uri.parse(consentUrl));
+    return;
+  }
+  await vscode.window.showInformationMessage(
+    'Open the Computor web app and accept the current privacy policy to continue.'
+  );
+}
+
+// The gate 403s every gated call, so many providers/commands can trip it almost
+// simultaneously. Surface the prompt at most once per interval.
+let lastNotifiedAt = 0;
+const NOTIFY_INTERVAL_MS = 15_000;
+
+/**
+ * If `error` is the consent gate's 403, surface an actionable, throttled
+ * notification and return true (handled). Otherwise return false so the caller
+ * falls back to its normal error handling.
+ */
+export async function handleConsentError(error: unknown): Promise<boolean> {
+  if (!isConsentRequiredError(error)) {
+    return false;
+  }
+
+  const now = Date.now();
+  if (now - lastNotifiedAt < NOTIFY_INTERVAL_MS) {
+    return true; // already surfaced recently; still "handled"
+  }
+  lastNotifiedAt = now;
+
+  const detail =
+    (error.response as any)?.message ||
+    'You must accept the current privacy policy before you can continue.';
+
+  const OPEN = 'Open Web App';
+  const choice = await vscode.window.showWarningMessage(`Computor: ${detail}`, OPEN);
+  if (choice === OPEN) {
+    await openConsentPage();
+  }
+  return true;
+}

--- a/src/utils/errorDisplay.ts
+++ b/src/utils/errorDisplay.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { HttpError } from '../http/errors/HttpError';
+import { isConsentRequiredError, handleConsentError } from './consentGate';
 
 /**
  * Display an error message with appropriate severity level
@@ -7,6 +8,14 @@ import { HttpError } from '../http/errors/HttpError';
  * Uses title and message from the error catalog when available
  */
 export function showErrorWithSeverity(error: Error | HttpError, fallbackMessage?: string): void {
+  // Consent gate: the same 403 blocks every action until the user accepts the
+  // privacy policy. Surface one actionable, throttled prompt (with a deep-link
+  // to the web app) instead of an opaque "HTTP 403: Forbidden".
+  if (isConsentRequiredError(error)) {
+    void handleConsentError(error);
+    return;
+  }
+
   let message = fallbackMessage || error.message;
   let severity: string | undefined;
 


### PR DESCRIPTION
## Why
When consent-blocked, the extension showed an opaque "HTTP 403: Forbidden" and the user-management view hammered the API in a retry loop.

## What
- `utils/consentGate.ts`: detect the consent gate 403 and show a throttled, actionable prompt with an **Open Web App** deep-link to the consent page.
- New palette command `computor.acceptPrivacyPolicy` ("Computor: Accept Privacy Policy") so the prompt is reachable after dismissal.
- Wire consent-awareness into the global error display + the lecturer tree (clickable consent node).
- **Fix API hammering:** `UserManagerTreeProvider.loadUsers` now sets `hasLoaded` in `finally`, breaking the `getChildren`↔`loadUsers`↔`fireChange` loop that fired on every 403.
- `getInstanceInfo()` + generated-types resync (incl. `InstanceInfoGet`).

Pairs with computor-fullstack PR of the same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)