### PR TITLE
fix(results): read offset-less test timestamps as UTC

### DIFF
--- a/src/ui/panels/TestResultsPanel.ts
+++ b/src/ui/panels/TestResultsPanel.ts
@@ -277,6 +277,43 @@ export class TestResultsTreeDataProvider implements vscode.TreeDataProvider<Resu
         return new vscode.ThemeIcon('file');
     }
 
+    /**
+     * Render a test report's `timestamp` as local time.
+     *
+     * Testers do not agree on the format. Everything driven by
+     * computor-testing emits a proper ISO 8601 instant
+     * ("2026-07-28T20:26:29.140387+00:00"), but the MATLAB framework
+     * (itp-matlab-testing, CodeAbilityTestOutput.m) emits an unzoned
+     * "yyyy-MM-dd HH:mm:ss" read off the worker's clock — and every worker
+     * runs on UTC.
+     *
+     * `new Date()` reads a date-time string with no offset as *local* time
+     * per the ECMAScript spec, so those MATLAB stamps rendered UTC_OFFSET
+     * early — two hours in CEST. Tag an offset-less stamp as UTC before
+     * parsing. This also repairs results already stored in MinIO, which no
+     * producer-side fix can reach.
+     */
+    private formatReportTimestamp(value: unknown): string | undefined {
+        if (typeof value !== 'string') {
+            return undefined;
+        }
+        const raw = value.trim();
+        if (!raw) {
+            return undefined;
+        }
+
+        // "YYYY-MM-DD[ T]HH:MM[:SS[.fff]]" with nothing naming a zone.
+        const offsetless =
+            /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/.test(raw);
+        const normalized = offsetless ? `${raw.replace(' ', 'T')}Z` : raw;
+
+        const date = new Date(normalized);
+        if (isNaN(date.getTime())) {
+            return raw; // unparseable — show it verbatim rather than "Invalid Date"
+        }
+        return date.toLocaleString();
+    }
+
     private formatFileSize(bytes: number): string {
         if (bytes < 1024) {
             return `${bytes} B`;
@@ -378,14 +415,7 @@ export class TestResultsTreeDataProvider implements vscode.TreeDataProvider<Resu
                 let toolTipHead: string | undefined = undefined;
 
                 if ('timestamp' in data) {
-                    // Convert UTC timestamp to local time
-                    try {
-                        const date = new Date(data.timestamp);
-                        descriptionHead = date.toLocaleString();
-                    } catch (e) {
-                        // Fallback to raw timestamp if parsing fails
-                        descriptionHead = `${data.timestamp}`;
-                    }
+                    descriptionHead = this.formatReportTimestamp(data.timestamp);
                 }
 
                 if ('description' in data) {

--- a/test/ui/testResultsPanel.test.ts
+++ b/test/ui/testResultsPanel.test.ts
@@ -172,3 +172,73 @@ describe('Result Details panel', () => {
     expect(last().body).to.contain('ZeroDivisionError');
   });
 });
+
+/**
+ * Every worker container runs on UTC, but the testers disagree on how they say
+ * so. computor-testing emits a real ISO 8601 instant; the MATLAB framework
+ * (itp-matlab-testing, CodeAbilityTestOutput.m) emits a bare
+ * "yyyy-MM-dd HH:mm:ss". `new Date()` reads an offset-less date-time as *local*
+ * time, so MATLAB runs used to render UTC_OFFSET early — two hours behind in
+ * CEST, one in CET.
+ */
+describe('Result Tree timestamp', () => {
+  function rootDescription(result: any): string | undefined {
+    const tree = new TestResultsTreeDataProvider({});
+    tree.refresh(result);
+    return tree.getChildren()[0]?.description;
+  }
+
+  // Fixed instant so the assertions do not depend on the current DST offset.
+  const expectedLocal = (iso: string) => new Date(iso).toLocaleString();
+
+  it('reads an offset-less MATLAB timestamp as UTC, not local time', () => {
+    // Verbatim from a stored MATLAB result_json.
+    const description = rootDescription({
+      type: 'MATLAB',
+      timestamp: '2026-08-10 07:12:00',
+      tests: []
+    });
+
+    expect(description).to.equal(expectedLocal('2026-08-10T07:12:00Z'));
+  });
+
+  it('renders the fixed MATLAB framework output unchanged', () => {
+    // What CodeAbilityTestOutput.m emits once it tags the zone, verified
+    // against MATLAB R2025b. Both forms must land on the same wall clock.
+    const legacy = rootDescription({ type: 'MATLAB', timestamp: '2026-08-10 07:12:00', tests: [] });
+    const fixed = rootDescription({ type: 'MATLAB', timestamp: '2026-08-10T07:12:00Z', tests: [] });
+
+    expect(fixed).to.equal(expectedLocal('2026-08-10T07:12:00Z'));
+    expect(fixed).to.equal(legacy);
+  });
+
+  it('keeps the offset an ISO timestamp already carries', () => {
+    const description = rootDescription({
+      type: 'python',
+      timestamp: '2026-07-28T20:26:29.140387+00:00',
+      tests: []
+    });
+
+    expect(description).to.equal(expectedLocal('2026-07-28T20:26:29.140387Z'));
+  });
+
+  it('does not shift a timestamp that names a non-UTC offset', () => {
+    const description = rootDescription({
+      type: 'python',
+      timestamp: '2026-08-10T09:12:00+02:00',
+      tests: []
+    });
+
+    expect(description).to.equal(expectedLocal('2026-08-10T07:12:00Z'));
+  });
+
+  it('shows an unparseable timestamp verbatim rather than "Invalid Date"', () => {
+    const description = rootDescription({
+      type: 'MATLAB',
+      timestamp: 'not a date',
+      tests: []
+    });
+
+    expect(description).to.equal('not a date');
+  });
+});


### PR DESCRIPTION
The Result Tree rendered MATLAB runs two hours early in CEST.

## Cause

Every worker container runs on UTC, but the testers disagree on how they say so:

| Tester | Emitted `timestamp` |
|---|---|
| computor-testing (Python, Octave, R, …) | `2026-07-28T20:26:29.140387+00:00` |
| MATLAB (`itp-matlab-testing`) | `2026-08-10 07:12:00` |

`new Date()` parses a date-time string with **no offset** as *local* time per the ECMAScript spec, so the MATLAB stamps were shifted by the local UTC offset — two hours in CEST, one in CET. Python results in the same tree were correct, which is what made it look intermittent.

Verified against the real `result_json` objects in MinIO, grouped by tester type:

```
MATLAB    n=4   e.g.  2026-08-10 07:12:00                  <- no T, no offset
python    n=6   e.g.  2026-07-28T20:26:29.140387+00:00     <- correct
```

## Fix

Tag an offset-less timestamp as UTC before parsing; leave anything that already names a zone alone. Doing it on the consumer side also repairs the results **already stored in MinIO**, which no producer-side fix can reach.

Also drops a dead `try/catch`: `new Date()` never throws, so an unparseable timestamp rendered `Invalid Date` instead of the intended raw fallback.

## Companion change

The producer is fixed separately in `itp-matlab-testing` (`CodeAbilityTestOutput.m`), which now emits `2026-08-10T07:12:00Z`. The two are independent — this PR handles both formats.

## Tests

5 new cases in `test/ui/testResultsPanel.test.ts` covering the legacy MATLAB form, the fixed form, an offset-bearing stamp, a non-UTC offset, and unparseable input. `tsc --noEmit` clean; 366 passing, 0 failing.