### PR TITLE
Run CI on release branch heads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [main, 'refactor/**', 'tests/**', 'feat/**', 'fix/**', 'chore/**', 'ci/**']
+    branches: [main, 'release/**', 'refactor/**', 'tests/**', 'feat/**', 'fix/**', 'chore/**', 'ci/**']
   pull_request:
     branches: [main, 'release/**']
 


### PR DESCRIPTION
Adds `release/**` to push CI so the exact merged release head receives checks, closing the remaining evidence gap from computor-org/issues#363.