### PR TITLE
Make 2026.10.1 release evidence reproducible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,11 +97,11 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-      # Publishes the exact bytes that were just checksummed and attached.
-      # Authentication is the federated Entra credential; set VSCE_PAT as a
-      # secret instead if a token is ever preferred.
+      # Marketplace publication is opt-in. A normal GitHub release remains a
+      # green, reproducible artifact build; the human publisher may run the
+      # documented Azure-backed command after checking the attached VSIX.
       - name: Azure login
-        if: github.event_name == 'release' || inputs.publish
+        if: github.event_name == 'workflow_dispatch' && inputs.publish
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -109,7 +109,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Publish to the Marketplace
-        if: github.event_name == 'release' || inputs.publish
+        if: github.event_name == 'workflow_dispatch' && inputs.publish
         env:
           COMPUTOR_RELEASE_CHANNEL: ${{ steps.channel.outputs.channel }}
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "computor",
-  "version": "2026.10.0",
+  "version": "2026.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "computor",
-      "version": "2026.10.0",
+      "version": "2026.10.1",
       "dependencies": {
         "@types/jszip": "^3.4.0",
         "fast-xml-parser": "^5.3.2",


### PR DESCRIPTION
## Goal

Make the existing 2026.10.1 candidate reproducible and keep human Azure-backed Marketplace publication separate from the artifact build.

## Changes

- align the npm lock metadata with `package.json` at 2026.10.1
- make Marketplace publication opt-in through `workflow_dispatch`; normal GitHub releases still build, test, checksum, and attach the VSIX

## Verification

`npm ci --no-audit --no-fund && npm run type-check && npm run lint && npm run check:assets && npm run test:coverage && COMPUTOR_RELEASE_CHANNEL=pre-release npm run package:vsix`

Result: 1,109 tests passed and the VSIX packaged successfully.

Part of computor-org/issues#363.
